### PR TITLE
fix: enforce max_content_length for file uploads

### DIFF
--- a/tensormap-backend/app/services/data_upload.py
+++ b/tensormap-backend/app/services/data_upload.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import uuid as uuid_pkg
 from typing import Any
@@ -28,6 +29,22 @@ def add_file_service(db: Session, file_wrapper: Any, project_id: uuid_pkg.UUID |
 
     filename = secure_filename(file_wrapper.filename.lower())
     file_path = os.path.join(upload_folder, filename)
+
+    # Enforce max upload size before saving to disk
+    # Primary guard: Content-Length header pre-check (fast path, before reading body)
+    file_size = 0
+    try:
+        file_wrapper.file.seek(0, 2)
+        file_size = file_wrapper.file.tell()
+    except (AttributeError, OSError) as exc:
+        logger.warning("Could not determine upload size; rejecting upload. Reason: %s", exc)
+        return _resp(413, False, "File size could not be verified. Upload rejected.")
+    finally:
+        with contextlib.suppress(AttributeError, OSError):
+            file_wrapper.file.seek(0)
+    if file_size > settings.max_content_length:
+        return _resp(413, False, "File too large. Maximum allowed size is 200MB.")
+
     file_wrapper.save(file_path)
 
     file_name_db = secure_filename(file_wrapper.filename.rsplit(".", 1)[0].lower())


### PR DESCRIPTION
## Summary
Fixes #189

`app/config.py` defines `max_content_length = 200MB` but this value was never checked during file upload. Any file size was accepted, saved to disk, and loaded into pandas, potentially crashing the server with very large files.

## Fix
Added size validation in `add_file_service` before saving to disk:
- Seek to end of file stream to get size
- Compare against `settings.max_content_length`
- Return HTTP 413 with a clear error message if exceeded
- Reset file pointer before proceeding with save

## Testing
- Files under 200MB: accepted as before 
- Files over 200MB: rejected with HTTP 413 and message 
  "File too large. Maximum allowed size is 200MB." 