### PR TITLE
ix: resolve ESLint warning in DataUpload.jsx

### DIFF
--- a/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
+++ b/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
@@ -49,7 +49,7 @@ function DataUpload() {
         setDataset(null);
       })
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, setProjectFiles]);
 
   useEffect(() => {
     fetchDataset();


### PR DESCRIPTION
## Summary

This PR fixes(#121 ) that by adding the missing dependency to the `useCallback` array.

## Root Cause

`fetchDataset` uses `setProjectFiles` inside its body but the dependency array only listed `[projectId]`:

```jsx
// before
const fetchDataset = useCallback(() => {
  ...
  setProjectFiles(response);   // used here
  ...
}, [projectId]);               // but missing from deps
```

## Fix

```diff
- }, [projectId]);
+ }, [projectId, setProjectFiles]);
```

`setProjectFiles` comes from Recoil's `useSetRecoilState`, which returns a **stable reference** (same guarantee as React's `useState` setter). Adding it to the dep array satisfies the lint rule without causing any extra re-renders or behaviour changes.

### Screenshots

### Before
<img width="764" height="197" alt="Screenshot 2026-02-25 at 3 11 01 PM" src="https://github.com/user-attachments/assets/cc371c9f-7f09-4926-ab24-3668bf21a62e" />

### After
<img width="772" height="512" alt="Screenshot 2026-02-25 at 3 12 21 PM" src="https://github.com/user-attachments/assets/d1ae45e6-0212-4aa9-894e-3c5478a52258" />



