### PR TITLE
fix: set Node ESLint env for postcss config

### DIFF
--- a/tensormap-frontend/postcss.config.js
+++ b/tensormap-frontend/postcss.config.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 module.exports = {
   plugins: {
     tailwindcss: {},


### PR DESCRIPTION
## Summary
- add Node ESLint environment declaration to PostCSS config
- resolve `no-undef` on `module.exports` in frontend lint run

## Validation
- Ran frontend lint successfully:
  - `npm run lint` in `tensormap-frontend`

Refs #121