### PR TITLE
  fix: use CommonJS syntax in postcss.config.js for Node 18 compatibility

### DIFF
--- a/tensormap-frontend/postcss.config.js
+++ b/tensormap-frontend/postcss.config.js
@@ -1,4 +1,4 @@
-export default {
+module.exports = {
   plugins: {
     tailwindcss: {},
     autoprefixer: {},


### PR DESCRIPTION
## Problem

`postcss.config.js` uses ESM `export default` syntax, but `package.json` does not define `"type": "module"`. As a result, Node.js treats `.js` files as CommonJS by default.

This causes `npm run build` and Docker builds to fail with:

```
SyntaxError: Unexpected token 'export'
```

## Fix

Replaced `export default` with `module.exports` to align with the project's CommonJS module configuration.

## Testing

* `npm run build` completes successfully
* `docker compose build` completes successfully