### PR TITLE
fix(backend): guard missing file record in model_run helper

### DIFF
--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -88,6 +88,8 @@ def _helper_generate_file_location(db: Session, file_id) -> str:
     """Resolve the on-disk path for a dataset file by its DB ID."""
     upload_folder = get_settings().upload_folder
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
+    if file is None:
+        raise ValueError(f"File with id {file_id} not found in database")
     if file.file_type == "zip":
         return upload_folder + "/" + file.file_name
     return upload_folder + "/" + file.file_name + "." + file.file_type

--- a/tensormap-backend/tests/test_model_run.py
+++ b/tensormap-backend/tests/test_model_run.py
@@ -3,7 +3,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from app.services.deep_learning import get_code_service, run_code_service
-from app.services.model_run import model_run
+from app.services.model_run import _helper_generate_file_location, model_run
 from app.shared.enums import ProblemType
 
 
@@ -24,6 +24,14 @@ def _make_db(model_config: MagicMock) -> MagicMock:
     db = MagicMock()
     db.exec.return_value.first.return_value = model_config
     return db
+
+
+def test_helper_generate_file_location_raises_when_file_missing():
+    db = MagicMock()
+    db.exec.return_value.first.return_value = None
+
+    with pytest.raises(ValueError, match="not found in database"):
+        _helper_generate_file_location(db, "missing-file-id")
 
 
 class TestModelRunEmitsErrorOnFailure:


### PR DESCRIPTION
## Summary
- add null-check in _helper_generate_file_location when DB file lookup returns none
- raise a clear ValueError instead of crashing with AttributeError on ile.file_type`n- add a unit test for the missing-file path

Part of #193