### PR TITLE
feat(frontend): add project edit/delete flows on project cards

### DIFF
--- a/tensormap-frontend/src/components/ui/dropdown-menu.jsx
+++ b/tensormap-frontend/src/components/ui/dropdown-menu.jsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef(
+  ({ className, children, checked, ...props }, ref) => (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  ),
+);
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({ className, ...props }) => {
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/tensormap-frontend/src/containers/ProjectsPage/ProjectCard.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/ProjectCard.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import {
   Card,
   CardHeader,
@@ -8,40 +10,263 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { FileText, Brain } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Trash2, Pencil, MoreVertical, FileText, Brain } from "lucide-react";
+import { deleteProject, updateProject } from "../../services/ProjectServices";
+import logger from "../../shared/logger";
 
-export default function ProjectCard({ project }) {
+/**
+ * Card representing a single ML project.
+ *
+ * Clicking the card body navigates to the project workspace.
+ * The menu exposes Edit and Delete actions. Edit opens an inline
+ * dialog pre-filled with the current name/description; Delete shows a
+ * confirmation dialog before calling the API.
+ *
+ * @param {{ project: object, onDeleted: (id: string) => void, onUpdated: (project: object) => void }} props
+ */
+export default function ProjectCard({ project, onDeleted, onUpdated }) {
   const navigate = useNavigate();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+  const [editError, setEditError] = useState(null);
+  const [editName, setEditName] = useState(project.name);
+  const [editDescription, setEditDescription] = useState(project.description ?? "");
 
-  const handleClick = () => {
+  const handleCardClick = () => {
     navigate(`/workspace/${project.id}/datasets`);
   };
 
+  const openDeleteDialog = (e) => {
+    e.stopPropagation();
+    setDeleteError(null);
+    setDeleteDialogOpen(true);
+  };
+
+  const openEditDialog = (e) => {
+    e.stopPropagation();
+    setEditError(null);
+    setEditName(project.name);
+    setEditDescription(project.description ?? "");
+    setEditDialogOpen(true);
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      const resp = await deleteProject(project.id);
+      if (resp.data.success) {
+        onDeleted(project.id);
+        setDeleteDialogOpen(false);
+      } else {
+        setDeleteError(resp?.data?.message || "Failed to delete project. Please try again.");
+      }
+    } catch (err) {
+      logger.error("Failed to delete project:", err);
+      setDeleteError("Failed to delete project. Please try again.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleUpdate = async (e) => {
+    e.preventDefault();
+    if (!editName.trim()) return;
+    setSaving(true);
+    try {
+      const resp = await updateProject(project.id, {
+        name: editName.trim(),
+        description: editDescription.trim() || null,
+      });
+      if (resp.data.success) {
+        if (resp?.data?.data?.id) {
+          onUpdated(resp.data.data);
+          setEditDialogOpen(false);
+        } else {
+          setEditError("Received an unexpected response from the server.");
+          logger.error("Unexpected update project response:", resp?.data);
+        }
+      } else {
+        setEditError(resp?.data?.message || "Failed to update project. Please try again.");
+      }
+    } catch (err) {
+      logger.error("Failed to update project:", err);
+      setEditError("Failed to update project. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <Card className="cursor-pointer transition-shadow hover:shadow-md" onClick={handleClick}>
-      <CardHeader>
-        <CardTitle className="text-lg">{project.name}</CardTitle>
-        {project.description && (
-          <CardDescription className="line-clamp-2">{project.description}</CardDescription>
-        )}
-      </CardHeader>
-      <CardContent>
-        <div className="flex gap-3">
-          <Badge variant="secondary" className="flex items-center gap-1">
-            <FileText className="h-3 w-3" />
-            {project.file_count ?? 0} files
-          </Badge>
-          <Badge variant="secondary" className="flex items-center gap-1">
-            <Brain className="h-3 w-3" />
-            {project.model_count ?? 0} models
-          </Badge>
+    <>
+      <Card
+        className="relative cursor-pointer transition-shadow hover:shadow-md"
+        onClick={handleCardClick}
+      >
+        <div className="absolute right-3 top-3 z-10">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Project options"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+              <DropdownMenuItem onClick={openEditDialog}>
+                <Pencil className="h-3.5 w-3.5" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-destructive" onClick={openDeleteDialog}>
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
-      </CardContent>
-      <CardFooter className="text-xs text-muted-foreground">
-        {project.updated_on
-          ? `Updated ${new Date(project.updated_on).toLocaleDateString()}`
-          : `Created ${new Date(project.created_on).toLocaleDateString()}`}
-      </CardFooter>
-    </Card>
+
+        <CardHeader className="pr-10">
+          <CardTitle className="text-lg">{project.name}</CardTitle>
+          {project.description && (
+            <CardDescription className="line-clamp-2">{project.description}</CardDescription>
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-3">
+            <Badge variant="secondary" className="flex items-center gap-1">
+              <FileText className="h-3 w-3" />
+              {project.file_count ?? 0} files
+            </Badge>
+            <Badge variant="secondary" className="flex items-center gap-1">
+              <Brain className="h-3 w-3" />
+              {project.model_count ?? 0} models
+            </Badge>
+          </div>
+        </CardContent>
+        <CardFooter className="text-xs text-muted-foreground">
+          {project.updated_on
+            ? `Updated ${new Date(project.updated_on).toLocaleDateString()}`
+            : `Created ${new Date(project.created_on).toLocaleDateString()}`}
+        </CardFooter>
+      </Card>
+
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!deleting) setDeleteDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete project</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{project.name}</strong>? This will permanently
+              remove the project along with all its datasets and models. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteError && (
+            <p className="text-sm font-medium text-destructive mt-2">{deleteError}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteDialogOpen(false)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? "Deleting..." : "Delete project"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editDialogOpen}
+        onOpenChange={(open) => {
+          if (!saving) setEditDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit project</DialogTitle>
+            <DialogDescription>Update the project name or description.</DialogDescription>
+          </DialogHeader>
+          {editError && <p className="text-sm font-medium text-destructive mt-2">{editError}</p>}
+          <form onSubmit={handleUpdate}>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-name">Project Name</Label>
+                <Input
+                  id="edit-name"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  maxLength={100}
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-description">Description (optional)</Label>
+                <Textarea
+                  id="edit-description"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  maxLength={500}
+                  rows={3}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving || !editName.trim()}>
+                {saving ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
+
+ProjectCard.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    file_count: PropTypes.number,
+    model_count: PropTypes.number,
+    created_on: PropTypes.string,
+    updated_on: PropTypes.string,
+  }).isRequired,
+  onDeleted: PropTypes.func.isRequired,
+  onUpdated: PropTypes.func.isRequired,
+};

--- a/tensormap-frontend/src/containers/ProjectsPage/ProjectsPage.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/ProjectsPage.jsx
@@ -43,6 +43,14 @@ export default function ProjectsPage() {
     setProjects((prev) => [newProject, ...prev]);
   };
 
+  const handleProjectDeleted = (deletedId) => {
+    setProjects((prev) => prev.filter((p) => p.id !== deletedId));
+  };
+
+  const handleProjectUpdated = (updatedProject) => {
+    setProjects((prev) => prev.map((p) => (p.id === updatedProject.id ? updatedProject : p)));
+  };
+
   return (
     <div className="min-h-[calc(100vh-3.5rem)] bg-background">
       <div className="mx-auto max-w-6xl px-6 py-8">
@@ -78,7 +86,12 @@ export default function ProjectsPage() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onDeleted={handleProjectDeleted}
+                onUpdated={handleProjectUpdated}
+              />
             ))}
           </div>
         )}

--- a/tensormap-frontend/src/services/ProjectServices.js
+++ b/tensormap-frontend/src/services/ProjectServices.js
@@ -23,3 +23,20 @@ export const getProject = (id) => axios.get(`${urls.BACKEND_PROJECT}/${id}`);
  * @returns {Promise<import("axios").AxiosResponse>}
  */
 export const createProject = (data) => axios.post(urls.BACKEND_PROJECT, data);
+
+/**
+ * Partially updates a project's name and/or description.
+ *
+ * @param {string} id
+ * @param {{ name?: string, description?: string | null }} data
+ * @returns {Promise<import("axios").AxiosResponse>}
+ */
+export const updateProject = (id, data) => axios.patch(`${urls.BACKEND_PROJECT}/${id}`, data);
+
+/**
+ * Deletes a project and all its associated files and models.
+ *
+ * @param {string} id
+ * @returns {Promise<import("axios").AxiosResponse>}
+ */
+export const deleteProject = (id) => axios.delete(`${urls.BACKEND_PROJECT}/${id}`);


### PR DESCRIPTION
## Summary
- Added project edit/delete service methods in the frontend API layer.
- Added a project card options menu (⋮) with **Edit** and **Delete** actions.
- Added an edit dialog with prefilled fields and in-place update behavior.
- Added a delete confirmation dialog with in-place removal behavior.
- Wired parent callbacks so the projects list updates without a full refetch.

## What Changed

### Frontend services
- Added `updateProject(id, data)` (PATCH)
- Added `deleteProject(id)` (DELETE)

### Project card UX
- Added top-right options menu that does not trigger card navigation.
- Added **Edit** flow:
  - Opens dialog prefilled with current name/description.
  - Calls `updateProject(...)`.
  - Calls `onUpdated(updatedProject)` on success.
- Added **Delete** flow:
  - Opens confirmation dialog with project name.
  - Calls `deleteProject(...)`.
  - Calls `onDeleted(project.id)` on success.
- Added full `PropTypes` for `ProjectCard` props.

### Projects page state handling
- Added `handleProjectDeleted(deletedId)` to remove card in-place.
- Added `handleProjectUpdated(updatedProject)` to replace card in-place.
- Passed `onDeleted` and `onUpdated` callbacks to each `ProjectCard`.

## Validation
- `npm run lint` ✅
- `npm run build` ✅

## Screenshots

### Before
<img width="1104" height="644" alt="Screenshot 2026-03-02 152755" src="https://github.com/user-attachments/assets/e4afe227-2a63-40a9-82be-d27c86262356" />

### After - Card options menu
<img width="1919" height="677" alt="Screenshot 2026-03-02 151945" src="https://github.com/user-attachments/assets/6d3283eb-e458-4818-84af-5c1b6c6a5db9" />

### After - Edit dialog
<img width="1916" height="800" alt="Screenshot 2026-03-02 152053" src="https://github.com/user-attachments/assets/f29dc063-3649-4457-857b-7826779dfb36" />

### After - Delete dialog
<img width="1919" height="879" alt="Screenshot 2026-03-02 152112" src="https://github.com/user-attachments/assets/3dbcebf7-b47f-40dd-abd4-4fe4ddb528ba" />

## Notes
- Frontend-only PR; backend endpoints already existed.
- No database or migration changes.