### PR TITLE
feat: add undo/redo support to ReactFlow canvas (history stack, shortcuts, toolbar)

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -295,9 +295,7 @@ function Canvas() {
   const handleNodesChange = useCallback(
     (changes) => {
       const hasRemoval = changes.some((c) => c.type === "remove");
-      const hasKeyboardMove = changes.some(
-        (c) => c.type === "position" && !c.dragging,
-      );
+      const hasKeyboardMove = changes.some((c) => c.type === "position" && !c.dragging);
       if (hasRemoval || hasKeyboardMove) {
         takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
       }
@@ -327,20 +325,17 @@ function Canvas() {
    */
   const dragStartStateRef = useRef(null);
 
-  const onNodeDragStart = useCallback(
-    (_event, node) => {
-      if (!dragStartStateRef.current) {
-        // First node in this drag gesture — capture canvas snapshot
-        dragStartStateRef.current = {
-          snapshotNodes: nodesRef.current,
-          snapshotEdges: edgesRef.current,
-          starts: {},
-        };
-      }
-      dragStartStateRef.current.starts[node.id] = { ...node.position };
-    },
-    [],
-  );
+  const onNodeDragStart = useCallback((_event, node) => {
+    if (!dragStartStateRef.current) {
+      // First node in this drag gesture — capture canvas snapshot
+      dragStartStateRef.current = {
+        snapshotNodes: nodesRef.current,
+        snapshotEdges: edgesRef.current,
+        starts: {},
+      };
+    }
+    dragStartStateRef.current.starts[node.id] = { ...node.position };
+  }, []);
 
   const onNodeDragStop = useCallback(
     (_event, node) => {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -1,6 +1,6 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useParams } from "react-router-dom";
-import { Trash2 } from "lucide-react";
+import { Trash2, Undo2, Redo2 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -36,6 +36,14 @@ import ModelSummaryPanel from "./ModelSummaryPanel";
 import { getAllModels, getModelGraph, saveModel } from "../../services/ModelServices";
 import { models as allModels } from "../../shared/atoms";
 import ContextMenu from "./ContextMenu";
+import useUndoRedo from "../../hooks/useUndoRedo";
+
+const isMac =
+  typeof navigator !== "undefined"
+    ? navigator.userAgentData
+      ? navigator.userAgentData.platform.toLowerCase().includes("mac")
+      : /Mac/i.test(navigator.platform)
+    : false;
 
 const nodeTypes = {
   custominput: InputNode,
@@ -73,6 +81,90 @@ function Canvas() {
       return false;
     }
   });
+
+  const nodesRef = useRef(nodes);
+  const edgesRef = useRef(edges);
+
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+
+  useEffect(() => {
+    edgesRef.current = edges;
+  }, [edges]);
+
+  const { takeSnapshot, undo, redo, canUndo, canRedo } = useUndoRedo(
+    setNodes,
+    setEdges,
+    nodesRef,
+    edgesRef,
+  );
+
+  /**
+   * Guard flag that suppresses snapshot-taking while undo/redo is restoring
+   * state. Set synchronously before calling undo/redo and cleared in a
+   * useEffect after the React render cycle completes.
+   */
+  const isRestoringRef = useRef(false);
+
+  // Reset the restoring flag after each render so that subsequent
+  // onNodesChange / onEdgesChange callbacks triggered by the state update
+  // are no longer suppressed.
+  useEffect(() => {
+    isRestoringRef.current = false;
+  });
+
+  const takeSnapshotAndUpdate = useCallback(
+    (currentNodes, currentEdges) => {
+      if (isRestoringRef.current) return;
+      takeSnapshot(currentNodes, currentEdges);
+    },
+    [takeSnapshot],
+  );
+
+  const performUndo = useCallback(() => {
+    isRestoringRef.current = true;
+    undo();
+  }, [undo]);
+
+  const performRedo = useCallback(() => {
+    isRestoringRef.current = true;
+    redo();
+  }, [redo]);
+
+  const undoRef = useRef(performUndo);
+  const redoRef = useRef(performRedo);
+
+  useEffect(() => {
+    undoRef.current = performUndo;
+    redoRef.current = performRedo;
+  }, [performUndo, performRedo]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const el = document.activeElement;
+      const tag = el?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || el?.isContentEditable) return;
+
+      const modKey = isMac ? event.metaKey : event.ctrlKey;
+
+      if (modKey && !event.shiftKey && event.code === "KeyZ") {
+        event.preventDefault();
+        event.stopPropagation();
+        undoRef.current();
+      } else if (
+        (modKey && event.code === "KeyY") ||
+        (modKey && event.shiftKey && event.code === "KeyZ")
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        redoRef.current();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
 
   // Auto-load the project's first saved model or draft on mount
   useEffect(() => {
@@ -192,7 +284,89 @@ function Canvas() {
     setModelName("");
   }, [draftKey, setNodes, setEdges]);
 
-  const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
+  const onConnect = useCallback(
+    (params) => {
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      setEdges((eds) => addEdge(params, eds));
+    },
+    [setEdges, takeSnapshotAndUpdate],
+  );
+
+  const handleNodesChange = useCallback(
+    (changes) => {
+      const hasRemoval = changes.some((c) => c.type === "remove");
+      const hasKeyboardMove = changes.some(
+        (c) => c.type === "position" && !c.dragging,
+      );
+      if (hasRemoval || hasKeyboardMove) {
+        takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      }
+      onNodesChange(changes);
+    },
+    [onNodesChange, takeSnapshotAndUpdate],
+  );
+
+  const handleEdgesChange = useCallback(
+    (changes) => {
+      const hasRemoval = changes.some((change) => change.type === "remove");
+      if (hasRemoval) {
+        takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      }
+      onEdgesChange(changes);
+    },
+    [onEdgesChange, takeSnapshotAndUpdate],
+  );
+
+  /**
+   * Track per-node start positions for drag operations. On the first
+   * onNodeDragStart in a gesture we capture a single snapshot of the
+   * canvas state (snapshotNodes / snapshotEdges) and begin recording
+   * each dragged node's original position. On each onNodeDragStop we
+   * remove the node from the map and, once all nodes have been dropped,
+   * commit the snapshot only if at least one node actually moved.
+   */
+  const dragStartStateRef = useRef(null);
+
+  const onNodeDragStart = useCallback(
+    (_event, node) => {
+      if (!dragStartStateRef.current) {
+        // First node in this drag gesture — capture canvas snapshot
+        dragStartStateRef.current = {
+          snapshotNodes: nodesRef.current,
+          snapshotEdges: edgesRef.current,
+          starts: {},
+        };
+      }
+      dragStartStateRef.current.starts[node.id] = { ...node.position };
+    },
+    [],
+  );
+
+  const onNodeDragStop = useCallback(
+    (_event, node) => {
+      const state = dragStartStateRef.current;
+      if (!state) return;
+
+      const startPos = state.starts[node.id];
+      if (startPos) {
+        const dx = Math.abs(node.position.x - startPos.x);
+        const dy = Math.abs(node.position.y - startPos.y);
+        if (dx > 0.5 || dy > 0.5) {
+          state.moved = true;
+        }
+        delete state.starts[node.id];
+      }
+
+      // All dragged nodes have been dropped
+      if (Object.keys(state.starts).length === 0) {
+        if (state.moved) {
+          takeSnapshotAndUpdate(state.snapshotNodes, state.snapshotEdges);
+        }
+        dragStartStateRef.current = null;
+      }
+    },
+    [takeSnapshotAndUpdate],
+  );
 
   const onDragOver = useCallback((event) => {
     event.preventDefault();
@@ -223,6 +397,7 @@ function Canvas() {
   }, []);
 
   const duplicateNode = useCallback(() => {
+    takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
     setNodes((nds) => {
       const source = nds.find((n) => n.id === contextMenu.nodeId);
       if (!source) return nds;
@@ -235,10 +410,11 @@ function Canvas() {
       return nds.concat(duplicate);
     });
     closeContextMenu();
-  }, [contextMenu.nodeId, setNodes, closeContextMenu]);
+  }, [contextMenu.nodeId, setNodes, closeContextMenu, takeSnapshotAndUpdate]);
 
   const onNodeUpdate = useCallback(
     (nodeId, newParams) => {
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
       setNodes((nds) =>
         nds.map((node) => {
           if (node.id === nodeId) {
@@ -248,7 +424,7 @@ function Canvas() {
         }),
       );
     },
-    [setNodes],
+    [setNodes, takeSnapshotAndUpdate],
   );
 
   const closeFeedback = () => {
@@ -256,12 +432,13 @@ function Canvas() {
   };
 
   const handleClearAll = useCallback(() => {
+    takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
     setNodes([]);
     setEdges([]);
     setModelName("");
     setSelectedNodeId(null);
     setClearConfirmOpen(false);
-  }, [setNodes, setEdges]);
+  }, [setNodes, setEdges, takeSnapshotAndUpdate]);
 
   const modelSaveHandler = () => {
     const data = {
@@ -356,9 +533,10 @@ function Canvas() {
         data: { label: `${type} node`, params: defaultParams[type] || {} },
       };
 
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
       setNodes((nds) => nds.concat(newNode));
     },
-    [reactFlowInstance, setNodes],
+    [reactFlowInstance, setNodes, takeSnapshotAndUpdate],
   );
 
   return (
@@ -376,7 +554,7 @@ function Canvas() {
             <DialogTitle>Clear canvas</DialogTitle>
             <DialogDescription>
               This will remove all {nodes.length} node{nodes.length !== 1 ? "s" : ""} and their
-              connections. This action cannot be undone.
+              connections. You can undo this with {isMac ? "⌘Z" : "Ctrl+Z"}.
             </DialogDescription>
           </DialogHeader>
           <DialogFooter>
@@ -408,8 +586,8 @@ function Canvas() {
               <ReactFlow
                 nodes={nodes}
                 edges={edges}
-                onNodesChange={onNodesChange}
-                onEdgesChange={onEdgesChange}
+                onNodesChange={handleNodesChange}
+                onEdgesChange={handleEdgesChange}
                 onConnect={onConnect}
                 onInit={setReactFlowInstance}
                 onDrop={onDrop}
@@ -417,9 +595,33 @@ function Canvas() {
                 onNodeClick={onNodeClick}
                 onPaneClick={onPaneClick}
                 onNodeContextMenu={onNodeContextMenu}
+                onNodeDragStart={onNodeDragStart}
+                onNodeDragStop={onNodeDragStop}
                 nodeTypes={nodeTypes}
                 defaultViewport={defaultViewport}
               >
+                <Panel position="top-left" className="flex gap-1">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={performUndo}
+                    disabled={!canUndo}
+                    title={`Undo (${isMac ? "⌘Z" : "Ctrl+Z"})`}
+                    className="h-8 w-8"
+                  >
+                    <Undo2 className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={performRedo}
+                    disabled={!canRedo}
+                    title={`Redo (${isMac ? "⌘⇧Z" : "Ctrl+Y"})`}
+                    className="h-8 w-8"
+                  >
+                    <Redo2 className="h-4 w-4" />
+                  </Button>
+                </Panel>
                 <Controls />
                 {hasDraft && (
                   <Panel position="top-right">

--- a/tensormap-frontend/src/hooks/useUndoRedo.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.js
@@ -1,0 +1,162 @@
+import { useCallback, useRef, useState } from "react";
+
+const MAX_HISTORY_SIZE = 50;
+
+/**
+ * Safely deep-clone a value using structuredClone, falling back to
+ * JSON round-trip when the value contains non-cloneable data (functions,
+ * DOM nodes, Symbols, etc.).
+ *
+ * @param {*} value - The value to clone
+ * @returns {*} A deep copy of value, or null if cloning fails entirely
+ */
+function safeClone(value) {
+  try {
+    return structuredClone(value);
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (e) {
+      console.warn("[useUndoRedo] Could not clone state; snapshot skipped.", e);
+      return null;
+    }
+  }
+}
+
+/**
+ * Push an entry to a stack, enforcing a maximum size.
+ *
+ * @param {Array} stack - The history stack (past or future)
+ * @param {object} entry - The {nodes, edges} snapshot to push
+ * @param {number} max - Maximum allowed stack length
+ */
+function cappedPush(stack, entry, max) {
+  stack.push(entry);
+  if (stack.length > max) stack.shift();
+}
+
+/**
+ * Custom hook for undo/redo functionality on ReactFlow canvas state.
+ *
+ * Uses a past/future two-stack pattern. Before each user action, the current
+ * state is pushed to the past stack. Undo pops from past (pushing the current
+ * state to future). Redo pops from future (pushing the current state to past).
+ *
+ * Rapid snapshots within 50 ms are deduplicated so that a single delete action
+ * (which fires both node-remove and edge-remove) records only one entry.
+ * The future (redo) stack is always cleared when a new action is taken, even
+ * if the snapshot itself is deduplicated.
+ *
+ * @param {Function} setNodes - ReactFlow setNodes function
+ * @param {Function} setEdges - ReactFlow setEdges function
+ * @param {React.MutableRefObject<Array>} nodesRef - Ref to current nodes
+ * @param {React.MutableRefObject<Array>} edgesRef - Ref to current edges
+ * @returns {{
+ *   takeSnapshot: (nodes: Array, edges: Array) => void,
+ *   undo: () => boolean,
+ *   redo: () => boolean,
+ *   canUndo: boolean,
+ *   canRedo: boolean,
+ * }}
+ */
+export default function useUndoRedo(setNodes, setEdges, nodesRef, edgesRef) {
+  const pastRef = useRef([]);
+  const futureRef = useRef([]);
+  const lastSnapshotTimeRef = useRef(0);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  /** Synchronise the reactive canUndo/canRedo state with the ref stacks. */
+  const syncState = useCallback(() => {
+    setCanUndo(pastRef.current.length > 0);
+    setCanRedo(futureRef.current.length > 0);
+  }, []);
+
+  /**
+   * Saves the given state to the past stack and clears the future stack.
+   * Calls within 50 ms of each other are deduplicated to batch related
+   * change events (e.g. node deletion + connected edge deletion).
+   *
+   * The future stack is **always** cleared when a new action is taken,
+   * even if the snapshot itself is deduplicated (prevents stale redo
+   * after undo → new action within the dedup window).
+   */
+  const takeSnapshot = useCallback(
+    (nodes, edges) => {
+      // Always invalidate the redo stack on a new intentional action
+      futureRef.current = [];
+
+      const now = Date.now();
+      if (now - lastSnapshotTimeRef.current < 50) {
+        syncState();
+        return;
+      }
+      lastSnapshotTimeRef.current = now;
+
+      const clonedNodes = safeClone(nodes);
+      const clonedEdges = safeClone(edges);
+      if (clonedNodes === null || clonedEdges === null) {
+        syncState();
+        return;
+      }
+
+      cappedPush(pastRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+      syncState();
+    },
+    [syncState],
+  );
+
+  /**
+   * Undo: pushes the current canvas state to the future stack and restores
+   * the most recent past state. Data is already deep-cloned when stored, so
+   * no re-cloning is needed when restoring.
+   * @returns {boolean} true if undo was performed
+   */
+  const undo = useCallback(() => {
+    if (pastRef.current.length === 0) return false;
+
+    const clonedNodes = safeClone(nodesRef.current);
+    const clonedEdges = safeClone(edgesRef.current);
+    if (clonedNodes === null || clonedEdges === null) {
+      // Cannot preserve current state for redo — abort to avoid data loss
+      console.warn("[useUndoRedo] undo aborted: failed to clone current state");
+      return false;
+    }
+
+    cappedPush(futureRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+
+    const previous = pastRef.current.pop();
+    setNodes(previous.nodes);
+    setEdges(previous.edges);
+    syncState();
+    return true;
+  }, [setNodes, setEdges, nodesRef, edgesRef, syncState]);
+
+  /**
+   * Redo: pushes the current canvas state to the past stack and restores
+   * the most recent future state. Data is already deep-cloned when stored, so
+   * no re-cloning is needed when restoring.
+   * @returns {boolean} true if redo was performed
+   */
+  const redo = useCallback(() => {
+    if (futureRef.current.length === 0) return false;
+
+    const clonedNodes = safeClone(nodesRef.current);
+    const clonedEdges = safeClone(edgesRef.current);
+    if (clonedNodes === null || clonedEdges === null) {
+      // Cannot preserve current state for undo — abort to avoid data loss
+      console.warn("[useUndoRedo] redo aborted: failed to clone current state");
+      return false;
+    }
+
+    cappedPush(pastRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+
+    const next = futureRef.current.pop();
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    syncState();
+    return true;
+  }, [setNodes, setEdges, nodesRef, edgesRef, syncState]);
+
+  return { takeSnapshot, undo, redo, canUndo, canRedo };
+}

--- a/tensormap-frontend/src/hooks/useUndoRedo.test.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.test.js
@@ -56,7 +56,7 @@ describe("useUndoRedo", () => {
   // ---------- basic undo ----------
 
   it("undo restores the previous state", () => {
-    const { result, setNodes, setEdges, nodesRef, edgesRef } = setup(
+    const { result, setNodes, setEdges } = setup(
       [{ id: "b" }],
       [{ id: "e1" }],
     );
@@ -197,7 +197,7 @@ describe("useUndoRedo", () => {
   // ---------- canUndo / canRedo reactive values ----------
 
   it("canUndo and canRedo correctly reflect stack state", async () => {
-    const { result, nodesRef, edgesRef } = setup([{ id: "x" }], []);
+    const { result } = setup([{ id: "x" }], []);
 
     expect(result.current.canUndo).toBe(false);
     expect(result.current.canRedo).toBe(false);
@@ -227,7 +227,7 @@ describe("useUndoRedo", () => {
   // ---------- future cleared even during dedup window ----------
 
   it("clears future stack even when snapshot is deduplicated", () => {
-    const { result, nodesRef, edgesRef } = setup([], []);
+    const { result, nodesRef } = setup([], []);
 
     // Take snapshot and immediately undo
     act(() => {
@@ -305,7 +305,7 @@ describe("useUndoRedo", () => {
   // ---------- undo/redo abort when clone fails ----------
 
   it("undo aborts and returns false when current state cannot be cloned", () => {
-    const { result, nodesRef } = setup([], []);
+    const { result } = setup([], []);
 
     // Take a valid snapshot
     act(() => {

--- a/tensormap-frontend/src/hooks/useUndoRedo.test.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.test.js
@@ -16,9 +16,7 @@ function setup(initialNodes = [], initialEdges = []) {
   const nodesRef = { current: initialNodes };
   const edgesRef = { current: initialEdges };
 
-  const { result } = renderHook(() =>
-    useUndoRedo(setNodes, setEdges, nodesRef, edgesRef),
-  );
+  const { result } = renderHook(() => useUndoRedo(setNodes, setEdges, nodesRef, edgesRef));
 
   return { result, setNodes, setEdges, nodesRef, edgesRef };
 }
@@ -56,10 +54,7 @@ describe("useUndoRedo", () => {
   // ---------- basic undo ----------
 
   it("undo restores the previous state", () => {
-    const { result, setNodes, setEdges } = setup(
-      [{ id: "b" }],
-      [{ id: "e1" }],
-    );
+    const { result, setNodes, setEdges } = setup([{ id: "b" }], [{ id: "e1" }]);
 
     // Snapshot the old state ([{id:'a'}], [])
     act(() => {
@@ -316,8 +311,12 @@ describe("useUndoRedo", () => {
     // Stub both structuredClone and JSON.stringify to force safeClone → null
     const origClone = globalThis.structuredClone;
     const origStringify = JSON.stringify;
-    globalThis.structuredClone = () => { throw new Error("clone fail"); };
-    JSON.stringify = () => { throw new Error("stringify fail"); };
+    globalThis.structuredClone = () => {
+      throw new Error("clone fail");
+    };
+    JSON.stringify = () => {
+      throw new Error("stringify fail");
+    };
 
     let ret;
     act(() => {
@@ -352,8 +351,12 @@ describe("useUndoRedo", () => {
     // Stub both structuredClone and JSON.stringify to force safeClone → null
     const origClone = globalThis.structuredClone;
     const origStringify = JSON.stringify;
-    globalThis.structuredClone = () => { throw new Error("clone fail"); };
-    JSON.stringify = () => { throw new Error("stringify fail"); };
+    globalThis.structuredClone = () => {
+      throw new Error("clone fail");
+    };
+    JSON.stringify = () => {
+      throw new Error("stringify fail");
+    };
 
     let ret;
     act(() => {

--- a/tensormap-frontend/src/hooks/useUndoRedo.test.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.test.js
@@ -1,0 +1,371 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import useUndoRedo from "./useUndoRedo";
+
+/**
+ * Helper: creates mock setters and stable refs, then renders the hook.
+ * Returns { result, setNodes, setEdges, nodesRef, edgesRef }.
+ */
+function setup(initialNodes = [], initialEdges = []) {
+  const setNodes = vi.fn((val) => {
+    nodesRef.current = typeof val === "function" ? val(nodesRef.current) : val;
+  });
+  const setEdges = vi.fn((val) => {
+    edgesRef.current = typeof val === "function" ? val(edgesRef.current) : val;
+  });
+  const nodesRef = { current: initialNodes };
+  const edgesRef = { current: initialEdges };
+
+  const { result } = renderHook(() =>
+    useUndoRedo(setNodes, setEdges, nodesRef, edgesRef),
+  );
+
+  return { result, setNodes, setEdges, nodesRef, edgesRef };
+}
+
+describe("useUndoRedo", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ---------- empty-stack guards ----------
+
+  it("undo on empty stack returns false and does not throw", () => {
+    const { result } = setup();
+    let ret;
+    act(() => {
+      ret = result.current.undo();
+    });
+    expect(ret).toBe(false);
+  });
+
+  it("redo on empty stack returns false and does not throw", () => {
+    const { result } = setup();
+    let ret;
+    act(() => {
+      ret = result.current.redo();
+    });
+    expect(ret).toBe(false);
+  });
+
+  // ---------- basic undo ----------
+
+  it("undo restores the previous state", () => {
+    const { result, setNodes, setEdges, nodesRef, edgesRef } = setup(
+      [{ id: "b" }],
+      [{ id: "e1" }],
+    );
+
+    // Snapshot the old state ([{id:'a'}], [])
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+
+    // Simulate that the canvas moved to ({id:'b'}, {id:'e1'})
+    // nodesRef/edgesRef already point there from setup
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(setNodes).toHaveBeenCalledWith([{ id: "a" }]);
+    expect(setEdges).toHaveBeenCalledWith([]);
+  });
+
+  // ---------- basic redo ----------
+
+  it("redo restores the undone state", () => {
+    const { result, setNodes, nodesRef } = setup([{ id: "a" }], []);
+
+    // Take snapshot, advance state
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    nodesRef.current = [{ id: "b" }];
+
+    // Undo → go back to a
+    act(() => {
+      result.current.undo();
+    });
+    // After undo, nodesRef simulates the restored state
+    nodesRef.current = [{ id: "a" }];
+
+    // Redo → go forward to b
+    act(() => {
+      result.current.redo();
+    });
+    expect(setNodes).toHaveBeenLastCalledWith([{ id: "b" }]);
+  });
+
+  // ---------- redo cleared after new action ----------
+
+  it("clears redo history when a new action is taken after undo", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    act(() => {
+      result.current.takeSnapshot([], []);
+    });
+    nodesRef.current = [{ id: "1" }];
+
+    // Advance past dedup window
+    vi.advanceTimersByTime(60);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "1" }], []);
+    });
+    nodesRef.current = [{ id: "2" }];
+    edgesRef.current = [];
+
+    // Undo
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    // Advance past dedup window, then new action
+    vi.advanceTimersByTime(60);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "1" }], []);
+    });
+
+    // Redo should now be impossible
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- MAX_HISTORY_SIZE ----------
+
+  it("caps history at 50 entries (51st push drops the oldest)", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    for (let i = 0; i < 55; i++) {
+      nodesRef.current = [{ id: String(i) }];
+      edgesRef.current = [];
+
+      act(() => {
+        result.current.takeSnapshot([{ id: String(i) }], []);
+      });
+      // Advance past dedup window
+      vi.advanceTimersByTime(60);
+    }
+
+    // canUndo should still be true
+    expect(result.current.canUndo).toBe(true);
+
+    // Undo 50 times — all should succeed
+    let undoCount = 0;
+    for (let i = 0; i < 55; i++) {
+      let succeeded;
+      act(() => {
+        succeeded = result.current.undo();
+      });
+      if (succeeded) undoCount++;
+    }
+    expect(undoCount).toBe(50);
+  });
+
+  // ---------- dedup within 50 ms ----------
+
+  it("deduplicates snapshots within 50 ms (only one entry added)", () => {
+    const { result } = setup([], []);
+
+    // Take two snapshots in rapid succession (< 50 ms)
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+      result.current.takeSnapshot([{ id: "b" }], []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+
+    // Only one undo should be available
+    let count = 0;
+    act(() => {
+      if (result.current.undo()) count++;
+    });
+    act(() => {
+      if (result.current.undo()) count++;
+    });
+    expect(count).toBe(1);
+  });
+
+  // ---------- canUndo / canRedo reactive values ----------
+
+  it("canUndo and canRedo correctly reflect stack state", async () => {
+    const { result, nodesRef, edgesRef } = setup([{ id: "x" }], []);
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "x" }], []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- future cleared even during dedup window ----------
+
+  it("clears future stack even when snapshot is deduplicated", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    // Take snapshot and immediately undo
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    nodesRef.current = [{ id: "b" }];
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    // Take a new snapshot within the dedup window — future must still clear
+    act(() => {
+      result.current.takeSnapshot([{ id: "c" }], []);
+    });
+
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- safeClone fallback ----------
+
+  it("handles non-cloneable data gracefully via JSON fallback", () => {
+    const { result } = setup([], []);
+
+    // Functions are not structuredClone-able but JSON.stringify drops them
+    const nodesWithFn = [{ id: "a", data: { callback: () => {} } }];
+
+    // Should not throw — falls back to JSON round-trip
+    act(() => {
+      result.current.takeSnapshot(nodesWithFn, []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+  });
+
+  // ---------- redo enforces MAX_HISTORY_SIZE on past stack ----------
+
+  it("enforces MAX_HISTORY_SIZE on past stack during redo", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    // Fill past stack to 50
+    for (let i = 0; i < 50; i++) {
+      act(() => {
+        result.current.takeSnapshot([{ id: String(i) }], []);
+      });
+      vi.advanceTimersByTime(60);
+    }
+
+    // Now undo once to create a redo entry
+    nodesRef.current = [{ id: "current" }];
+    edgesRef.current = [];
+    act(() => {
+      result.current.undo();
+    });
+
+    // Redo pushes to past — should still be capped at 50, not 51
+    act(() => {
+      result.current.redo();
+    });
+
+    // Verify by counting: undo should succeed at most 50 times
+    let undoCount = 0;
+    for (let i = 0; i < 55; i++) {
+      let ok;
+      act(() => {
+        ok = result.current.undo();
+      });
+      if (ok) undoCount++;
+    }
+    expect(undoCount).toBeLessThanOrEqual(50);
+  });
+
+  // ---------- undo/redo abort when clone fails ----------
+
+  it("undo aborts and returns false when current state cannot be cloned", () => {
+    const { result, nodesRef } = setup([], []);
+
+    // Take a valid snapshot
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    vi.advanceTimersByTime(60);
+
+    // Stub both structuredClone and JSON.stringify to force safeClone → null
+    const origClone = globalThis.structuredClone;
+    const origStringify = JSON.stringify;
+    globalThis.structuredClone = () => { throw new Error("clone fail"); };
+    JSON.stringify = () => { throw new Error("stringify fail"); };
+
+    let ret;
+    act(() => {
+      ret = result.current.undo();
+    });
+
+    // Restore
+    globalThis.structuredClone = origClone;
+    JSON.stringify = origStringify;
+
+    // Undo should abort — state and stacks remain intact
+    expect(ret).toBe(false);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("redo aborts and returns false when current state cannot be cloned", () => {
+    const { result, nodesRef } = setup([], []);
+
+    // Take snapshot, advance, undo to create redo entry
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    vi.advanceTimersByTime(60);
+    nodesRef.current = [{ id: "b" }];
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.canRedo).toBe(true);
+
+    // Stub both structuredClone and JSON.stringify to force safeClone → null
+    const origClone = globalThis.structuredClone;
+    const origStringify = JSON.stringify;
+    globalThis.structuredClone = () => { throw new Error("clone fail"); };
+    JSON.stringify = () => { throw new Error("stringify fail"); };
+
+    let ret;
+    act(() => {
+      ret = result.current.redo();
+    });
+
+    // Restore
+    globalThis.structuredClone = origClone;
+    JSON.stringify = origStringify;
+
+    // Redo should abort — redo stack remains intact
+    expect(ret).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+  });
+});


### PR DESCRIPTION


 ## Description

Adds undo/redo functionality to the ReactFlow drag-and-drop canvas. Users can revert and re-apply canvas changes (node add/delete/move, edge connect/delete, property edits) using keyboard shortcuts or toolbar buttons.

fixes #143 

**Key changes:**
- New `useUndoRedo` custom hook using a past/future two-stack pattern
- Keyboard shortcuts: Ctrl+Z (undo), Ctrl+Y / Ctrl+Shift+Z (redo), with Cmd variants for Mac
- Toolbar undo/redo buttons in a `<Panel>` with enabled/disabled states
- History capped at 50 entries
- 50ms snapshot deduplication to batch related events (e.g. node + edge deletion)

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

Manual testing performed:
1. Dropped multiple nodes onto the canvas, verified Ctrl+Z undoes exactly one node at a time
2. Verified Ctrl+Y redoes exactly one node at a time
3. Tested node drag — undo restores the node to its previous position
4. Tested edge deletion and node deletion — both undo correctly
5. Tested property edits via the side panel — undo reverts the parameter change
6. Verified toolbar buttons reflect enabled/disabled state correctly
7. Verified redo history is cleared when a new action is taken after undo
8. ESLint passes with no new warnings

## Screenshots (if applicable)

<img width="1437" height="667" alt="image" src="https://github.com/user-attachments/assets/94da7b51-71ff-40cd-9504-9d075f5806ea" />

## Screen Recording

https://github.com/user-attachments/assets/f7d99bd9-9086-497c-8671-392eaea62ed3


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally