### PR TITLE
fix: add logging to Socket.IO connect handler (#211)

### DIFF
--- a/tensormap-backend/app/socketio_instance.py
+++ b/tensormap-backend/app/socketio_instance.py
@@ -4,6 +4,9 @@ import socketio
 
 from app.config import get_settings
 from app.shared.constants import SOCKETIO_DL_NAMESPACE
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
 
 sio = socketio.AsyncServer(
     async_mode="asgi",
@@ -13,5 +16,6 @@ sio = socketio.AsyncServer(
 
 @sio.on("connect", namespace=SOCKETIO_DL_NAMESPACE)
 async def dl_connect(sid, environ):
-    """Accept client connections to the training progress namespace."""
-    pass
+    """Accept and log client connections to the training progress namespace."""
+    client_ip = environ.get("REMOTE_ADDR", "unknown")
+    logger.info("Client connected to training namespace: sid=%s, ip=%s", sid, client_ip)


### PR DESCRIPTION
## Summary
Adds basic connection logging for the Socket.IO training namespace instead of leaving the connect handler empty.

## Changes
- add backend logger import in `app/socketio_instance.py`
- log client SID and remote IP when a client connects to `/dl-result`
- replace the empty `pass` body in the connect handler

## Why
Issue #211 identified that the namespace connect handler was effectively a no-op, which makes debugging connection lifecycle problems harder.

Closes #211