### PR TITLE
feat: add per-layer delete button in canvas nodes

### DIFF
--- a/tensormap-backend/migrations/versions/e8c4d7f91a2b_merge_model_basic_heads.py
+++ b/tensormap-backend/migrations/versions/e8c4d7f91a2b_merge_model_basic_heads.py
@@ -1,0 +1,21 @@
+"""merge model_basic migration heads
+
+Revision ID: e8c4d7f91a2b
+Revises: c3a1d9e02f45, d4b7f1a03e82
+Create Date: 2026-03-13 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "e8c4d7f91a2b"
+down_revision = ("c3a1d9e02f45", "d4b7f1a03e82")
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Merge the batch_size and graph_json schema branches."""
+
+
+def downgrade() -> None:
+    """Unmerge the batch_size and graph_json schema branches."""

--- a/tensormap-frontend/package-lock.json
+++ b/tensormap-frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
+        "@radix-ui/react-dropdown-menu": "^2.1.16",
         "@radix-ui/react-label": "^2.1.8",
         "@radix-ui/react-select": "^2.2.6",
         "@radix-ui/react-separator": "^1.1.8",
@@ -1476,6 +1477,35 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.16.tgz",
+      "integrity": "sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-menu": "2.1.16",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-focus-guards": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.3.tgz",
@@ -1576,6 +1606,64 @@
           "optional": true
         },
         "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu": {
+      "version": "2.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.16.tgz",
+      "integrity": "sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.3",
+        "@radix-ui/react-collection": "1.1.7",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-direction": "1.1.1",
+        "@radix-ui/react-dismissable-layer": "1.1.11",
+        "@radix-ui/react-focus-guards": "1.1.3",
+        "@radix-ui/react-focus-scope": "1.1.7",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.8",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.5",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-roving-focus": "1.1.11",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-callback-ref": "1.1.1",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.6.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-menu/node_modules/@radix-ui/react-slot": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.3.tgz",
+      "integrity": "sha512-aeNmHnBxbi2St0au6VBVC7JXFlhLlOnvIIlePNniyUNAClzmtAUEY8/pBiK3iHjufOlwA+c20/8jngo7xcrg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
           "optional": true
         }
       }

--- a/tensormap-frontend/package.json
+++ b/tensormap-frontend/package.json
@@ -4,6 +4,7 @@
   "private": true,
   "dependencies": {
     "@radix-ui/react-dialog": "^1.1.15",
+    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-separator": "^1.1.8",

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
@@ -1,8 +1,8 @@
 import PropTypes from "prop-types";
-import { Handle, Position, useReactFlow } from "reactflow";
+import { Handle, Position } from "reactflow";
+import NodeDeleteButton from "../shared/NodeDeleteButton";
 
 function ConvNode({ data, id }) {
-  const { deleteElements } = useReactFlow();
   const p = data.params;
   const parts = [
     p.filter ? `F: ${p.filter}` : null,
@@ -14,27 +14,12 @@ function ConvNode({ data, id }) {
     .filter(Boolean)
     .join(", ");
 
-  const handleDelete = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    deleteElements({ nodes: [{ id }] });
-  };
-
   return (
     <div className="w-48 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
       <div className="flex items-center justify-between rounded-t-lg bg-node-conv px-3 py-1.5 text-xs font-bold text-white">
         <span>Conv2D</span>
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
-          aria-label="Delete layer"
-          title="Delete layer"
-          data-testid="conv-node-delete-button"
-        >
-          ×
-        </button>
+        <NodeDeleteButton id={id} testId="conv-node-delete-button" />
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">{parts || "Not configured"}</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
@@ -1,7 +1,8 @@
 import PropTypes from "prop-types";
-import { Handle, Position } from "reactflow";
+import { Handle, Position, useReactFlow } from "reactflow";
 
 function ConvNode({ data, id }) {
+  const { deleteElements } = useReactFlow();
   const p = data.params;
   const parts = [
     p.filter ? `F: ${p.filter}` : null,
@@ -13,11 +14,26 @@ function ConvNode({ data, id }) {
     .filter(Boolean)
     .join(", ");
 
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteElements({ nodes: [{ id }] });
+  };
+
   return (
     <div className="w-48 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
-      <div className="rounded-t-lg bg-node-conv px-3 py-1.5 text-xs font-bold text-white">
-        Conv2D
+      <div className="flex items-center justify-between rounded-t-lg bg-node-conv px-3 py-1.5 text-xs font-bold text-white">
+        <span>Conv2D</span>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
+          aria-label="Delete layer"
+          title="Delete layer"
+        >
+          ×
+        </button>
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">{parts || "Not configured"}</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.jsx
@@ -31,6 +31,7 @@ function ConvNode({ data, id }) {
           className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
           aria-label="Delete layer"
           title="Delete layer"
+          data-testid="conv-node-delete-button"
         >
           ×
         </button>

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
@@ -5,6 +5,7 @@ import ConvNode from "./ConvNode";
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+  useReactFlow: () => ({ deleteElements: vi.fn() }),
 }));
 
 describe("ConvNode", () => {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
@@ -1,11 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import ConvNode from "./ConvNode";
+
+const deleteElementsMock = vi.fn();
 
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
-  useReactFlow: () => ({ deleteElements: vi.fn() }),
+  useReactFlow: () => ({ deleteElements: deleteElementsMock }),
 }));
 
 describe("ConvNode", () => {
@@ -23,6 +25,10 @@ describe("ConvNode", () => {
       },
     },
   };
+
+  beforeEach(() => {
+    deleteElementsMock.mockClear();
+  });
 
   it("renders the title correctly", () => {
     render(<ConvNode {...defaultProps} />);
@@ -90,5 +96,15 @@ describe("ConvNode", () => {
 
     const sourceHandle = screen.getByTestId("handle-source-right");
     expect(sourceHandle).toBeInTheDocument();
+  });
+
+  it("renders delete button and deletes node on click", () => {
+    render(<ConvNode {...defaultProps} />);
+
+    const deleteButton = screen.getByTestId("conv-node-delete-button");
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+    expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });
   });
 });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
@@ -101,8 +101,9 @@ describe("ConvNode", () => {
   it("renders delete button and deletes node on click", () => {
     render(<ConvNode {...defaultProps} />);
 
-    const deleteButton = screen.getByTestId("conv-node-delete-button");
+    const deleteButton = screen.getByRole("button", { name: "Delete layer" });
     expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveAttribute("title", "Delete layer");
 
     fireEvent.click(deleteButton);
     expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
@@ -25,6 +25,7 @@ function DenseNode({ data, id }) {
           className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
           aria-label="Delete layer"
           title="Delete layer"
+          data-testid="dense-node-delete-button"
         >
           ×
         </button>

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
@@ -1,17 +1,33 @@
 import PropTypes from "prop-types";
-import { Handle, Position } from "reactflow";
+import { Handle, Position, useReactFlow } from "reactflow";
 
 function DenseNode({ data, id }) {
+  const { deleteElements } = useReactFlow();
   const { units, activation } = data.params;
   const summary = [units ? `Units: ${units}` : null, activation ? `Act: ${activation}` : null]
     .filter(Boolean)
     .join(", ");
 
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteElements({ nodes: [{ id }] });
+  };
+
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
-      <div className="rounded-t-lg bg-node-dense px-3 py-1.5 text-xs font-bold text-white">
-        Dense
+      <div className="flex items-center justify-between rounded-t-lg bg-node-dense px-3 py-1.5 text-xs font-bold text-white">
+        <span>Dense</span>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
+          aria-label="Delete layer"
+          title="Delete layer"
+        >
+          ×
+        </button>
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">{summary || "Not configured"}</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.jsx
@@ -1,34 +1,19 @@
 import PropTypes from "prop-types";
-import { Handle, Position, useReactFlow } from "reactflow";
+import { Handle, Position } from "reactflow";
+import NodeDeleteButton from "../shared/NodeDeleteButton";
 
 function DenseNode({ data, id }) {
-  const { deleteElements } = useReactFlow();
   const { units, activation } = data.params;
   const summary = [units ? `Units: ${units}` : null, activation ? `Act: ${activation}` : null]
     .filter(Boolean)
     .join(", ");
-
-  const handleDelete = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    deleteElements({ nodes: [{ id }] });
-  };
 
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
       <div className="flex items-center justify-between rounded-t-lg bg-node-dense px-3 py-1.5 text-xs font-bold text-white">
         <span>Dense</span>
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
-          aria-label="Delete layer"
-          title="Delete layer"
-          data-testid="dense-node-delete-button"
-        >
-          ×
-        </button>
+        <NodeDeleteButton id={id} testId="dense-node-delete-button" />
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">{summary || "Not configured"}</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
@@ -1,11 +1,13 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import DenseNode from "./DenseNode";
+
+const deleteElementsMock = vi.fn();
 
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
-  useReactFlow: () => ({ deleteElements: vi.fn() }),
+  useReactFlow: () => ({ deleteElements: deleteElementsMock }),
 }));
 
 describe("DenseNode", () => {
@@ -18,6 +20,10 @@ describe("DenseNode", () => {
       },
     },
   };
+
+  beforeEach(() => {
+    deleteElementsMock.mockClear();
+  });
 
   it("renders the title correctly", () => {
     render(<DenseNode {...defaultProps} />);
@@ -67,5 +73,15 @@ describe("DenseNode", () => {
     // and a source handle on the right
     const sourceHandle = screen.getByTestId("handle-source-right");
     expect(sourceHandle).toBeInTheDocument();
+  });
+
+  it("renders delete button and deletes node on click", () => {
+    render(<DenseNode {...defaultProps} />);
+
+    const deleteButton = screen.getByTestId("dense-node-delete-button");
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+    expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });
   });
 });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
@@ -5,6 +5,7 @@ import DenseNode from "./DenseNode";
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+  useReactFlow: () => ({ deleteElements: vi.fn() }),
 }));
 
 describe("DenseNode", () => {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
@@ -78,8 +78,9 @@ describe("DenseNode", () => {
   it("renders delete button and deletes node on click", () => {
     render(<DenseNode {...defaultProps} />);
 
-    const deleteButton = screen.getByTestId("dense-node-delete-button");
+    const deleteButton = screen.getByRole("button", { name: "Delete layer" });
     expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveAttribute("title", "Delete layer");
 
     fireEvent.click(deleteButton);
     expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
@@ -1,30 +1,14 @@
 import PropTypes from "prop-types";
-import { Handle, Position, useReactFlow } from "reactflow";
+import { Handle, Position } from "reactflow";
+import NodeDeleteButton from "../shared/NodeDeleteButton";
 
 function FlattenNode({ id }) {
-  const { deleteElements } = useReactFlow();
-
-  const handleDelete = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    deleteElements({ nodes: [{ id }] });
-  };
-
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
       <div className="flex items-center justify-between rounded-t-lg bg-node-flatten px-3 py-1.5 text-xs font-bold text-white">
         <span>Flatten</span>
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
-          aria-label="Delete layer"
-          title="Delete layer"
-          data-testid="flatten-node-delete-button"
-        >
-          ×
-        </button>
+        <NodeDeleteButton id={id} testId="flatten-node-delete-button" />
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">No parameters</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
@@ -1,12 +1,29 @@
 import PropTypes from "prop-types";
-import { Handle, Position } from "reactflow";
+import { Handle, Position, useReactFlow } from "reactflow";
 
 function FlattenNode({ id }) {
+  const { deleteElements } = useReactFlow();
+
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteElements({ nodes: [{ id }] });
+  };
+
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
       <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
-      <div className="rounded-t-lg bg-node-flatten px-3 py-1.5 text-xs font-bold text-white">
-        Flatten
+      <div className="flex items-center justify-between rounded-t-lg bg-node-flatten px-3 py-1.5 text-xs font-bold text-white">
+        <span>Flatten</span>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
+          aria-label="Delete layer"
+          title="Delete layer"
+        >
+          ×
+        </button>
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">No parameters</div>
       <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.jsx
@@ -21,6 +21,7 @@ function FlattenNode({ id }) {
           className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
           aria-label="Delete layer"
           title="Delete layer"
+          data-testid="flatten-node-delete-button"
         >
           ×
         </button>

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
@@ -44,8 +44,9 @@ describe("FlattenNode", () => {
   it("renders delete button and deletes node on click", () => {
     render(<FlattenNode {...defaultProps} />);
 
-    const deleteButton = screen.getByTestId("flatten-node-delete-button");
+    const deleteButton = screen.getByRole("button", { name: "Delete layer" });
     expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveAttribute("title", "Delete layer");
 
     fireEvent.click(deleteButton);
     expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
@@ -5,6 +5,7 @@ import FlattenNode from "./FlattenNode";
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+  useReactFlow: () => ({ deleteElements: vi.fn() }),
 }));
 
 describe("FlattenNode", () => {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
@@ -1,17 +1,23 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import FlattenNode from "./FlattenNode";
+
+const deleteElementsMock = vi.fn();
 
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
-  useReactFlow: () => ({ deleteElements: vi.fn() }),
+  useReactFlow: () => ({ deleteElements: deleteElementsMock }),
 }));
 
 describe("FlattenNode", () => {
   const defaultProps = {
     id: "test-node-flatten",
   };
+
+  beforeEach(() => {
+    deleteElementsMock.mockClear();
+  });
 
   it("renders the title correctly", () => {
     render(<FlattenNode {...defaultProps} />);
@@ -33,5 +39,15 @@ describe("FlattenNode", () => {
     // and a source handle on the right
     const sourceHandle = screen.getByTestId("handle-source-right");
     expect(sourceHandle).toBeInTheDocument();
+  });
+
+  it("renders delete button and deletes node on click", () => {
+    render(<FlattenNode {...defaultProps} />);
+
+    const deleteButton = screen.getByTestId("flatten-node-delete-button");
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+    expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });
   });
 });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
@@ -1,15 +1,31 @@
 import PropTypes from "prop-types";
-import { Handle, Position } from "reactflow";
+import { Handle, Position, useReactFlow } from "reactflow";
 
 function InputNode({ data, id }) {
+  const { deleteElements } = useReactFlow();
   const dims = [data.params["dim-1"], data.params["dim-2"], data.params["dim-3"]]
     .filter((d) => d !== "" && d !== undefined)
     .join(" × ");
 
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteElements({ nodes: [{ id }] });
+  };
+
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
-      <div className="rounded-t-lg bg-node-input px-3 py-1.5 text-xs font-bold text-white">
-        Input
+      <div className="flex items-center justify-between rounded-t-lg bg-node-input px-3 py-1.5 text-xs font-bold text-white">
+        <span>Input</span>
+        <button
+          type="button"
+          onClick={handleDelete}
+          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
+          aria-label="Delete layer"
+          title="Delete layer"
+        >
+          ×
+        </button>
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">
         {dims ? `Dim: ${dims}` : "No dimensions set"}

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
@@ -23,6 +23,7 @@ function InputNode({ data, id }) {
           className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
           aria-label="Delete layer"
           title="Delete layer"
+          data-testid="input-node-delete-button"
         >
           ×
         </button>

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.jsx
@@ -1,32 +1,17 @@
 import PropTypes from "prop-types";
-import { Handle, Position, useReactFlow } from "reactflow";
+import { Handle, Position } from "reactflow";
+import NodeDeleteButton from "../shared/NodeDeleteButton";
 
 function InputNode({ data, id }) {
-  const { deleteElements } = useReactFlow();
   const dims = [data.params["dim-1"], data.params["dim-2"], data.params["dim-3"]]
     .filter((d) => d !== "" && d !== undefined)
     .join(" × ");
-
-  const handleDelete = (event) => {
-    event.preventDefault();
-    event.stopPropagation();
-    deleteElements({ nodes: [{ id }] });
-  };
 
   return (
     <div className="w-44 rounded-lg border bg-white shadow-sm">
       <div className="flex items-center justify-between rounded-t-lg bg-node-input px-3 py-1.5 text-xs font-bold text-white">
         <span>Input</span>
-        <button
-          type="button"
-          onClick={handleDelete}
-          className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
-          aria-label="Delete layer"
-          title="Delete layer"
-          data-testid="input-node-delete-button"
-        >
-          ×
-        </button>
+        <NodeDeleteButton id={id} testId="input-node-delete-button" />
       </div>
       <div className="px-3 py-2 text-xs text-muted-foreground">
         {dims ? `Dim: ${dims}` : "No dimensions set"}

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
@@ -1,12 +1,14 @@
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import InputNode from "./InputNode";
+
+const deleteElementsMock = vi.fn();
 
 // Mock reactflow's Handle and Position since we're testing the node purely presentationally.
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
-  useReactFlow: () => ({ deleteElements: vi.fn() }),
+  useReactFlow: () => ({ deleteElements: deleteElementsMock }),
 }));
 
 describe("InputNode", () => {
@@ -20,6 +22,10 @@ describe("InputNode", () => {
       },
     },
   };
+
+  beforeEach(() => {
+    deleteElementsMock.mockClear();
+  });
 
   it("renders the title correctly", () => {
     render(<InputNode {...defaultProps} />);
@@ -70,5 +76,15 @@ describe("InputNode", () => {
     // Should not have a target handle
     const targetHandleLeft = screen.queryByTestId("handle-target-left");
     expect(targetHandleLeft).not.toBeInTheDocument();
+  });
+
+  it("renders delete button and deletes node on click", () => {
+    render(<InputNode {...defaultProps} />);
+
+    const deleteButton = screen.getByTestId("input-node-delete-button");
+    expect(deleteButton).toBeInTheDocument();
+
+    fireEvent.click(deleteButton);
+    expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });
   });
 });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
@@ -81,8 +81,9 @@ describe("InputNode", () => {
   it("renders delete button and deletes node on click", () => {
     render(<InputNode {...defaultProps} />);
 
-    const deleteButton = screen.getByTestId("input-node-delete-button");
+    const deleteButton = screen.getByRole("button", { name: "Delete layer" });
     expect(deleteButton).toBeInTheDocument();
+    expect(deleteButton).toHaveAttribute("title", "Delete layer");
 
     fireEvent.click(deleteButton);
     expect(deleteElementsMock).toHaveBeenCalledWith({ nodes: [{ id: defaultProps.id }] });

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
@@ -6,6 +6,7 @@ import InputNode from "./InputNode";
 vi.mock("reactflow", () => ({
   Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
   Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+  useReactFlow: () => ({ deleteElements: vi.fn() }),
 }));
 
 describe("InputNode", () => {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/shared/NodeDeleteButton.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/shared/NodeDeleteButton.jsx
@@ -1,0 +1,32 @@
+import PropTypes from "prop-types";
+import { useReactFlow } from "reactflow";
+
+function NodeDeleteButton({ id, testId }) {
+  const { deleteElements } = useReactFlow();
+
+  const handleDelete = (event) => {
+    event.preventDefault();
+    event.stopPropagation();
+    deleteElements({ nodes: [{ id }] });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleDelete}
+      className="rounded px-1 leading-none text-white/80 hover:bg-white/20 hover:text-white"
+      aria-label="Delete layer"
+      title="Delete layer"
+      data-testid={testId}
+    >
+      ×
+    </button>
+  );
+}
+
+NodeDeleteButton.propTypes = {
+  id: PropTypes.string.isRequired,
+  testId: PropTypes.string.isRequired,
+};
+
+export default NodeDeleteButton;


### PR DESCRIPTION
## Description
Adds per-layer delete controls to canvas nodes so users can remove mistakenly added layers directly from the node UI.

Also includes the Alembic merge migration required to keep backend startup migrations resolvable.

Fixes #206

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing


## Screenshots (if applicable)

https://github.com/user-attachments/assets/a81ecb3f-e434-4b2c-9963-3c29ec9e4cbd



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [ ] My changes generate no new warnings
- [x] Tests pass locally
