### PR TITLE
 feat: add full activation function options to Conv2D and Dense nodes

### DIFF
--- a/pr.md
+++ b/pr.md
@@ -1,0 +1,56 @@
+# feat: add full activation function options to Conv2D and Dense nodes
+
+Closes #129
+
+## Summary
+
+Expands the activation function dropdown for the Conv2D node from the two hardcoded options (`none`, `relu`) to the full set of commonly used Keras activation functions: `none`, `relu`, `sigmoid`, `tanh`, `softmax`, `elu`, `selu`.
+
+For consistency, the Dense node dropdown is unified to use the same list. A single shared `ACTIVATIONS` constant replaces the two separate `denseActivations` and `convActivations` arrays (DRY). The backend already maps `"none"` → `"linear"` for Conv2D; the same mapping is now applied to Dense so both layer types behave correctly when `"none"` is selected.
+
+## Changes
+
+### Root Cause
+`convActivations` in `NodePropertiesPanel.jsx` only contained `["none", "relu"]`. The backend had no issues — it passes the activation string directly to `tf.keras.layers.Conv2D(activation=…)`, which natively supports all standard Keras names.
+
+### Frontend
+- **`NodePropertiesPanel.jsx`** — Replaced separate `denseActivations` and `convActivations` arrays with a single `ACTIVATIONS` constant containing all 7 options. Both the Dense and Conv2D `<Select>` dropdowns now render from this shared list.
+
+### Backend
+- **`model_generation.py`** — Added `"none"` → `"linear"` mapping for the `customdense` branch in `_build_layer()` to match the existing Conv2D handling.
+
+### No changes needed
+- **`ConvNode.jsx`** — already renders activation via `Act: ${p.activation}` and suppresses it when `"none"`.
+- **`Canvas.jsx`** — Conv2D default activation is already `"none"`.
+
+## Acceptance Criteria
+
+- [x] Conv2D property panel shows all 7 activation options: none, relu, sigmoid, tanh, softmax, elu, selu
+- [x] Dense property panel shows the same 7 activation options for consistency
+- [x] Default activation for Conv2D remains `"none"`
+- [x] Selecting each option correctly updates node data via `updateParam`
+- [x] Backend maps `"none"` → `"linear"` for both Conv2D and Dense layers
+- [x] No regressions — existing activation values (`relu`, `sigmoid`, etc.) still work
+- [x] Conv2D node on canvas displays the selected activation name
+
+## Changed Files
+
+| File | Change |
+|---|---|
+| `tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx` | Unified activation options into shared `ACTIVATIONS` constant (7 options) |
+| `tensormap-backend/app/services/model_generation.py` | Map `"none"` → `"linear"` for Dense layer activation |
+
+## How to Test
+
+```bash
+# Frontend — start dev server and verify dropdowns
+cd tensormap-frontend
+npm install
+npm run dev
+# Open canvas, add a Conv2D node, open properties panel — confirm 7 activation options appear
+# Repeat for Dense node
+
+# Backend — run existing tests
+cd tensormap-backend
+uv run pytest -v
+```

--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -80,9 +80,10 @@ def _build_layer(node: dict, input_tensor):
     name = node["id"]
 
     if node_type == "customdense":
+        activation = params["activation"]
         return tf.keras.layers.Dense(
             units=int(params["units"]),
-            activation=params["activation"],
+            activation="linear" if activation == "none" else activation,
             name=name,
         )(input_tensor)
 

--- a/tensormap-backend/pyproject.toml
+++ b/tensormap-backend/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
 dev = [
     "ruff>=0.8",
     "pre-commit>=4.0",
+    "pytest>=8.0",
 ]
 
 [tool.ruff]

--- a/tensormap-backend/tests/test_data_process_service.py
+++ b/tensormap-backend/tests/test_data_process_service.py
@@ -1,0 +1,413 @@
+"""Unit tests for the data_process service.
+
+All database interactions use MagicMock — no running DB required.
+CSV-based tests use pytest's tmp_path fixture for realistic temp files.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from app.models.data import DataFile, DataProcess
+from app.services.data_process import (
+    add_target_service,
+    delete_one_target_by_id_service,
+    get_all_targets_service,
+    get_data_metrics,
+    get_file_data,
+    get_one_target_by_id_service,
+    preprocess_data,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def file_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_file(file_id):
+    """A DataFile-shaped mock."""
+    f = MagicMock(spec=DataFile)
+    f.id = file_id
+    f.file_name = "iris"
+    f.file_type = "csv"
+    return f
+
+
+@pytest.fixture()
+def sample_target(file_id):
+    """A DataProcess-shaped mock."""
+    t = MagicMock(spec=DataProcess)
+    t.id = 1
+    t.file_id = file_id
+    t.target = "species"
+    return t
+
+
+@pytest.fixture()
+def classification_csv(tmp_path):
+    """Create a small classification CSV and return the directory."""
+    df = pd.DataFrame(
+        {
+            "sepal_length": [5.1, 4.9, 7.0, 6.3],
+            "sepal_width": [3.5, 3.0, 3.2, 3.3],
+            "species": ["setosa", "setosa", "versicolor", "virginica"],
+        }
+    )
+    df.to_csv(tmp_path / "iris.csv", index=False)
+    return tmp_path
+
+
+@pytest.fixture()
+def regression_csv(tmp_path):
+    """Create a small regression CSV and return the directory."""
+    df = pd.DataFrame(
+        {
+            "size": [1500, 2000, 2500, 3000],
+            "bedrooms": [3, 4, 4, 5],
+            "price": [300000, 400000, 500000, 600000],
+        }
+    )
+    df.to_csv(tmp_path / "housing.csv", index=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# add_target_service
+# ---------------------------------------------------------------------------
+
+
+class TestAddTargetService:
+    def test_success(self, mock_db, file_id, sample_file):
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = add_target_service(mock_db, file_id, "species")
+
+        assert status == 201
+        assert body["success"] is True
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = add_target_service(mock_db, file_id, "species")
+
+        assert status == 400
+        assert body["success"] is False
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# get_one_target_by_id_service
+# ---------------------------------------------------------------------------
+
+
+class TestGetOneTargetByIdService:
+    def test_success(self, mock_db, file_id, sample_file, sample_target):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=sample_target)),
+        ]
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"]["target_field"] == "species"
+        assert body["data"]["file_name"] == "iris"
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    def test_target_not_found(self, mock_db, file_id, sample_file):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# delete_one_target_by_id_service
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteOneTargetByIdService:
+    def test_success(self, mock_db, file_id, sample_file, sample_target):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=sample_target)),
+        ]
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_target)
+        mock_db.commit.assert_called_once()
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    def test_target_not_found(self, mock_db, file_id, sample_file):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# get_all_targets_service
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllTargetsService:
+    def test_success(self, mock_db, file_id):
+        row = MagicMock()
+        row.file_id = file_id
+        row.file_name = "iris"
+        row.file_type = "csv"
+        row.target = "species"
+
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=1)),
+            MagicMock(all=MagicMock(return_value=[row])),
+        ]
+
+        body, status = get_all_targets_service(mock_db)
+
+        assert status == 200
+        assert body["success"] is True
+        assert len(body["data"]) == 1
+        assert body["data"][0]["target_field"] == "species"
+        assert body["pagination"]["total"] == 1
+
+    def test_empty(self, mock_db):
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=0)),
+            MagicMock(all=MagicMock(return_value=[])),
+        ]
+
+        body, status = get_all_targets_service(mock_db)
+
+        assert status == 200
+        assert body["data"] == []
+        assert body["pagination"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_data_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestGetDataMetrics:
+    @patch("app.services.data_process.get_settings")
+    def test_classification_csv(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        data = body["data"]
+        assert "data_types" in data
+        assert "correlation_matrix" in data
+        assert "metric" in data
+        assert "sepal_length" in data["data_types"]
+
+    @patch("app.services.data_process.get_settings")
+    def test_regression_csv(self, mock_settings, mock_db, file_id, regression_csv):
+        reg_file = MagicMock(spec=DataFile)
+        reg_file.id = file_id
+        reg_file.file_name = "housing"
+        reg_file.file_type = "csv"
+
+        mock_settings.return_value.upload_folder = str(regression_csv)
+        mock_db.exec.return_value.first.return_value = reg_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert "size" in body["data"]["correlation_matrix"]
+        assert "price" in body["data"]["metric"]
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_file_not_on_disk(self, mock_settings, mock_db, file_id, sample_file, tmp_path):
+        mock_settings.return_value.upload_folder = str(tmp_path / "nonexistent")
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 500
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_empty_csv(self, mock_settings, mock_db, file_id, tmp_path):
+        """Metrics on a CSV with headers but no data rows."""
+        pd.DataFrame(columns=["a", "b"]).to_csv(tmp_path / "empty.csv", index=False)
+
+        empty_file = MagicMock(spec=DataFile)
+        empty_file.file_name = "empty"
+        empty_file.file_type = "csv"
+
+        mock_settings.return_value.upload_folder = str(tmp_path)
+        mock_db.exec.return_value.first.return_value = empty_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert body["data"]["metric"]["a"]["count"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# get_file_data
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileData:
+    @patch("app.services.data_process.get_settings")
+    def test_success(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"] is not None
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_file_data(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_file_missing_on_disk(self, mock_settings, mock_db, file_id, sample_file, tmp_path):
+        mock_settings.return_value.upload_folder = str(tmp_path / "missing")
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id)
+
+        assert status == 500
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# preprocess_data
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessData:
+    @patch("app.services.data_process.get_settings")
+    def test_drop_column(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Drop Column"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert "species" not in df.columns
+
+    @patch("app.services.data_process.get_settings")
+    def test_categorical_to_numerical(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Categorical to Numerical"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert pd.api.types.is_integer_dtype(df["species"])
+
+    @patch("app.services.data_process.get_settings")
+    def test_one_hot_encoding(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "One Hot Encoding"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert "species" not in df.columns
+        assert any("species" in col for col in df.columns)
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = preprocess_data(mock_db, file_id, [])
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_missing_column(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        """Dropping a column that doesn't exist returns a 500 error."""
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Drop Column"
+        t.feature = "nonexistent_column"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 500
+        assert body["success"] is False

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -11,17 +11,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const denseActivations = [
-  { value: "relu", label: "ReLU" },
-  { value: "linear", label: "Linear" },
-  { value: "sigmoid", label: "Sigmoid" },
-  { value: "softmax", label: "Softmax" },
-  { value: "tanh", label: "Tanh" },
-];
-
-const convActivations = [
+const ACTIVATIONS = [
   { value: "none", label: "None" },
   { value: "relu", label: "ReLU" },
+  { value: "sigmoid", label: "Sigmoid" },
+  { value: "tanh", label: "Tanh" },
+  { value: "softmax", label: "Softmax" },
+  { value: "elu", label: "ELU" },
+  { value: "selu", label: "SELU" },
 ];
 
 const convPaddings = [
@@ -133,7 +130,7 @@ function NodePropertiesPanel({
                 <SelectValue placeholder="Select activation" />
               </SelectTrigger>
               <SelectContent>
-                {denseActivations.map((a) => (
+                {ACTIVATIONS.map((a) => (
                   <SelectItem key={a.value} value={a.value}>
                     {a.label}
                   </SelectItem>
@@ -238,7 +235,7 @@ function NodePropertiesPanel({
                 <SelectValue placeholder="Activation" />
               </SelectTrigger>
               <SelectContent>
-                {convActivations.map((a) => (
+                {ACTIVATIONS.map((a) => (
                   <SelectItem key={a.value} value={a.value}>
                     {a.label}
                   </SelectItem>


### PR DESCRIPTION
Closes #129

## Summary

Expands the activation function dropdown for the Conv2D node from the two hardcoded options (none, relu) to the full set of commonly used Keras activation functions: none, relu, sigmoid, tanh, softmax, elu, selu.

For consistency, the Dense node dropdown is unified to use the same list. A single shared `ACTIVATIONS` constant replaces the two separate `denseActivations` and `convActivations` arrays (DRY). The backend already maps `"none"` → `"linear"` for Conv2D; the same mapping is now applied to Dense so both layer types behave correctly when `"none"` is selected.

## Changes

### Root Cause
`convActivations` in `NodePropertiesPanel.jsx` only contained `["none", "relu"]`. The backend had no issues  it passes the activation string directly to `tf.keras.layers.Conv2D(activation=…)`, which natively supports all standard Keras names.

### Frontend
- **`NodePropertiesPanel.jsx`** - Replaced separate `denseActivations` and `convActivations` arrays with a single `ACTIVATIONS` constant containing all 7 options. Both the Dense and Conv2D `<Select>` dropdowns now render from this shared list.

### Backend
- **`model_generation.py`** - Added `"none"` → `"linear"` mapping for the `customdense` branch in `_build_layer()` to match the existing Conv2D handling.



## How to Test

```bash
# Frontend - start dev server and verify dropdowns
cd tensormap-frontend
npm install
npm run dev
# Open canvas, add a Conv2D node, open properties panel - confirm 7 activation options appear
# Repeat for Dense node

# Backend - run existing tests
cd tensormap-backend
uv run pytest -v
```
