### PR TITLE
Add  support for RMSprop, Adagrad, AdamW optimizers & data shuffling (additional fixes)

### DIFF
--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -159,6 +159,8 @@ def _run(model_name: str, db: Session) -> None:
         file_location = _helper_generate_file_location(db, file_id=model_configs.file_id)
         features = pd.read_csv(file_location)
         features.dropna(inplace=True)
+        # Shuffle data to prevent issues with ordered datasets
+        features = features.sample(frac=1, random_state=42).reset_index(drop=True)
 
         X = features.drop(model_configs.target_field, axis=1)
         y = features[model_configs.target_field]

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -29,6 +29,9 @@ import { models as modelListAtom } from "../../shared/atoms";
 const optimizerOptions = [
   { key: "opt_1", label: "Adam", value: "adam" },
   { key: "opt_2", label: "SGD", value: "sgd" },
+  { key: "opt_3", label: "RMSprop", value: "rmsprop" },
+  { key: "opt_4", label: "Adagrad", value: "adagrad" },
+  { key: "opt_5", label: "AdamW", value: "adamw" },
 ];
 
 const metricOptions = [
@@ -61,7 +64,7 @@ export default function Training() {
     file_id: "",
     target_field: "",
     problem_type_id: "",
-    optimizer: "",
+    optimizer: "adam",
     metric: "",
     epochs: "",
     batch_size: "",
@@ -561,6 +564,7 @@ export default function Training() {
               <div className="space-y-1">
                 <Label>Optimizer</Label>
                 <Select
+                  value={trainingConfig.optimizer}
                   onValueChange={(v) => {
                     setTrainingConfig((prev) => ({ ...prev, optimizer: v }));
                     updateValidationErrors("optimizer", v);


### PR DESCRIPTION
## Description

This PR adds support for a wider range of Keras optimizers in the model training interface.

(+) Fixes a critical bug in the data splitting logic that caused 0% evaluation accuracy on ordered datasets.


### Key Changes:
- **Optimizer Expansion:** Added RMSprop, Adagrad, and AdamW to the training configuration options.
- **Default Selection:** Set Adam as the default optimizer and ensured the UI correctly reflects the state.
- **Shuffling Fix:** Implemented deterministic shuffling using `pandas.sample` before train/test splitting to ensure representative datasets.

Fixes #139 

## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] **Manual testing:** Verified that selecting each of the 5 optimizers (Adam, SGD, RMSprop, Adagrad, AdamW) correctly triggers a training job.
- [x] **Metric Verification:** Confirmed that evaluation accuracy is now non-zero and consistent with training performance thanks to the new shuffling logic.
- [x] **API Validation:** Inspected payload requests and backend compilation logs to ensure strings are passed correctly to `model.compile()`.

## Screenshots (if applicable)
[Optimizer Implementation Walkthrough.pdf](https://github.com/user-attachments/files/25561939/PR.pdf)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
