### PR TITLE
fix: catch ValueError in get_code_service to return clean 400 response

### DIFF
--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -315,7 +315,17 @@ def get_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | N
     err = _verify_model_project(db, model_name, project_id)
     if err:
         return err
-    python_code = generate_code(model_name, db)
+    try:
+        python_code = generate_code(model_name, db)
+    except ValueError as e:
+        logger.warning("Code generation failed for model '%s': %s", model_name, str(e))
+        return _resp(400, False, str(e))
+    except (FileNotFoundError, OSError):
+        logger.exception("File error during code generation for model '%s'", model_name)
+        return _resp(500, False, "Failed to read model file")
+    except Exception:
+        logger.exception("Unexpected error during code generation for model '%s'", model_name)
+        return _resp(500, False, "Internal error generating code")
     return {"content": python_code, "file_name": model_name + ".py"}, 200
 
 


### PR DESCRIPTION
## Summary
Fixes #197

## Change
`get_code_service()` called `generate_code()` without error handling. Since PR #196 added `ValueError` raises to `generate_code()` for missing models/files, these exceptions propagated uncaught to the router, returning 500 instead of a clean error response.

Added try/except to catch `ValueError` and return a proper 400 response with the error message.