### PR TITLE
feat: Implement canvas draft auto-save and loading

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -8,7 +8,9 @@ import ReactFlow, {
   Controls,
   Background,
   BackgroundVariant,
+  Panel,
 } from "reactflow";
+import { Button } from "@/components/ui/button";
 import { useRecoilState } from "recoil";
 import * as strings from "../../constants/Strings";
 import logger from "../../shared/logger";
@@ -48,16 +50,53 @@ function Canvas() {
   });
   const defaultViewport = { x: 10, y: 15, zoom: 0.5 };
 
-  // Auto-load the project's first saved model on mount
+  const draftKey = `tensormap_draft_${projectId || "default"}`;
+  const isLoaded = useRef(false);
+  const [hasDraft, setHasDraft] = useState(() => {
+    try {
+      return !!localStorage.getItem(draftKey);
+    } catch (e) {
+      return false;
+    }
+  });
+
+  // Auto-load the project's first saved model or draft on mount
   useEffect(() => {
     let cancelled = false;
     async function loadModel() {
+      // 1. Try loading from draft first
+      try {
+        const draftStr = localStorage.getItem(draftKey);
+        if (draftStr) {
+          const draft = JSON.parse(draftStr);
+          if (draft.nodes?.length > 0 || draft.edges?.length > 0 || draft.modelName) {
+            if (!cancelled) {
+              setNodes(draft.nodes || []);
+              setEdges(draft.edges || []);
+              setModelName(draft.modelName || "");
+              setHasDraft(true);
+              isLoaded.current = true;
+            }
+            return;
+          }
+        }
+      } catch (e) {
+        logger.error("Failed to load draft:", e);
+      }
+
+      // 2. Fallback to loading from DB
       try {
         const modelNames = await getAllModels(projectId);
-        if (cancelled || !modelNames || modelNames.length === 0) return;
+        if (cancelled || !modelNames || modelNames.length === 0) {
+          if (!cancelled) isLoaded.current = true;
+          return;
+        }
 
         const result = await getModelGraph(modelNames[0], projectId);
-        if (cancelled || !result.success) return;
+        if (cancelled || !result.success) {
+          if (!cancelled) isLoaded.current = true;
+          return;
+        }
 
         const { graph, model_name } = result.data;
 
@@ -74,18 +113,60 @@ function Canvas() {
           target: edge.target,
         }));
 
-        setNodes(loadedNodes);
-        setEdges(loadedEdges);
-        setModelName(model_name);
+        if (!cancelled) {
+          setNodes(loadedNodes);
+          setEdges(loadedEdges);
+          setModelName(model_name);
+          isLoaded.current = true;
+        }
       } catch (err) {
         logger.error("Failed to auto-load model:", err);
+        if (!cancelled) isLoaded.current = true;
       }
     }
     loadModel();
     return () => {
       cancelled = true;
     };
-  }, [projectId, setNodes, setEdges]);
+  }, [projectId, setNodes, setEdges, draftKey]);
+
+  // Handle debounced saving of draft
+  useEffect(() => {
+    if (!isLoaded.current) return;
+
+    const timer = setTimeout(() => {
+      if (nodes.length === 0 && edges.length === 0 && !modelName) {
+        try {
+          localStorage.removeItem(draftKey);
+        } catch (e) {
+          logger.error("Failed to remove draft:", e);
+        }
+        setHasDraft(false);
+        return;
+      }
+
+      try {
+        localStorage.setItem(draftKey, JSON.stringify({ nodes, edges, modelName }));
+        setHasDraft(true);
+      } catch (e) {
+        logger.error("Failed to save draft:", e);
+      }
+    }, 500);
+
+    return () => clearTimeout(timer);
+  }, [nodes, edges, modelName, draftKey]);
+
+  const handleDiscardDraft = useCallback(() => {
+    try {
+      localStorage.removeItem(draftKey);
+    } catch (e) {
+      logger.error("Failed to remove draft:", e);
+    }
+    setHasDraft(false);
+    setNodes([]);
+    setEdges([]);
+    setModelName("");
+  }, [draftKey, setNodes, setEdges]);
 
   const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
 
@@ -138,6 +219,12 @@ function Canvas() {
     saveModel(data)
       .then((resp) => {
         if (resp.success) {
+          try {
+            localStorage.removeItem(draftKey);
+            setHasDraft(false);
+          } catch (e) {
+            logger.error("Failed to clear draft on save:", e);
+          }
           setModelList((prevList) => [
             ...prevList,
             {
@@ -238,6 +325,13 @@ function Canvas() {
               defaultViewport={defaultViewport}
             >
               <Controls />
+              {hasDraft && (
+                <Panel position="top-right">
+                  <Button variant="destructive" onClick={handleDiscardDraft}>
+                    Discard Draft
+                  </Button>
+                </Panel>
+              )}
               <Background
                 id="1"
                 gap={10}


### PR DESCRIPTION
## Description

This PR adds a robust draft management system to the canvas to prevent accidental data loss and improve the editing experience.

###  What’s included:

* **Debounced Auto-Save (500ms):** Automatically saves every change to nodes, edges, and parameters into `localStorage`.
* **Draft Restoring:** On page load, restores the exact previous canvas state (nodes, edges, types, and parameter values) if a local draft exists; otherwise, loads data from the database as before.
* **Discard Draft Button:** Shows a prominent red **Discard Draft** button whenever a local draft exists, allowing users to reset the canvas instantly.
* **Draft Clearing on Save:** When the user successfully uses **Validate & Save**, the local draft is automatically cleared from `localStorage`.

This ensures users never lose work due to refreshes, crashes, or accidental navigation.

Fixes #141


---

## Type of Change

* [ ] Bug fix
* [x] New feature
* [ ] Breaking change
* [ ] Documentation update

---

## How Has This Been Tested?

* Manually edited nodes, edges, and parameters and verified auto-save to `localStorage`

* Refreshed the page and confirmed draft state is restored correctly

* Tested **Discard Draft** button to ensure it clears state and resets canvas

* Tested **Validate & Save** flow to confirm draft is cleared after successful save

* [x] Existing tests pass

* [ ] New tests added

* [x] Manual testing

---

## Screenshots (if applicable)

<img width="707" height="728" alt="image" src="https://github.com/user-attachments/assets/cde734c4-dff0-471f-862a-091dbc264095" />
<img width="1937" height="933" alt="image" src="https://github.com/user-attachments/assets/173bd8d0-cd86-4809-bb83-e8b8b174669e" />


---

## Checklist

* [x] My code follows the project's style guidelines
* [x] I have performed a self-review
* [ ] I have added/updated documentation as needed
* [x] My changes generate no new warnings
* [x] Tests pass locally

---

