### PR TITLE
feat: store ReactFlow graph as JSON column in model_basic (#140)

### DIFF
--- a/tensormap-backend/app/models/ml.py
+++ b/tensormap-backend/app/models/ml.py
@@ -2,7 +2,7 @@ import uuid as uuid_pkg
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, func
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import UUID as PgUUID
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -31,6 +31,11 @@ class ModelBasic(SQLModel, table=True):
     epochs: int | None = Field(default=None, nullable=True)
     batch_size: int | None = Field(default=None, nullable=True)
     loss: str | None = Field(default=None, max_length=50, nullable=True)
+    # sa_column is required here because SQLModel infers nullable from the
+    # Python type hint alone, which does not produce the correct DDL for JSON
+    # columns.  Explicit Column(JSON, nullable=True) ensures the database
+    # column is created with the right type and NULL constraint.
+    graph_json: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     created_on: datetime | None = Field(default=None, sa_column=Column(DateTime, server_default=func.now()))
     updated_on: datetime | None = Field(
         default=None, sa_column=Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/tensormap-backend/app/schemas/deep_learning.py
+++ b/tensormap-backend/app/schemas/deep_learning.py
@@ -39,12 +39,20 @@ class NodeData(BaseModel):
     params: dict[str, Any]  # varies per node type; validated downstream by model_generation + TensorFlow
 
 
+class NodePosition(BaseModel):
+    """X/Y canvas coordinates for a ReactFlow node."""
+
+    x: float
+    y: float
+
+
 class GraphNode(BaseModel):
     """A single node in the ReactFlow model graph."""
 
     id: str
     type: str
     data: NodeData
+    position: NodePosition | None = None
 
 
 class GraphEdge(BaseModel):

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -1,7 +1,9 @@
 import contextlib
+import copy
 import json
 import os
 import re
+import sys
 import uuid as uuid_pkg
 from typing import Any
 
@@ -48,6 +50,37 @@ def _sanitize_model_name(name: str) -> str:
     if not name or not re.fullmatch(r"[A-Za-z0-9_\-]+", name):
         raise ValueError(f"Invalid model name: {name!r}. Only alphanumeric, hyphens, and underscores are allowed.")
     return name
+
+
+# Maximum size (in bytes) for the serialised graph JSON stored in the DB.
+_MAX_GRAPH_JSON_BYTES = 512 * 1024  # 512 KB
+
+
+def _extract_graph(payload: dict) -> dict | None:
+    """Extract the graph portion (nodes + edges) from a request payload.
+
+    Both ``model_validate_service`` (which receives the full request body) and
+    ``model_save_service`` (which receives only the ``model`` sub-object) call
+    this helper so that ``graph_json`` always stores the same shape:
+    ``{"nodes": [...], "edges": [...], "model_name": ...}``.
+    """
+    if payload is None:
+        return None
+    # If the payload wraps the graph under a "model" key, unwrap it.
+    if "nodes" not in payload and "model" in payload and isinstance(payload["model"], dict):
+        return payload["model"]
+    return payload
+
+
+def _validate_graph_size(graph: dict | None) -> str | None:
+    """Return an error message if the serialised graph exceeds the size limit, else None."""
+    if graph is None:
+        return None
+    raw = json.dumps(graph)
+    size = sys.getsizeof(raw)
+    if size > _MAX_GRAPH_JSON_BYTES:
+        return f"Graph payload too large ({size} bytes > {_MAX_GRAPH_JSON_BYTES})"
+    return None
 
 
 def _build_model_summary(keras_model) -> dict:
@@ -116,7 +149,12 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
         metric=code[DL_MODEL][MODEL_METRIC],
         epochs=code[DL_MODEL][MODEL_EPOCHS],
         loss=loss,
+        graph_json=_extract_graph(incoming),
     )
+
+    size_err = _validate_graph_size(model.graph_json)
+    if size_err:
+        return _resp(413, False, size_err)
 
     configs = []
     params = flatten(incoming, separator=".")
@@ -176,9 +214,15 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
     if existing:
         return _resp(400, False, "Model name already used. Use a different name")
 
+    graph_data = _extract_graph(incoming)
+    size_err = _validate_graph_size(graph_data)
+    if size_err:
+        return _resp(413, False, size_err)
+
     model = ModelBasic(
         model_name=model_name,
         project_id=project_id,
+        graph_json=graph_data,
     )
 
     configs = []
@@ -298,7 +342,12 @@ def run_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | N
 
 
 def get_model_graph_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
-    """Retrieve the full ReactFlow graph for a saved model by unflattening its ModelConfigs."""
+    """Retrieve the full ReactFlow graph for a saved model.
+
+    If ``graph_json`` is populated (models created/saved after the column was
+    added), the raw ReactFlow JSON is returned directly.  Older models fall back
+    to reconstructing the graph from the flattened ``ModelConfigs`` rows.
+    """
     stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
     if project_id is not None:
         stmt = stmt.where(ModelBasic.project_id == project_id)
@@ -306,18 +355,39 @@ def get_model_graph_service(db: Session, model_name: str, project_id: uuid_pkg.U
     if not model:
         return _resp(404, False, "Model not found")
 
+    # Fast path: graph was stored directly in the JSON column
+    if model.graph_json is not None:
+        # Deep-copy to avoid mutating the ORM-tracked dict (which could trigger
+        # an unintended UPDATE on the next flush/commit in the same session).
+        graph = copy.deepcopy(model.graph_json)
+        _apply_auto_layout(graph)
+        return _resp(200, True, "Model graph retrieved successfully", {"model_name": model_name, "graph": graph})
+
+    # Legacy path: reconstruct graph from flattened ModelConfigs
     configs = db.exec(select(ModelConfigs).where(ModelConfigs.model_id == model.id)).all()
     if not configs:
         return _resp(404, False, "No graph configuration found for this model")
 
     graph = _unflatten_model_configs(configs)
-
-    # Ensure every node has a position (auto-layout fallback)
-    for i, node in enumerate(graph.get("nodes", [])):
-        if "position" not in node:
-            node["position"] = {"x": 100, "y": i * 200}
+    _apply_auto_layout(graph)
 
     return _resp(200, True, "Model graph retrieved successfully", {"model_name": model_name, "graph": graph})
+
+
+def _apply_auto_layout(graph: dict) -> None:
+    """Assign default positions to nodes that lack one.
+
+    This is a simple vertical-stack layout used as a fallback so that the
+    ReactFlow canvas can render the graph without crashing.  For a more
+    sophisticated layout (e.g. dagre), see:
+    https://reactflow.dev/docs/examples/layout/dagre/
+
+    TODO: Replace with a proper auto-layout algorithm (e.g. dagre) in a
+    follow-up issue.
+    """
+    for i, node in enumerate(graph.get("nodes", [])):
+        if "position" not in node:
+            node["position"] = {"x": 100.0, "y": float(i * 200)}
 
 
 def _unflatten_model_configs(configs: list[ModelConfigs]) -> dict:

--- a/tensormap-backend/migrations/versions/d4b7f1a03e82_add_graph_json_to_model_basic.py
+++ b/tensormap-backend/migrations/versions/d4b7f1a03e82_add_graph_json_to_model_basic.py
@@ -1,0 +1,27 @@
+"""add_graph_json_to_model_basic
+
+Revision ID: d4b7f1a03e82
+Revises: f1a2b3c4d5e6
+Create Date: 2026-02-27 14:32:08.473291
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d4b7f1a03e82"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "model_basic",
+        sa.Column("graph_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("model_basic", "graph_json")

--- a/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
+++ b/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
@@ -180,19 +180,19 @@ def _build_model_configs():
                 "id": "n0",
                 "type": "custominput",
                 "data": {"params": {"dim-1": "4"}},
-                "position": {"x": 100, "y": 200},
+                "position": {"x": 100.0, "y": 200.0},
             },
             {
                 "id": "n1",
                 "type": "customdense",
                 "data": {"params": {"units": "16", "activation": "relu"}},
-                "position": {"x": 100, "y": 400},
+                "position": {"x": 100.0, "y": 400.0},
             },
             {
                 "id": "n2",
                 "type": "customdense",
                 "data": {"params": {"units": "3", "activation": "softmax"}},
-                "position": {"x": 100, "y": 600},
+                "position": {"x": 100.0, "y": 600.0},
             },
         ],
         "edges": [

--- a/tensormap-backend/tests/test_graph_json.py
+++ b/tensormap-backend/tests/test_graph_json.py
@@ -1,0 +1,301 @@
+"""Unit tests for graph_json storage, retrieval, and auto-layout logic.
+
+Covers:
+- Fast path (graph_json IS NOT NULL) with and without positions
+- Legacy fallback path (graph_json IS NULL, configs present)
+- Consistent graph shape from _extract_graph helper
+- Size-guard rejection for oversized payloads
+- Deep-copy safety (ORM object not mutated)
+- get_available_model_list excludes graph_json from response
+
+All database interactions use MagicMock — no running DB required.
+TensorFlow / flatten_json are stubbed out via sys.modules.
+"""
+
+import copy
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub heavy third-party modules so tests run without them installed.
+_tf_stub = MagicMock()
+sys.modules.setdefault("tensorflow", _tf_stub)
+sys.modules.setdefault("flatten_json", MagicMock())
+
+from app.models.ml import ModelBasic, ModelConfigs  # noqa: E402
+from app.services.deep_learning import (  # noqa: E402
+    _apply_auto_layout,
+    _extract_graph,
+    _validate_graph_size,
+    get_available_model_list,
+    get_model_graph_service,
+)
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_GRAPH = {
+    "nodes": [
+        {"id": "n0", "type": "custominput", "data": {"params": {"dim-1": "4"}}, "position": {"x": 100.0, "y": 0.0}},
+        {
+            "id": "n1",
+            "type": "customdense",
+            "data": {"params": {"units": "16", "activation": "relu"}},
+            "position": {"x": 100.0, "y": 200.0},
+        },
+    ],
+    "edges": [{"source": "n0", "target": "n1"}],
+    "model_name": "test_model",
+}
+
+SAMPLE_GRAPH_NO_POSITIONS = {
+    "nodes": [
+        {"id": "n0", "type": "custominput", "data": {"params": {"dim-1": "4"}}},
+        {"id": "n1", "type": "customdense", "data": {"params": {"units": "16", "activation": "relu"}}},
+    ],
+    "edges": [{"source": "n0", "target": "n1"}],
+    "model_name": "test_model",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+def _make_model(*, graph_json=None, model_name="test_model", model_id=1):
+    """Create a MagicMock that behaves like a ModelBasic with the given graph_json."""
+    m = MagicMock(spec=ModelBasic)
+    m.id = model_id
+    m.model_name = model_name
+    m.graph_json = graph_json
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _extract_graph
+# ---------------------------------------------------------------------------
+
+
+class TestExtractGraph:
+    def test_returns_none_for_none(self):
+        assert _extract_graph(None) is None
+
+    def test_unwraps_model_key(self):
+        """When payload is the full request body with a 'model' sub-key, extract it."""
+        payload = {"model": {"nodes": [1, 2], "edges": []}, "code": {}}
+        result = _extract_graph(payload)
+        assert result == {"nodes": [1, 2], "edges": []}
+
+    def test_returns_payload_when_nodes_present(self):
+        """When payload already has 'nodes' at top level, return as-is."""
+        payload = {"nodes": [1, 2], "edges": [], "model_name": "m"}
+        result = _extract_graph(payload)
+        assert result is payload
+
+    def test_model_validate_and_save_produce_same_shape(self):
+        """Both write-path payloads should produce the same extracted graph shape."""
+        graph = {"nodes": [{"id": "n0"}], "edges": [], "model_name": "m"}
+
+        # model_validate_service receives full request body
+        validate_payload = {"model": graph, "code": {"dl_model": {}}}
+        # model_save_service receives request.model.model_dump() — the graph itself
+        save_payload = graph
+
+        assert _extract_graph(validate_payload) == _extract_graph(save_payload)
+
+
+# ---------------------------------------------------------------------------
+# _validate_graph_size
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGraphSize:
+    def test_none_graph_returns_none(self):
+        assert _validate_graph_size(None) is None
+
+    def test_small_graph_returns_none(self):
+        assert _validate_graph_size(SAMPLE_GRAPH) is None
+
+    def test_oversized_graph_returns_error(self):
+        huge = {"nodes": [{"id": str(i), "data": "x" * 10000} for i in range(100)]}
+        result = _validate_graph_size(huge)
+        assert result is not None
+        assert "too large" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _apply_auto_layout
+# ---------------------------------------------------------------------------
+
+
+class TestApplyAutoLayout:
+    def test_adds_positions_to_nodes_without_them(self):
+        graph = copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS)
+        _apply_auto_layout(graph)
+        for node in graph["nodes"]:
+            assert "position" in node
+            assert isinstance(node["position"]["x"], float)
+            assert isinstance(node["position"]["y"], float)
+
+    def test_preserves_existing_positions(self):
+        graph = copy.deepcopy(SAMPLE_GRAPH)
+        original_positions = [copy.deepcopy(n["position"]) for n in graph["nodes"]]
+        _apply_auto_layout(graph)
+        for node, orig_pos in zip(graph["nodes"], original_positions, strict=True):
+            assert node["position"] == orig_pos
+
+    def test_handles_empty_nodes(self):
+        graph = {"nodes": [], "edges": []}
+        _apply_auto_layout(graph)  # should not raise
+
+    def test_handles_missing_nodes_key(self):
+        graph = {"edges": []}
+        _apply_auto_layout(graph)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# get_model_graph_service — fast path
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelGraphFastPath:
+    def test_returns_graph_from_graph_json(self, mock_db):
+        """When graph_json is populated, it should be returned directly."""
+        model = _make_model(graph_json=copy.deepcopy(SAMPLE_GRAPH))
+        mock_db.exec.return_value.first.return_value = model
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"]["graph"]["nodes"] == SAMPLE_GRAPH["nodes"]
+        assert body["data"]["model_name"] == "test_model"
+
+    def test_adds_positions_when_missing(self, mock_db):
+        """Fast path should auto-layout nodes that lack positions."""
+        model = _make_model(graph_json=copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS))
+        mock_db.exec.return_value.first.return_value = model
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        for node in body["data"]["graph"]["nodes"]:
+            assert "position" in node
+
+    def test_does_not_mutate_orm_object(self, mock_db):
+        """The service must not modify model.graph_json in-place."""
+        original_graph = copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS)
+        model = _make_model(graph_json=copy.deepcopy(original_graph))
+        mock_db.exec.return_value.first.return_value = model
+
+        get_model_graph_service(mock_db, "test_model")
+
+        # The ORM object's graph_json should be unchanged (no positions added)
+        for node in model.graph_json["nodes"]:
+            assert "position" not in node
+
+    def test_model_not_found_returns_404(self, mock_db):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_model_graph_service(mock_db, "nonexistent")
+
+        assert status == 404
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# get_model_graph_service — legacy fallback path
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelGraphLegacyPath:
+    def test_falls_back_to_model_configs(self, mock_db):
+        """When graph_json is None, the service reconstructs from ModelConfigs."""
+        model = _make_model(graph_json=None)
+
+        # First .exec().first() returns the model; second .exec().all() returns configs
+        first_call = MagicMock()
+        first_call.first.return_value = model
+
+        cfg1 = MagicMock(spec=ModelConfigs)
+        cfg1.parameter = "nodes.0.id"
+        cfg1.value = "n0"
+        cfg2 = MagicMock(spec=ModelConfigs)
+        cfg2.parameter = "nodes.0.type"
+        cfg2.value = "custominput"
+        cfg3 = MagicMock(spec=ModelConfigs)
+        cfg3.parameter = "nodes.0.data.params.dim-1"
+        cfg3.value = "4"
+
+        second_call = MagicMock()
+        second_call.all.return_value = [cfg1, cfg2, cfg3]
+
+        mock_db.exec.side_effect = [first_call, second_call]
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        assert body["success"] is True
+        graph = body["data"]["graph"]
+        assert "nodes" in graph
+        # Auto-layout should have been applied
+        for node in graph["nodes"]:
+            assert "position" in node
+
+    def test_legacy_no_configs_returns_404(self, mock_db):
+        """When graph_json is None AND no ModelConfigs exist, return 404."""
+        model = _make_model(graph_json=None)
+
+        first_call = MagicMock()
+        first_call.first.return_value = model
+
+        second_call = MagicMock()
+        second_call.all.return_value = []
+
+        mock_db.exec.side_effect = [first_call, second_call]
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 404
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# get_available_model_list — should NOT include graph_json
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableModelList:
+    def test_excludes_graph_json_from_response(self, mock_db):
+        """The list endpoint should return only id and model_name."""
+        m1 = MagicMock(spec=ModelBasic)
+        m1.id = 1
+        m1.model_name = "model_a"
+        m1.graph_json = {"nodes": [], "edges": []}
+
+        m2 = MagicMock(spec=ModelBasic)
+        m2.id = 2
+        m2.model_name = "model_b"
+        m2.graph_json = None
+
+        # count query
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=2)),  # total count
+            MagicMock(all=MagicMock(return_value=[m1, m2])),  # model list
+        ]
+
+        body, status = get_available_model_list(mock_db)
+
+        assert status == 200
+        for item in body["data"]:
+            assert "graph_json" not in item
+            assert "id" in item
+            assert "model_name" in item


### PR DESCRIPTION
Closes #140 

## Summary

When a user designs a neural network on the ReactFlow canvas and validates it, the original graph structure (nodes, edges, positions, parameters) was never persisted. Only a compiled Keras JSON file was saved to disk, making it impossible to reload the architecture back onto the canvas, compare models by structure, or query the graph at the database level. This PR adds a `graph_json` column to `model_basic` and stores the full ReactFlow graph at validation/save time.

## Root Cause

Three compounding gaps:

| Gap | Detail |
|---|---|
| No DB column | `ModelBasic` had nowhere to store the raw graph |
| Graph never captured | Both `model_validate_service` and `model_save_service` had the full dict in `incoming["model"]` / `incoming` but never wrote it anywhere |
| Positions silently stripped | `GraphNode` schema had no `position` field — Pydantic discarded `position` from every node before the service layer, making canvas reload impossible |

The existing `get_model_graph_service` worked around the missing column by reconstructing the graph from flattened `ModelConfigs` key-value rows, a lossy and complex operation that could not recover node positions.

## Design Decisions

- **JSON column over a separate table** — The graph is a document (hierarchical, variable-shape). A single nullable JSON column is simpler, queryable at the DB level, and avoids an extra join.
- **Nullable column** — Existing rows are completely unaffected. The service falls back to the legacy `ModelConfigs` reconstruction for any row where `graph_json IS NULL`.
- **`position` field on `GraphNode`** — Without this field in the Pydantic schema, node positions are stripped before reaching the service. Making it optional preserves full backward compatibility with clients that omit it.
- **Fast path / legacy fallback** — `get_model_graph_service` checks `model.graph_json` first (single column read). If `NULL`, it transparently falls back to the existing `_unflatten_model_configs` logic — zero regression risk for pre-migration models.

## Changes in Detail

### `app/models/ml.py`
Added `graph_json: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))` to `ModelBasic`, with `JSON` imported from `sqlalchemy`.

### Migration `d4b7f1a03e82`
Purely additive — adds a nullable JSON column. `downgrade()` drops it cleanly.

### `app/schemas/deep_learning.py`
```python
class GraphNode(BaseModel):
    id: str
    type: str
    data: NodeData
    position: dict[str, Any] | None = None   # ← new
```

### `app/services/deep_learning.py`

**`model_validate_service`** — stores the graph on creation:
```python
model = ModelBasic(
    ...
    graph_json=incoming["model"],   # ← new
)
```

**`model_save_service`** — stores the graph on save:
```python
model = ModelBasic(
    model_name=model_name,
    project_id=project_id,
    graph_json=incoming,            # ← new
)
```

**`get_model_graph_service`** — fast path for new models, legacy fallback for old:
```python
if model.graph_json is not None:
    graph = model.graph_json
    # auto-layout fallback for any node lacking position
    ...
    return graph   # direct — no reconstruction needed

# legacy: reconstruct from ModelConfigs as before
```

**`get_available_model_list`** — richer response:
```python
data = [{"model_name": m.model_name, "graph_json": m.graph_json} for m in models]
```

### `Training.jsx`
Updated `getAllModels` mapping to consume the new object shape:
```js
const models = response.map((item, index) => ({
    label: item.model_name + strings.MODEL_EXTENSION,
    value: item.model_name,
    key: index,
}));
```
