### PR TITLE
fix: wire batch_size parameter through full training stack (#127)

### DIFF
--- a/tensormap-backend/app/models/ml.py
+++ b/tensormap-backend/app/models/ml.py
@@ -29,6 +29,7 @@ class ModelBasic(SQLModel, table=True):
     optimizer: str | None = Field(default=None, max_length=50, nullable=True)
     metric: str | None = Field(default=None, max_length=50, nullable=True)
     epochs: int | None = Field(default=None, nullable=True)
+    batch_size: int | None = Field(default=None, nullable=True)
     loss: str | None = Field(default=None, max_length=50, nullable=True)
     created_on: datetime | None = Field(default=None, sa_column=Column(DateTime, server_default=func.now()))
     updated_on: datetime | None = Field(

--- a/tensormap-backend/app/schemas/deep_learning.py
+++ b/tensormap-backend/app/schemas/deep_learning.py
@@ -97,4 +97,5 @@ class TrainingConfigRequest(BaseModel):
     optimizer: str = Field(min_length=1)
     metric: str = Field(min_length=1)
     epochs: int = Field(gt=0)
+    batch_size: int = Field(default=32, gt=0)
     project_id: uuid_pkg.UUID | None = None

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -241,6 +241,7 @@ def update_training_config_service(
     model.optimizer = config["optimizer"]
     model.metric = config["metric"]
     model.epochs = config["epochs"]
+    model.batch_size = config.get("batch_size", 32)
     model.loss = loss
 
     try:

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -171,6 +171,8 @@ def _run(model_name: str, db: Session) -> None:
         x_testing = X[split_index:]
         y_testing = y[split_index:]
 
+        batch_size = model_configs.batch_size if model_configs.batch_size is not None else 32
+
     with open(_helper_generate_json_model_file_location(model_name=model_name)) as f:
         json_string = f.read()
     model = tf.keras.models.model_from_json(json_string, custom_objects=None)
@@ -199,6 +201,7 @@ def _run(model_name: str, db: Session) -> None:
             x_training,
             y_training,
             epochs=model_configs.epochs,
+            batch_size=batch_size,
             callbacks=[CustomProgressBar()],
             verbose=0,
         )

--- a/tensormap-backend/migrations/versions/c3a1d9e02f45_add_batch_size_to_model_basic.py
+++ b/tensormap-backend/migrations/versions/c3a1d9e02f45_add_batch_size_to_model_basic.py
@@ -1,0 +1,27 @@
+"""add_batch_size_to_model_basic
+
+Revision ID: c3a1d9e02f45
+Revises: f1a2b3c4d5e6
+Create Date: 2026-02-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3a1d9e02f45"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "model_basic",
+        sa.Column("batch_size", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("model_basic", "batch_size")

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -366,6 +366,7 @@ export default function Training() {
       optimizer: trainingConfig.optimizer,
       metric: trainingConfig.metric,
       epochs: Number(trainingConfig.epochs),
+      batch_size: trainingConfig.batch_size ? Number(trainingConfig.batch_size) : 32,
       project_id: projectId || null,
     };
 


### PR DESCRIPTION
### Summary

Closes #127

The `batch_size` field was collected from the user on the Training page but silently dropped before ever reaching `model.fit()`. TensorFlow always used its default of 32 regardless of what was entered. This PR wires `batch_size` through every layer of the stack so the user's value is actually respected.

### Root Cause

`batch_size` was lost at four independent points:

| Layer | Problem |
|-------|---------|
| `Training.jsx` `handleSaveConfig` | `batch_size` existed in state but was never included in the payload sent to the API |
| `TrainingConfigRequest` schema | No `batch_size` field — Pydantic would reject or ignore any value sent |
| `update_training_config_service` | Never assigned `config["batch_size"]` to `model.batch_size` |
| `ModelBasic` DB model | No `batch_size` column — nothing to persist or read back in `model_run.py` |

### Changes

#### Backend

| File | Change |
|------|--------|
| `app/models/ml.py` | Added `batch_size: int \| None` nullable column to `ModelBasic` |
| `migrations/versions/c3a1d9e02f45_...py` | Alembic migration to add the column (`down_revision = "f1a2b3c4d5e6"`, the current single head on main) |
| `app/schemas/deep_learning.py` | Added `batch_size: int = Field(default=32, gt=0)` to `TrainingConfigRequest` |
| `app/services/deep_learning.py` | `update_training_config_service` now persists `model.batch_size = config.get("batch_size", 32)` |
| `app/services/model_run.py` | Reads `model_configs.batch_size` (falls back to 32 for legacy rows) and passes it to `model.fit()` in the tabular path |

#### Frontend

| File | Change |
|------|--------|
| `Training.jsx` | `handleSaveConfig` now includes `batch_size: trainingConfig.batch_size ? Number(trainingConfig.batch_size) : 32` in the PATCH request payload |

### Backward Compatibility

- Existing model rows with `batch_size = NULL` fall back to **32** at runtime — identical behaviour to before
- API clients that omit `batch_size` receive the default of 32 via Pydantic's field default
- Migration column is nullable so `alembic upgrade head` is non-breaking for existing data
- No breaking changes to any existing endpoint or schema

### Testing

- Manually verified the field flows end-to-end: form → PATCH request → DB → `model.fit()`
- Setting `batch_size=16` vs `batch_size=128` on the same dataset produces visibly different epoch durations and steps-per-epoch counts in the Socket.IO progress output
