### PR TITLE
feat: add model architecture summary panel (#145)

### DIFF
--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -58,12 +58,14 @@ def _build_model_summary(keras_model) -> dict:
             output_shape = str(layer.output_shape)
         except AttributeError:
             output_shape = "unknown"
-        layers.append({
-            "name": layer.name,
-            "type": layer.__class__.__name__,
-            "output_shape": output_shape,
-            "param_count": int(layer.count_params()),
-        })
+        layers.append(
+            {
+                "name": layer.name,
+                "type": layer.__class__.__name__,
+                "output_shape": output_shape,
+                "param_count": int(layer.count_params()),
+            }
+        )
 
     total = int(keras_model.count_params())
     trainable = int(sum(w.numpy().size for w in keras_model.trainable_weights))

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -23,6 +23,7 @@ import ConvNode from "./CustomNodes/ConvNode/ConvNode";
 import Sidebar from "./Sidebar";
 import NodePropertiesPanel from "./NodePropertiesPanel";
 import { canSaveModel, generateModelJSON } from "./Helpers";
+import ModelSummaryPanel from "./ModelSummaryPanel";
 import { getAllModels, getModelGraph, saveModel } from "../../services/ModelServices";
 import { models as allModels } from "../../shared/atoms";
 import ContextMenu from "./ContextMenu";
@@ -43,6 +44,7 @@ function Canvas() {
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
   const [modelName, setModelName] = useState("");
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const [modelSummary, setModelSummary] = useState(null);
   const [feedbackDialog, setFeedbackDialog] = useState({
     open: false,
     success: false,
@@ -246,6 +248,7 @@ function Canvas() {
     saveModel(data)
       .then((resp) => {
         if (resp.success) {
+          setModelSummary(resp.data?.summary || null);
           try {
             localStorage.removeItem(draftKey);
             setHasDraft(false);
@@ -272,6 +275,7 @@ function Canvas() {
       })
       .catch((error) => {
         logger.error(error);
+        setModelSummary(null);
         setFeedbackDialog({
           open: true,
           success: false,
@@ -389,6 +393,7 @@ function Canvas() {
           </div>
         </ReactFlowProvider>
       </div>
+      <ModelSummaryPanel summary={modelSummary} onClose={() => setModelSummary(null)} />
     </>
   );
 }

--- a/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
@@ -21,11 +21,7 @@ export default function ModelSummaryPanel({ summary, onClose }) {
             onClick={() => setCollapsed((c) => !c)}
             aria-label={collapsed ? "Expand summary" : "Collapse summary"}
           >
-            {collapsed ? (
-              <ChevronDown className="h-4 w-4" />
-            ) : (
-              <ChevronUp className="h-4 w-4" />
-            )}
+            {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
           </Button>
           <Button
             variant="ghost"
@@ -70,9 +66,7 @@ export default function ModelSummaryPanel({ summary, onClose }) {
           <div className="mt-3 flex flex-wrap gap-4 border-t pt-3 text-xs text-muted-foreground">
             <span>
               Total params:{" "}
-              <strong className="text-foreground">
-                {summary.total_params.toLocaleString()}
-              </strong>
+              <strong className="text-foreground">{summary.total_params.toLocaleString()}</strong>
             </span>
             <span>
               Trainable:{" "}
@@ -101,7 +95,7 @@ ModelSummaryPanel.propTypes = {
         type: PropTypes.string.isRequired,
         output_shape: PropTypes.string.isRequired,
         param_count: PropTypes.number.isRequired,
-      })
+      }),
     ).isRequired,
     total_params: PropTypes.number.isRequired,
     trainable_params: PropTypes.number.isRequired,

--- a/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
@@ -1,0 +1,111 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function ModelSummaryPanel({ summary, onClose }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (!summary) return null;
+
+  return (
+    <Card className="mt-4">
+      <CardHeader className="flex flex-row items-center justify-between py-3">
+        <CardTitle className="text-sm">Model Architecture Summary</CardTitle>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-label={collapsed ? "Expand summary" : "Collapse summary"}
+          >
+            {collapsed ? (
+              <ChevronDown className="h-4 w-4" />
+            ) : (
+              <ChevronUp className="h-4 w-4" />
+            )}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={onClose}
+            aria-label="Close summary"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      {!collapsed && (
+        <CardContent className="pt-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 text-left font-medium">Layer</th>
+                  <th className="py-2 text-left font-medium">Type</th>
+                  <th className="py-2 text-left font-medium">Output Shape</th>
+                  <th className="py-2 text-right font-medium">Params</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.layers.map((layer, i) => (
+                  <tr key={i} className="border-b last:border-0">
+                    <td className="py-1.5 pr-3 font-mono">{layer.name}</td>
+                    <td className="py-1.5 pr-3">{layer.type}</td>
+                    <td className="py-1.5 pr-3 font-mono text-muted-foreground">
+                      {layer.output_shape}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {layer.param_count.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 border-t pt-3 text-xs text-muted-foreground">
+            <span>
+              Total params:{" "}
+              <strong className="text-foreground">
+                {summary.total_params.toLocaleString()}
+              </strong>
+            </span>
+            <span>
+              Trainable:{" "}
+              <strong className="text-foreground">
+                {summary.trainable_params.toLocaleString()}
+              </strong>
+            </span>
+            <span>
+              Non-trainable:{" "}
+              <strong className="text-foreground">
+                {summary.non_trainable_params.toLocaleString()}
+              </strong>
+            </span>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+ModelSummaryPanel.propTypes = {
+  summary: PropTypes.shape({
+    layers: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        output_shape: PropTypes.string.isRequired,
+        param_count: PropTypes.number.isRequired,
+      })
+    ).isRequired,
+    total_params: PropTypes.number.isRequired,
+    trainable_params: PropTypes.number.isRequired,
+    non_trainable_params: PropTypes.number.isRequired,
+  }),
+  onClose: PropTypes.func.isRequired,
+};


### PR DESCRIPTION
## Summary

When designing a neural network on the TensorMap canvas users had no visibility into model complexity — parameter count, per-layer output shapes, or the trainable/non-trainable breakdown. This PR adds a `_build_model_summary()` backend helper that extracts structured summary data from the already-built Keras model during validation/save, and a collapsible `ModelSummaryPanel` on the frontend that displays it after successful validation.

## Root Cause (Gap Analysis)

| Gap | Detail |
|---|---|
| No summary extraction | `model_save_service` and `model_validate_service` both instantiate a `tf.keras.Model` but discard it — the `data` field of every success response was `None` |
| No frontend display | `Canvas.jsx` only checked `resp.success` and showed a dialog; `resp.data` was never read |
| No component | Nothing in the component tree could render layer-level stats |

## Design Decisions

- **Reuse the already-built `keras_model`**: Both service functions already call `tf.keras.models.model_from_json()` to validate the model. The result was previously thrown away. Assigning it to a variable costs nothing and enables summary extraction.
- **`data.summary` in response, not a new endpoint**: The summary is produced during validation/save. Adding a separate `/model/summary` endpoint would require re-building the Keras model on each call. Embedding it in the existing success response is simpler and faster.
- **Collapsible, closeable panel below canvas**: Matches the existing `Card`-based layout. Closing clears React state — no re-validation needed. Collapsing hides only the table body, keeping the header visible.
- **`modelSummary` cleared on save failure**: Avoids showing stale summary data from a previous attempted model.


## Backward Compatibility

- The `data` field in success responses was previously `null` — any client that ignored `data` is unaffected; the field now carries `{"summary": {...}}`
- Error responses are completely unchanged
- No new endpoints, no schema changes, no DB migrations required

## Testing

- Save a valid canvas model → summary panel appears below canvas with per-layer rows and param totals matching Keras's `model.summary()` output
- Collapse → header remains visible, table hidden
- Close → panel disappears; re-saving shows a fresh summary
- Invalid model save → panel is not shown (or previous panel cleared)

Closes #145
