### PR TITLE
feat: add model deletion with cascade cleanup

### DIFF
--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from app.database import get_db
 from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
 from app.services.deep_learning import (
+    delete_model_service,
     get_available_model_list,
     get_code_service,
     get_model_graph_service,
@@ -86,6 +87,17 @@ def get_model_graph(
 ):
     """Retrieve the full ReactFlow graph for a saved model."""
     body, status_code = get_model_graph_service(db, model_name=model_name, project_id=project_id)
+    return JSONResponse(status_code=status_code, content=body)
+
+
+@router.delete("/model/{model_id}")
+async def delete_model(
+    model_id: int,
+    db: Session = Depends(get_db),
+):
+    """Delete a saved model and its associated configuration records."""
+    logger.info("Deleting model id=%s", model_id)
+    body, status_code = delete_model_service(db, model_id=model_id)
     return JSONResponse(status_code=status_code, content=body)
 
 

--- a/tensormap-backend/tests/test_deep_learning_service.py
+++ b/tensormap-backend/tests/test_deep_learning_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for the deep_learning service — delete_model_service.
+
+All database interactions use MagicMock — no running DB required.
+File-system interactions are patched via unittest.mock.patch.
+TensorFlow is stubbed out via sys.modules so the tests run without it installed.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy third-party modules that deep_learning.py imports at module level
+# so the tests can run without TensorFlow / flatten_json installed.
+_tf_stub = MagicMock()
+sys.modules.setdefault("tensorflow", _tf_stub)
+sys.modules.setdefault("flatten_json", MagicMock())
+
+from app.models.ml import ModelBasic  # noqa: E402
+from app.services.deep_learning import delete_model_service  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_model():
+    m = MagicMock(spec=ModelBasic)
+    m.id = 1
+    m.model_name = "my_model"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# delete_model_service
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteModelService:
+    def test_success_deletes_model_and_file(self, mock_db, sample_model, tmp_path):
+        """Deleting an existing model removes the DB row and the JSON file."""
+        mock_db.get.return_value = sample_model
+
+        model_file = tmp_path / "my_model.json"
+        model_file.write_text("{}")
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_model)
+        mock_db.commit.assert_called_once()
+        assert not model_file.exists()
+
+    def test_model_not_found_returns_404(self, mock_db):
+        """Returns 404 when no model with the given ID exists."""
+        mock_db.get.return_value = None
+
+        body, status_code = delete_model_service(mock_db, model_id=999)
+
+        assert status_code == 404
+        assert body["success"] is False
+        assert "not found" in body["message"].lower()
+        mock_db.delete.assert_not_called()
+
+    def test_success_when_json_file_missing(self, mock_db, sample_model, tmp_path):
+        """Deletion succeeds even when the model JSON file is already absent."""
+        mock_db.get.return_value = sample_model
+
+        # Do NOT create the file — it is intentionally absent
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_model)
+
+    def test_db_error_rolls_back(self, mock_db, sample_model):
+        """A database exception triggers a rollback and returns 500."""
+        mock_db.get.return_value = sample_model
+        mock_db.commit.side_effect = Exception("DB failure")
+
+        body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 500
+        assert body["success"] is False
+        mock_db.rollback.assert_called_once()
+
+    def test_get_called_with_correct_id(self, mock_db, sample_model, tmp_path):
+        """db.get is called with ModelBasic and the provided model_id."""
+        mock_db.get.return_value = sample_model
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            delete_model_service(mock_db, model_id=42)
+
+        mock_db.get.assert_called_once_with(ModelBasic, 42)

--- a/tensormap-frontend/src/constants/Urls.js
+++ b/tensormap-frontend/src/constants/Urls.js
@@ -22,5 +22,6 @@ export const BACKEND_DELETE_FILE = "/data/upload/file/";
 export const BACKEND_GET_MODEL_GRAPH = "/model";
 export const BACKEND_SAVE_MODEL = "/model/save";
 export const BACKEND_UPDATE_TRAINING_CONFIG = "/model/training-config";
+export const BACKEND_DELETE_MODEL = "/model";
 export const BACKEND_PROJECT = "/project";
 export const BACKEND_GET_COLUMN_STATS = "/data/process/stats/";

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -1,11 +1,20 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams } from "react-router-dom";
+import { Trash2 } from "lucide-react";
 import io from "socket.io-client";
 import { useRecoilState } from "recoil";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -16,12 +25,14 @@ import {
 import * as urls from "../../constants/Urls";
 import * as strings from "../../constants/Strings";
 import logger from "../../shared/logger";
+import FeedbackDialog from "../../components/shared/FeedbackDialog";
 import Result from "../../components/ResultPanel/Result/Result";
 import {
   download_code,
   runModel,
   getAllModels,
   updateTrainingConfig,
+  deleteModel,
 } from "../../services/ModelServices";
 import { getAllFiles } from "../../services/FileServices";
 import { models as modelListAtom } from "../../shared/atoms";
@@ -52,6 +63,12 @@ export default function Training() {
   const [resultValues, setResultValues] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [connectionError, setConnectionError] = useState(null);
+  const [deleteConfirm, setDeleteConfirm] = useState({ open: false, model: null });
+  const [deleteFeedback, setDeleteFeedback] = useState({
+    open: false,
+    success: false,
+    message: "",
+  });
   const socketRef = useRef(null);
   const timeoutRef = useRef(null);
 
@@ -128,9 +145,10 @@ export default function Training() {
 
     getAllModels(projectId)
       .then((response) => {
-        const models = response.map((file, index) => ({
-          label: file + strings.MODEL_EXTENSION,
-          value: file,
+        const models = response.map((item, index) => ({
+          label: item.model_name + strings.MODEL_EXTENSION,
+          value: item.model_name,
+          id: item.id,
           key: index,
         }));
         setModelList(models);
@@ -417,8 +435,75 @@ export default function Training() {
     setIsLoading(false);
   };
 
+  const handleDeleteClick = (model, e) => {
+    e.stopPropagation();
+    setDeleteConfirm({ open: true, model });
+  };
+
+  const handleDeleteConfirm = () => {
+    const { model } = deleteConfirm;
+    setDeleteConfirm({ open: false, model: null });
+    deleteModel(model.id)
+      .then((resp) => {
+        if (resp.success) {
+          setModelList((prev) => prev.filter((m) => m.id !== model.id));
+          if (selectedModel === model.value) {
+            setSelectedModel(null);
+            setConfigSaved(false);
+          }
+        } else {
+          logger.error("Failed to delete model:", resp.message);
+          setDeleteFeedback({
+            open: true,
+            success: false,
+            message: resp.message || "Failed to delete model",
+          });
+        }
+      })
+      .catch((error) => {
+        logger.error("Error deleting model:", error);
+        setDeleteFeedback({
+          open: true,
+          success: false,
+          message: error.message || "An unexpected error occurred",
+        });
+      });
+  };
+
   return (
     <div className="space-y-6">
+      <FeedbackDialog
+        open={deleteFeedback.open}
+        onClose={() => setDeleteFeedback((prev) => ({ ...prev, open: false }))}
+        success={deleteFeedback.success}
+        message={deleteFeedback.message}
+      />
+      <Dialog
+        open={deleteConfirm.open}
+        onOpenChange={(open) => !open && setDeleteConfirm({ open: false, model: null })}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete model</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{deleteConfirm.model?.label}</strong>? This
+              action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteConfirm({ open: false, model: null })}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Card>
         <CardHeader>
           <CardTitle>Model Training</CardTitle>
@@ -426,7 +511,11 @@ export default function Training() {
         <CardContent>
           <div className="flex flex-wrap items-center gap-4">
             <div className="space-y-1">
-              <Select onValueChange={handleModelSelect} disabled={modelList.length === 0}>
+              <Select
+                onValueChange={handleModelSelect}
+                value={selectedModel ?? ""}
+                disabled={modelList.length === 0}
+              >
                 <SelectTrigger className={`w-64 ${validationErrors.model ? "border-red-500" : ""}`}>
                   <SelectValue
                     placeholder={modelList.length === 0 ? "No models created" : "Select a model"}
@@ -435,7 +524,17 @@ export default function Training() {
                 <SelectContent>
                   {modelList.map((model) => (
                     <SelectItem key={model.key} value={model.value}>
-                      {model.label}
+                      <span className="flex items-center justify-between gap-2 w-full">
+                        <span>{model.label}</span>
+                        <button
+                          type="button"
+                          className="ml-auto text-destructive hover:text-destructive/80"
+                          onClick={(e) => handleDeleteClick(model, e)}
+                          aria-label={`Delete ${model.label}`}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/tensormap-frontend/src/services/ModelServices.js
+++ b/tensormap-frontend/src/services/ModelServices.js
@@ -25,10 +25,10 @@ export const validateModel = async (data) =>
     });
 
 /**
- * Fetches the list of validated model names, optionally scoped to a project.
+ * Fetches the list of validated model objects, optionally scoped to a project.
  *
  * @param {string} [projectId]
- * @returns {Promise<string[]>} Array of model name strings.
+ * @returns {Promise<Array<{ id: number, model_name: string }>>} Array of model objects.
  */
 export const getAllModels = async (projectId) => {
   const params = projectId ? { project_id: projectId } : {};
@@ -45,6 +45,24 @@ export const getAllModels = async (projectId) => {
       throw err;
     });
 };
+
+/**
+ * Deletes a saved model by its database ID.
+ *
+ * @param {number} modelId
+ * @returns {Promise<{ success: boolean, message: string }>}
+ */
+export const deleteModel = async (modelId) =>
+  axios
+    .delete(`${urls.BACKEND_DELETE_MODEL}/${modelId}`)
+    .then((resp) => resp.data)
+    .catch((err) => {
+      logger.error(err);
+      if (err.response && err.response.data) {
+        return err.response.data;
+      }
+      return { success: false, message: "Unknown error occurred" };
+    });
 
 /**
  * Downloads the generated Python training script for a model.


### PR DESCRIPTION
Closes #133

## Summary

TensorMap previously had no way to delete saved models, causing the model list to accumulate stale entries over time.

This PR introduces a complete full-stack delete capability:
	•	Backend: DELETE /model/{id} endpoint with cascade cleanup
	•	Frontend: Per-model delete button with confirmation dialog in the Training UI

## Changes

### Backend

**`tensormap-backend/app/services/deep_learning.py`**
- Added `delete_model_service(db, model_id)`: looks up `ModelBasic` by integer PK, deletes it (the existing `cascade="all,delete"` on the `configs` relationship automatically removes all associated `ModelConfigs` rows), and does a best-effort removal of the model JSON file from disk.
- Updated `get_available_model_list()` to return `{ id, model_name }` objects instead of bare strings, so the frontend can issue DELETE requests using the numeric DB id.

**`tensormap-backend/app/routers/deep_learning.py`**
- Added `DELETE /model/{model_id}` route backed by `delete_model_service`.

**`tensormap-backend/tests/test_deep_learning_service.py`** *(new)*
- 5 unit tests for `delete_model_service` using `MagicMock` — no live DB or TensorFlow required:
  - `test_success_deletes_model_and_file` — happy path, JSON file is removed
  - `test_model_not_found_returns_404` — returns 404 when id is unknown
  - `test_success_when_json_file_missing` — deletion still succeeds if JSON file is already gone
  - `test_db_error_rolls_back` — DB exception triggers rollback and returns 500
  - `test_get_called_with_correct_id` — verifies `db.get(ModelBasic, id)` call signature

**`tensormap-backend/tests/__init__.py`** *(new)* — makes `tests/` a proper Python package.

### Frontend

**`tensormap-frontend/src/constants/Urls.js`**
- Added `BACKEND_DELETE_MODEL = "/model"` constant.

**`tensormap-frontend/src/services/ModelServices.js`**
- Updated `getAllModels()` to handle the new `{ id, model_name }` response shape.
- Added `deleteModel(modelId)` — issues `DELETE /model/{modelId}`.

**`tensormap-frontend/src/containers/Training/Training.jsx`**
- Added `deleteConfirm` state, `handleDeleteClick`, and `handleDeleteConfirm` handlers.
- Renders a `<Trash2>` icon button next to each model in the dropdown.
- Clicking the trash icon opens a confirmation dialog showing the model name.
- Confirming calls `deleteModel`, removes the entry from the Recoil atom, and clears `selectedModel` if the deleted model was active.
- Cancelling closes the dialog with no side effects.

**`tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx`**
- Updated `loadModel()` to consume the new `{ id, model_name }` shape from `getAllModels()`.
- Replaced the optimistic `setModelList` push after save with a re-fetch of `getAllModels()` so every entry in the list carries a valid DB id (needed for deletion).


## Testing

```bash
# Backend unit tests (no DB / TF required)
cd tensormap-backend
uv run pytest tests/test_deep_learning_service.py -v
# 5 passed
```
