### PR TITLE
feat: add right-click context menu to duplicate canvas nodes

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.jsx
@@ -1,0 +1,40 @@
+import PropTypes from "prop-types";
+
+/**
+ * A minimal right-click context menu for canvas nodes.
+ *
+ * Renders at fixed screen coordinates (clientX / clientY) so it stays
+ * pinned to where the user right-clicked regardless of canvas pan/zoom.
+ * A full-screen transparent overlay sits behind the menu so that any
+ * click outside the menu triggers onClose without needing document-level
+ * event listeners (which would require explicit cleanup).
+ */
+function ContextMenu({ x, y, onDuplicate, onClose }) {
+  return (
+    <>
+      {/* transparent overlay — catches clicks outside the menu */}
+      <div className="fixed inset-0 z-40" onClick={onClose} />
+
+      <div
+        style={{ left: x, top: y }}
+        className="fixed z-50 min-w-[140px] rounded-md border bg-white py-1 shadow-md"
+      >
+        <button
+          className="w-full px-3 py-1.5 text-left text-sm hover:bg-accent"
+          onClick={onDuplicate}
+        >
+          Duplicate
+        </button>
+      </div>
+    </>
+  );
+}
+
+ContextMenu.propTypes = {
+  x: PropTypes.number.isRequired,
+  y: PropTypes.number.isRequired,
+  onDuplicate: PropTypes.func.isRequired,
+  onClose: PropTypes.func.isRequired,
+};
+
+export default ContextMenu;

--- a/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
+++ b/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
@@ -49,7 +49,7 @@ function DataUpload() {
         setDataset(null);
       })
       .finally(() => setLoading(false));
-  }, [projectId]);
+  }, [projectId, setProjectFiles]);
 
   useEffect(() => {
     fetchDataset();


### PR DESCRIPTION
## Summary

mplements issue #130 by adding a right-click context menu to ReactFlow nodes with a Duplicate option. The duplicated node has the same type and parameters, a new unique ID, no edges, and is positioned at a +50px offset from the original.

## Changes

- Added ContextMenu.jsx (fixed-position menu with overlay for outside-click dismissal)
- Updated Canvas.jsx to handle context menu state and duplicateNode logic
- Fixed react-hooks/exhaustive-deps lint warning in DataUpload.jsx

## Implementation notes

- Menu positioned using position: fixed at clientX / clientY
- Overlay handles outside-click dismissal (no global listeners required)
- duplicateNode uses functional state update to avoid stale closures
- New node:
- - id: crypto.randomUUID()
- - Same type
- - +50px position offset
- - Shallow-cloned params
- - No edges attached
- Menu closes on duplicate action, pane click, or outside click

## Testing

```bash
cd tensormap-frontend
npm run lint    # 0 errors, 0 warnings
npm start       # manual test at http://localhost:3300
```


Closes #130
