### PR TITLE
fix(backend): catch code generation ValueError in get_code_service

### DIFF
--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -316,7 +316,10 @@ def get_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | N
     err = _verify_model_project(db, model_name, project_id)
     if err:
         return err
-    python_code = generate_code(model_name, db)
+    try:
+        python_code = generate_code(model_name, db)
+    except ValueError as e:
+        return _resp(400, False, str(e))
     return {"content": python_code, "file_name": model_name + ".py"}, 200
 
 

--- a/tensormap-backend/tests/test_model_run.py
+++ b/tensormap-backend/tests/test_model_run.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from app.services.deep_learning import run_code_service
+from app.services.deep_learning import get_code_service, run_code_service
 from app.services.model_run import model_run
 from app.shared.enums import ProblemType
 
@@ -84,3 +84,20 @@ class TestRunCodeServiceOnFailure:
             result, _ = run_code_service(db, "my_model")
 
         assert result["success"] is False
+
+
+class TestGetCodeServiceOnFailure:
+    def test_returns_http_400_when_generate_code_raises_value_error(self):
+        db = MagicMock()
+        with patch("app.services.deep_learning.generate_code", side_effect=ValueError("file missing")):
+            _, status_code = get_code_service(db, "my_model")
+
+        assert status_code == 400
+
+    def test_response_body_has_error_message_from_value_error(self):
+        db = MagicMock()
+        with patch("app.services.deep_learning.generate_code", side_effect=ValueError("file missing")):
+            result, _ = get_code_service(db, "my_model")
+
+        assert result["success"] is False
+        assert result["message"] == "file missing"


### PR DESCRIPTION
## Summary
- wrap generate_code() in get_code_service with ValueError handling
- return standard 400 response with the error message instead of bubbling to 500
- add unit tests for status code and message contract

Fixes #197