### PR TITLE
feat: Implement model deletion functionality and update model listing

### DIFF
--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from app.database import get_db
 from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
 from app.services.deep_learning import (
+    delete_model_service,
     get_available_model_list,
     get_code_service,
     get_model_graph_service,
@@ -22,6 +23,18 @@ from app.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 router = APIRouter(tags=["deep-learning"])
+
+
+@router.delete("/model/{model_id}")
+async def delete_model(
+    model_id: int,
+    project_id: uuid_pkg.UUID | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Delete a saved model and its configurations."""
+    logger.debug("Deleting model with id=%d", model_id)
+    body, status_code = delete_model_service(db, model_id=model_id, project_id=project_id)
+    return JSONResponse(status_code=status_code, content=body)
 
 
 @router.post("/model/validate")

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -138,14 +138,17 @@ function Canvas() {
     saveModel(data)
       .then((resp) => {
         if (resp.success) {
-          setModelList((prevList) => [
-            ...prevList,
-            {
-              label: modelName + strings.MODEL_EXTENSION,
-              value: modelName,
-              key: prevList.length + 1,
-            },
-          ]);
+          getAllModels(projectId)
+            .then((response) => {
+              const models = response.map((file, index) => ({
+                label: file.name + strings.MODEL_EXTENSION,
+                value: file.name,
+                id: file.id,
+                key: index,
+              }));
+              setModelList(models);
+            })
+            .catch((error) => logger.error("Error refreshing models:", error));
         }
         setFeedbackDialog({
           open: true,

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -22,9 +22,19 @@ import {
   runModel,
   getAllModels,
   updateTrainingConfig,
+  deleteModel,
 } from "../../services/ModelServices";
 import { getAllFiles } from "../../services/FileServices";
 import { models as modelListAtom } from "../../shared/atoms";
+import { Trash2 } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 const optimizerOptions = [
   { key: "opt_1", label: "Adam", value: "adam" },
@@ -49,6 +59,8 @@ export default function Training() {
   const [resultValues, setResultValues] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [connectionError, setConnectionError] = useState(null);
+  const [isDeleteDialogOpen, setIsDeleteDialogOpen] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
   const socketRef = useRef(null);
   const timeoutRef = useRef(null);
 
@@ -114,8 +126,9 @@ export default function Training() {
     getAllModels(projectId)
       .then((response) => {
         const models = response.map((file, index) => ({
-          label: file + strings.MODEL_EXTENSION,
-          value: file,
+          label: file.name + strings.MODEL_EXTENSION,
+          value: file.name,
+          id: file.id,
           key: index,
         }));
         setModelList(models);
@@ -224,7 +237,7 @@ export default function Training() {
       setResultValues(["Training timed out. The model may still be running on the server."]);
     }, 300000);
     runModel(selectedModel, projectId)
-      .then(() => {})
+      .then(() => { })
       .catch((error) => {
         clearTimeout(timeoutRef.current);
         logger.error(error.response?.data);
@@ -236,6 +249,30 @@ export default function Training() {
   const handleClear = () => {
     setResultValues([]);
     setIsLoading(false);
+  };
+
+  const handleDeleteModel = () => {
+    const modelToDelete = modelList.find((m) => m.value === selectedModel);
+    if (!modelToDelete) return;
+
+    setIsDeleting(true);
+    deleteModel(modelToDelete.id, projectId)
+      .then((resp) => {
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+        if (resp.success) {
+          setModelList((prev) => prev.filter((m) => m.id !== modelToDelete.id));
+          setSelectedModel(null);
+          setConfigSaved(false);
+        } else {
+          logger.error("Error deleting model:", resp.message);
+        }
+      })
+      .catch((error) => {
+        setIsDeleting(false);
+        setIsDeleteDialogOpen(false);
+        logger.error("Error deleting model:", error);
+      });
   };
 
   return (
@@ -259,6 +296,15 @@ export default function Training() {
               </SelectContent>
             </Select>
             <Button
+              variant="destructive"
+              size="icon"
+              disabled={!selectedModel}
+              onClick={() => setIsDeleteDialogOpen(true)}
+              title="Delete Model"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+            <Button
               onClick={handleDownload}
               disabled={!selectedModel || !configSaved}
               variant="outline"
@@ -278,6 +324,25 @@ export default function Training() {
           </div>
         </CardContent>
       </Card>
+
+      <Dialog open={isDeleteDialogOpen} onOpenChange={setIsDeleteDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete Model</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete the model &quot;{selectedModel}&quot;? This action cannot be undone and will permanently remove the model and its configurations.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setIsDeleteDialogOpen(false)} disabled={isDeleting}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteModel} disabled={isDeleting}>
+              {isDeleting ? "Deleting..." : "Delete"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
 
       {selectedModel && (
         <Card>

--- a/tensormap-frontend/src/services/ModelServices.js
+++ b/tensormap-frontend/src/services/ModelServices.js
@@ -4,6 +4,27 @@ import * as strings from "../constants/Strings";
 import logger from "../shared/logger";
 
 /**
+ * Deletes a model by its ID.
+ *
+ * @param {string|number} modelId
+ * @param {string} [projectId]
+ * @returns {Promise<{ success: boolean, message: string }>}
+ */
+export const deleteModel = async (modelId, projectId) => {
+  const params = projectId ? { project_id: projectId } : {};
+  return axios
+    .delete(`${urls.BACKEND_GET_MODEL_GRAPH}/${encodeURIComponent(modelId)}`, { params })
+    .then((resp) => resp.data)
+    .catch((err) => {
+      logger.error(err);
+      if (err.response && err.response.data) {
+        return err.response.data;
+      }
+      return { success: false, message: "Unknown error occurred" };
+    });
+};
+
+/**
  * Sends a model graph and training config to the backend for validation.
  *
  * On network error, returns a fallback `{ success: false }` object


### PR DESCRIPTION


## Description

I have implemented the model deletion feature for both backend and frontend.

Backend: Created the delete_model_service to accept an ID, query the model configs, cascade deletes across the DB schema for configs, remove any generated .json files, and successfully hooked it locally to the router /model/{id} path via HTTP DELETE.
Backend Model Format: Modified get_available_model_list format to dynamically return an array of objects [{"id": "X", "name": "Y"}] instead of just an array of ["Y"].
Frontend Model Services: Developed the API function deleteModel resolving with promises to the Backend DELETE route.
Frontend UI: Appended the requested model Delete visual feature with a React Trash2 Icon component directly adjacent to the model dropdown inside Training.jsx. It properly spawns a clean shadcn/ui confirmation dialog verifying intent to completely wipe the model.
Verification: Fixed the volume paths on docker-compose to hot-reload, successfully wrote to the database to create a sample test model, extracted the dynamically issued sequence-generated ID, successfully triggered the new deletion endpoint via our test script, and verified HTTP 200 response alongside confirming the empty array return list post-deletion.

Fixes #133

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [ ] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [ ] Tests pass locally
