### PR TITLE
test: verify /lint comment trigger

### DIFF
--- a/tensormap-frontend/src/constants/Strings.js
+++ b/tensormap-frontend/src/constants/Strings.js
@@ -16,3 +16,5 @@ export const PROCESS_FAIL_MODEL_BUTTON = "Try again";
 export const UPLOAD_SUCCESS_MODEL_MESSAGE = "File uploaded successfully";
 export const DL_RESULT_LISTENER = "result :::";
 export const MODEL_EXTENSION = ".py";
+
+// Test: verify /lint comment trigger works on PRs


### PR DESCRIPTION
## Summary
- Adds a test comment to `strings.js` to verify the new `/lint` issue_comment workflow trigger

## Test plan
- [ ] PR creation triggers normal `pull_request` lint workflow
- [ ] Commenting `/lint` on this PR retriggers lint via `issue_comment`
- [ ] Comment posting works correctly for both triggers

This PR will be closed after testing.