### PR TITLE
Paginate dataset preview to avoid loading full CSVs

### DIFF
--- a/tensormap-backend/app/routers/data_process.py
+++ b/tensormap-backend/app/routers/data_process.py
@@ -83,14 +83,14 @@ async def get_correlation(file_id: uuid_pkg.UUID, db: Session = Depends(get_db))
 
 
 @router.get("/data/process/file/{file_id}")
-async def get_file(
+def get_file(
     file_id: uuid_pkg.UUID,
-    page: int = Query(1, ge=1),
-    page_size: int = Query(50, ge=1, le=1000),
+    offset: int = Query(0, ge=0),
+    limit: int = Query(100, ge=1, le=500),
     db: Session = Depends(get_db),
 ):
-    """Return a paginated slice of a CSV file's contents with pagination metadata."""
-    body, status_code = get_file_data(db, file_id=file_id, page=page, page_size=page_size)
+    """Return a paginated CSV preview as JSON records."""
+    body, status_code = get_file_data(db, file_id=file_id, offset=offset, limit=limit)
     return JSONResponse(status_code=status_code, content=body)
 
 

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -26,11 +26,44 @@ def _get_file_path(file: DataFile) -> str:
 
 
 def add_target_service(db: Session, file_id: uuid_pkg.UUID, target: str) -> tuple:
-    """Create a DataProcess record linking a file to its target column."""
+    """Create or update the target field for a file."""
     try:
         file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
         if not file:
             return _resp(400, False, "File doesn't exist in DB")
+
+        if file.file_type != "csv":
+            return _resp(400, False, "Only CSV files support target field assignment")
+
+        columns = file.columns
+        if columns is None:
+            file_path = _get_file_path(file)
+            header_df = pd.read_csv(file_path, nrows=0)
+            columns = list(header_df.columns)
+            file.columns = columns
+            db.add(file)
+            db.commit()
+
+        if target not in columns:
+            return _resp(422, False, f"Target column '{target}' not found. Available columns: {columns}")
+
+        existing_rows = db.exec(select(DataProcess).where(DataProcess.file_id == file_id)).all()
+        if existing_rows:
+            target_record = existing_rows[0]
+            for duplicate in existing_rows[1:]:
+                db.delete(duplicate)
+
+            if target_record.target == target:
+                if len(existing_rows) > 1:
+                    db.commit()
+                    logger.info("Cleaned up duplicate target rows for file_id=%s", file_id)
+                return _resp(200, True, "Target field already set for this file")
+
+            target_record.target = target
+            db.add(target_record)
+            db.commit()
+            logger.info("Target field updated to '%s' for file_id=%s", target, file_id)
+            return _resp(200, True, "Target field updated successfully")
 
         data_process = DataProcess(file_id=file_id, target=target)
         db.add(data_process)
@@ -38,8 +71,9 @@ def add_target_service(db: Session, file_id: uuid_pkg.UUID, target: str) -> tupl
         logger.info("Target field '%s' added for file_id=%s", target, file_id)
         return _resp(201, True, "Target field added successfully")
     except Exception as e:
+        db.rollback()
         logger.exception("Error storing record: %s", str(e))
-        return _resp(500, False, f"Error storing record: {e}")
+        return _resp(500, False, "An error occurred while storing the target field")
 
 
 def get_all_targets_service(db: Session, offset: int = 0, limit: int = 50) -> tuple:
@@ -111,13 +145,14 @@ def get_data_metrics(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     try:
         df = pd.read_csv(file_path)
     except FileNotFoundError:
-        return _resp(500, False, f"File not found: {file_path}")
+        logger.error("File not found on disk: %s", file_path)
+        return _resp(500, False, "File not found on server")
     except pd.errors.ParserError as e:
         logger.exception("CSV parsing error: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error parsing CSV file")
     except Exception as e:
         logger.exception("Error reading file: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error reading CSV file")
 
     metrics = {
         "data_types": df.dtypes.apply(str).to_dict(),
@@ -137,13 +172,14 @@ def get_column_stats_service(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     try:
         df = pd.read_csv(file_path)
     except FileNotFoundError:
-        return _resp(500, False, f"File not found: {file_path}")
+        logger.error("File not found on disk: %s", file_path)
+        return _resp(500, False, "File not found on server")
     except pd.errors.ParserError as e:
         logger.exception("CSV parsing error: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error parsing CSV file")
     except Exception as e:
         logger.exception("Error reading file: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error reading CSV file")
 
     total_rows = len(df)
     total_cols = len(df.columns)
@@ -190,13 +226,14 @@ def get_correlation_matrix(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     try:
         df = pd.read_csv(file_path)
     except FileNotFoundError:
-        return _resp(500, False, f"File not found: {file_path}")
+        logger.error("File not found on disk: %s", file_path)
+        return _resp(500, False, "File not found on server")
     except pd.errors.ParserError as e:
         logger.exception("CSV parsing error: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error parsing CSV file")
     except Exception as e:
         logger.exception("Error reading file: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error reading CSV file")
 
     numeric_df = df.select_dtypes(include="number")
     if numeric_df.empty:
@@ -244,13 +281,14 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID, offset: int = 0, limit: i
         skiprows = range(1, offset + 1) if offset > 0 else None
         df = pd.read_csv(file_path, skiprows=skiprows, nrows=limit)
     except FileNotFoundError:
-        return _resp(500, False, f"File not found: {file_path}")
+        logger.error("File not found on disk: %s", file_path)
+        return _resp(500, False, "File not found on server")
     except pd.errors.ParserError as e:
         logger.exception("CSV parsing error: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error parsing CSV file")
     except Exception as e:
         logger.exception("Error reading file: %s", str(e))
-        return _resp(500, False, f"Error reading CSV: {e}")
+        return _resp(500, False, "Error reading CSV file")
 
     rows = df.to_dict(orient="records")
     data = {
@@ -396,7 +434,7 @@ def preprocess_data(db: Session, file_id: uuid_pkg.UUID, transformations: list) 
         return _resp(200, True, "Dataset preprocessed successfully")
     except pd.errors.ParserError as e:
         logger.exception("CSV parsing error: %s", str(e))
-        return _resp(500, False, f"Error parsing CSV data: {e}")
+        return _resp(500, False, "Error parsing CSV data")
     except Exception as e:
         logger.exception("Error preprocessing data: %s", str(e))
-        return _resp(500, False, f"Error preprocessing data: {e}")
+        return _resp(500, False, "Error preprocessing data")

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -19,6 +19,17 @@ def _resp(status_code: int, success: bool, message: str, data: Any = None) -> tu
     return {"success": success, "message": message, "data": data}, status_code
 
 
+def _paginated_resp(data: list, pagination: dict) -> tuple:
+    """Build a standard API response tuple for paginated data."""
+    body = {
+        "success": True,
+        "message": "Data sent successfully",
+        "data": data,
+        "pagination": pagination,
+    }
+    return body, 200
+
+
 def _get_file_path(file: DataFile) -> str:
     """Resolve the on-disk path for a DataFile record."""
     settings = get_settings()
@@ -31,6 +42,39 @@ def add_target_service(db: Session, file_id: uuid_pkg.UUID, target: str) -> tupl
         file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
         if not file:
             return _resp(400, False, "File doesn't exist in DB")
+        if file.file_type != "csv":
+            return _resp(400, False, "Only CSV files support target field assignment")
+
+        # Validate target against dataset columns.
+        columns = file.columns
+        if columns is None:
+            file_path = _get_file_path(file)
+            header_df = pd.read_csv(file_path, nrows=0)
+            columns = list(header_df.columns)
+            file.columns = columns
+            db.add(file)
+            db.commit()
+
+        if target not in (columns or []):
+            return _resp(
+                422,
+                False,
+                f"Target column '{target}' not found. Available columns: {columns or []}",
+            )
+
+        existing_rows = db.exec(select(DataProcess).where(DataProcess.file_id == file_id)).all()
+        if existing_rows:
+            target_record = existing_rows[0]
+            # Backfill cleanup in case legacy duplicates exist.
+            for duplicate in existing_rows[1:]:
+                db.delete(duplicate)
+            if target_record.target == target and len(existing_rows) == 1:
+                return _resp(200, True, "Target field already set for this file")
+            target_record.target = target
+            db.add(target_record)
+            db.commit()
+            logger.info("Target field updated to '%s' for file_id=%s", target, file_id)
+            return _resp(200, True, "Target field updated successfully")
 
         if file.file_type != "csv":
             return _resp(400, False, "Only CSV files support target field assignment")
@@ -246,40 +290,38 @@ def get_correlation_matrix(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     return _resp(200, True, "Correlation matrix computed successfully", {"columns": columns, "matrix": matrix})
 
 
-def get_file_data(db: Session, file_id: uuid_pkg.UUID, offset: int = 0, limit: int = 100) -> tuple:
-    """Read and return a paginated preview of a CSV file.
-
-    The response includes:
-    - ``rows``: list of records for the current page
-    - ``columns``: ordered list of column names
-    - ``pagination``: total/offset/limit metadata
-    """
+def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size: int = 50) -> tuple:
+    """Read and return the paginated contents of a CSV file as JSON."""
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if not file:
         return _resp(400, False, "Unable to open file")
-    if file.file_type != "csv":
-        return _resp(400, False, "Only CSV files support row preview")
 
     file_path = _get_file_path(file)
+
     try:
-        # Cache columns from disk if missing in DB.
-        if file.columns is None:
-            header_df = pd.read_csv(file_path, nrows=0)
-            file.columns = list(header_df.columns)
-            db.add(file)
-            db.commit()
-        columns = file.columns or []
+        with open(file_path, "rb") as f:
+            total_rows = sum(1 for _ in f) - 1
+        total_rows = max(total_rows, 0)
+    except FileNotFoundError:
+        logger.error("File not found on disk: %s", file_path)
+        return _resp(500, False, "File not found on server")
+    except Exception as e:
+        logger.exception("Error reading file count: %s", str(e))
+        return _resp(500, False, "Error reading file")
 
-        # Use cached row_count when available; otherwise count once and cache.
-        if file.row_count is None:
-            file.row_count = sum(chunk.shape[0] for chunk in pd.read_csv(file_path, chunksize=10_000))
-            db.add(file)
-            db.commit()
-        total_rows = file.row_count or 0
+    total_pages = (total_rows + page_size - 1) // page_size if page_size > 0 else 0
 
-        # Read only the requested page rows (keep header row intact).
-        skiprows = range(1, offset + 1) if offset > 0 else None
-        df = pd.read_csv(file_path, skiprows=skiprows, nrows=limit)
+    if total_rows > 0 and page > total_pages:
+        return _resp(400, False, f"Page {page} exceeds total pages ({total_pages})")
+
+    if total_rows == 0:
+        return _paginated_resp([], {"page": page, "page_size": page_size, "total_rows": 0, "total_pages": 0})
+
+    start_idx = (page - 1) * page_size
+    skip = list(range(1, start_idx + 1)) if start_idx > 0 else None
+
+    try:
+        df_page = pd.read_csv(file_path, skiprows=skip, nrows=page_size)
     except FileNotFoundError:
         logger.error("File not found on disk: %s", file_path)
         return _resp(500, False, "File not found on server")
@@ -290,13 +332,12 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID, offset: int = 0, limit: i
         logger.exception("Error reading file: %s", str(e))
         return _resp(500, False, "Error reading CSV file")
 
-    rows = df.to_dict(orient="records")
-    data = {
-        "rows": rows,
-        "columns": columns,
-        "pagination": {"total": total_rows, "offset": offset, "limit": limit},
-    }
-    return _resp(200, True, "Data sent successfully", data)
+    # For empty or any dataframe slice, to_dict will convert to list of plain dict elements avoiding json strings
+    data_list = df_page.to_dict(orient="records")
+
+    return _paginated_resp(
+        data_list, {"page": page, "page_size": page_size, "total_rows": total_rows, "total_pages": total_pages}
+    )
 
 
 # Transformation handler functions

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -19,17 +19,6 @@ def _resp(status_code: int, success: bool, message: str, data: Any = None) -> tu
     return {"success": success, "message": message, "data": data}, status_code
 
 
-def _paginated_resp(data: list, pagination: dict) -> tuple:
-    """Build a standard API response tuple for paginated data."""
-    body = {
-        "success": True,
-        "message": "Data sent successfully",
-        "data": data,
-        "pagination": pagination,
-    }
-    return body, 200
-
-
 def _get_file_path(file: DataFile) -> str:
     """Resolve the on-disk path for a DataFile record."""
     settings = get_settings()
@@ -220,36 +209,40 @@ def get_correlation_matrix(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     return _resp(200, True, "Correlation matrix computed successfully", {"columns": columns, "matrix": matrix})
 
 
-def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size: int = 50) -> tuple:
-    """Read and return the paginated contents of a CSV file as JSON."""
+def get_file_data(db: Session, file_id: uuid_pkg.UUID, offset: int = 0, limit: int = 100) -> tuple:
+    """Read and return a paginated preview of a CSV file.
+
+    The response includes:
+    - ``rows``: list of records for the current page
+    - ``columns``: ordered list of column names
+    - ``pagination``: total/offset/limit metadata
+    """
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if not file:
         return _resp(400, False, "Unable to open file")
+    if file.file_type != "csv":
+        return _resp(400, False, "Only CSV files support row preview")
 
     file_path = _get_file_path(file)
-
     try:
-        with open(file_path, "rb") as f:
-            total_rows = sum(1 for _ in f) - 1
-        total_rows = max(total_rows, 0)
-    except FileNotFoundError:
-        return _resp(500, False, f"File not found: {file_path}")
-    except Exception as e:
-        return _resp(500, False, f"Error reading file count: {e}")
+        # Cache columns from disk if missing in DB.
+        if file.columns is None:
+            header_df = pd.read_csv(file_path, nrows=0)
+            file.columns = list(header_df.columns)
+            db.add(file)
+            db.commit()
+        columns = file.columns or []
 
-    total_pages = (total_rows + page_size - 1) // page_size if page_size > 0 else 0
+        # Use cached row_count when available; otherwise count once and cache.
+        if file.row_count is None:
+            file.row_count = sum(chunk.shape[0] for chunk in pd.read_csv(file_path, chunksize=10_000))
+            db.add(file)
+            db.commit()
+        total_rows = file.row_count or 0
 
-    if total_rows > 0 and page > total_pages:
-        return _resp(400, False, f"Page {page} exceeds total pages ({total_pages})")
-
-    if total_rows == 0:
-        return _paginated_resp([], {"page": page, "page_size": page_size, "total_rows": 0, "total_pages": 0})
-
-    start_idx = (page - 1) * page_size
-    skip = list(range(1, start_idx + 1)) if start_idx > 0 else None
-
-    try:
-        df_page = pd.read_csv(file_path, skiprows=skip, nrows=page_size)
+        # Read only the requested page rows (keep header row intact).
+        skiprows = range(1, offset + 1) if offset > 0 else None
+        df = pd.read_csv(file_path, skiprows=skiprows, nrows=limit)
     except FileNotFoundError:
         return _resp(500, False, f"File not found: {file_path}")
     except pd.errors.ParserError as e:
@@ -259,12 +252,13 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size:
         logger.exception("Error reading file: %s", str(e))
         return _resp(500, False, f"Error reading CSV: {e}")
 
-    # For empty or any dataframe slice, to_dict will convert to list of plain dict elements avoiding json strings
-    data_list = df_page.to_dict(orient="records")
-
-    return _paginated_resp(
-        data_list, {"page": page, "page_size": page_size, "total_rows": total_rows, "total_pages": total_pages}
-    )
+    rows = df.to_dict(orient="records")
+    data = {
+        "rows": rows,
+        "columns": columns,
+        "pagination": {"total": total_rows, "offset": offset, "limit": limit},
+    }
+    return _resp(200, True, "Data sent successfully", data)
 
 
 # Transformation handler functions

--- a/tensormap-backend/tests/test_data_process_service.py
+++ b/tensormap-backend/tests/test_data_process_service.py
@@ -43,6 +43,7 @@ def sample_file(file_id):
     f.id = file_id
     f.file_name = "iris"
     f.file_type = "csv"
+    f.columns = None
     f.row_count = None
     return f
 
@@ -308,60 +309,18 @@ class TestGetDataMetrics:
 
 class TestGetFileData:
     @patch("app.services.data_process.get_settings")
-    def test_get_file_data_page1(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+    def test_success(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
         mock_settings.return_value.upload_folder = str(classification_csv)
         mock_db.exec.return_value.first.return_value = sample_file
 
-        body, status = get_file_data(mock_db, file_id, page=1, page_size=3)
+        body, status = get_file_data(mock_db, file_id)
 
         assert status == 200
         assert body["success"] is True
-        assert body["pagination"]["page"] == 1
-        assert body["pagination"]["total_rows"] == 4
-        assert body["pagination"]["total_pages"] == 2
-        assert len(body["data"]) == 3
-
-    @patch("app.services.data_process.get_settings")
-    def test_get_file_data_last_page_partial(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
-        mock_settings.return_value.upload_folder = str(classification_csv)
-        mock_db.exec.return_value.first.return_value = sample_file
-
-        body, status = get_file_data(mock_db, file_id, page=2, page_size=3)
-
-        assert status == 200
-        assert body["success"] is True
-        assert body["pagination"]["page"] == 2
-        assert len(body["data"]) == 1
-
-    @patch("app.services.data_process.get_settings")
-    def test_get_file_data_out_of_range_page(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
-        mock_settings.return_value.upload_folder = str(classification_csv)
-        mock_db.exec.return_value.first.return_value = sample_file
-
-        body, status = get_file_data(mock_db, file_id, page=999, page_size=2)
-
-        assert status == 400
-        assert body["success"] is False
-        assert "exceeds total pages" in body["message"]
-
-    @patch("app.services.data_process.get_settings")
-    def test_get_file_data_empty_file(self, mock_settings, mock_db, file_id, tmp_path):
-        pd.DataFrame(columns=["a", "b"]).to_csv(tmp_path / "empty.csv", index=False)
-
-        empty_file = MagicMock(spec=DataFile)
-        empty_file.file_name = "empty"
-        empty_file.file_type = "csv"
-        empty_file.row_count = None
-
-        mock_settings.return_value.upload_folder = str(tmp_path)
-        mock_db.exec.return_value.first.return_value = empty_file
-
-        body, status = get_file_data(mock_db, file_id, page=1, page_size=50)
-
-        assert status == 200
-        assert body["pagination"]["total_rows"] == 0
-        assert body["pagination"]["total_pages"] == 0
-        assert len(body["data"]) == 0
+        assert body["data"]["rows"] is not None
+        assert body["data"]["columns"] == ["sepal_length", "sepal_width", "species"]
+        assert body["data"]["pagination"]["total"] == 4
+        assert body["data"]["pagination"]["offset"] == 0
 
     def test_file_not_in_db(self, mock_db, file_id):
         mock_db.exec.return_value.first.return_value = None
@@ -380,6 +339,21 @@ class TestGetFileData:
 
         assert status == 500
         assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_success_with_offset_and_limit(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id, offset=1, limit=2)
+
+        assert status == 200
+        assert body["success"] is True
+        assert len(body["data"]["rows"]) == 2
+        assert body["data"]["rows"][0]["sepal_length"] == pytest.approx(4.9)
+        assert body["data"]["pagination"]["total"] == 4
+        assert body["data"]["pagination"]["offset"] == 1
+        assert body["data"]["pagination"]["limit"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tensormap-frontend/src/components/Process/DisplayDataset.jsx
+++ b/tensormap-frontend/src/components/Process/DisplayDataset.jsx
@@ -20,23 +20,26 @@ const DisplayDataset = ({ fileId }) => {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
 
-  const fetchData = useCallback(async (nextOffset = 0) => {
-    try {
-      setLoading(true);
-      setError(null);
-      const fileData = await getFileData(fileId, { offset: nextOffset, limit: PAGE_SIZE });
-      setRows(fileData.rows || []);
-      setColumns(fileData.columns || []);
-      setPagination(fileData.pagination || { total: 0, offset: nextOffset, limit: PAGE_SIZE });
-    } catch (e) {
-      logger.error("Error fetching dataset:", e);
-      setError("Failed to load dataset");
-      setRows([]);
-      setColumns([]);
-    } finally {
-      setLoading(false);
-    }
-  }, [fileId]);
+  const fetchData = useCallback(
+    async (nextOffset = 0) => {
+      try {
+        setLoading(true);
+        setError(null);
+        const fileData = await getFileData(fileId, { offset: nextOffset, limit: PAGE_SIZE });
+        setRows(fileData.rows || []);
+        setColumns(fileData.columns || []);
+        setPagination(fileData.pagination || { total: 0, offset: nextOffset, limit: PAGE_SIZE });
+      } catch (e) {
+        logger.error("Error fetching dataset:", e);
+        setError("Failed to load dataset");
+        setRows([]);
+        setColumns([]);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [fileId],
+  );
 
   useEffect(() => {
     if (fileId) {
@@ -57,7 +60,11 @@ const DisplayDataset = ({ fileId }) => {
   }
 
   if (!rows.length) {
-    return <div className="flex h-48 items-center justify-center text-muted-foreground">No rows found.</div>;
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        No rows found.
+      </div>
+    );
   }
 
   const { total, offset, limit } = pagination;
@@ -108,7 +115,12 @@ const DisplayDataset = ({ fileId }) => {
           Showing {start}-{end} of {total}
         </span>
         <div className="flex items-center gap-2">
-          <Button variant="outline" size="sm" onClick={handlePrevious} disabled={!hasPrev || loading}>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handlePrevious}
+            disabled={!hasPrev || loading}
+          >
             Previous
           </Button>
           <Button variant="outline" size="sm" onClick={handleNext} disabled={!hasNext || loading}>

--- a/tensormap-frontend/src/components/Process/DisplayDataset.jsx
+++ b/tensormap-frontend/src/components/Process/DisplayDataset.jsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
+import { Button } from "@/components/ui/button";
 import { getFileData } from "../../services/FileServices";
 import logger from "../../shared/logger";
-import { Button } from "../ui/button";
 
 /**
  * Tabular preview of a CSV dataset.
@@ -12,61 +12,43 @@ import { Button } from "../ui/button";
  *
  * @param {{ fileId: string }} props
  */
-const DisplayDataset = ({ fileId, pageSize = 50 }) => {
-  const [data, setData] = useState(null);
+const DisplayDataset = ({ fileId }) => {
+  const PAGE_SIZE = 50;
+  const [rows, setRows] = useState([]);
+  const [columns, setColumns] = useState([]);
+  const [pagination, setPagination] = useState({ total: 0, offset: 0, limit: PAGE_SIZE });
+  const [loading, setLoading] = useState(true);
   const [error, setError] = useState(null);
-  const [isLoading, setIsLoading] = useState(true);
-  const [page, setPage] = useState(1);
-  const [pagination, setPagination] = useState(null);
-  const abortControllerRef = React.useRef(null);
 
-  const fetchData = useCallback(
-    async (currentFileId, currentPage = 1) => {
-      if (abortControllerRef.current) {
-        abortControllerRef.current.abort();
-      }
-      const controller = new AbortController();
-      abortControllerRef.current = controller;
-
-      setIsLoading(true);
-      try {
-        setError(null);
-        const fileData = await getFileData(currentFileId, currentPage, pageSize, controller.signal);
-
-        if (!controller.signal.aborted) {
-          setData(fileData.data);
-          setPagination(fileData.pagination);
-        }
-      } catch (e) {
-        if (e.name !== "CanceledError" && e.name !== "AbortError") {
-          logger.error("Error fetching dataset:", e);
-          setError("Failed to load dataset");
-          setData(null);
-        }
-      } finally {
-        if (!controller.signal.aborted) {
-          setIsLoading(false);
-        }
-      }
-    },
-    [pageSize],
-  );
-
-  useEffect(() => {
-    setPage(1);
+  const fetchData = useCallback(async (nextOffset = 0) => {
+    try {
+      setLoading(true);
+      setError(null);
+      const fileData = await getFileData(fileId, { offset: nextOffset, limit: PAGE_SIZE });
+      setRows(fileData.rows || []);
+      setColumns(fileData.columns || []);
+      setPagination(fileData.pagination || { total: 0, offset: nextOffset, limit: PAGE_SIZE });
+    } catch (e) {
+      logger.error("Error fetching dataset:", e);
+      setError("Failed to load dataset");
+      setRows([]);
+      setColumns([]);
+    } finally {
+      setLoading(false);
+    }
   }, [fileId]);
 
   useEffect(() => {
     if (fileId) {
-      fetchData(fileId, page);
+      fetchData(0);
     }
-  }, [fileId, page, fetchData]);
+  }, [fileId, fetchData]);
 
   if (error) {
     return <div className="flex h-48 items-center justify-center text-destructive">{error}</div>;
   }
 
-  if (isLoading) {
+  if (loading) {
     return (
       <div className="flex h-48 items-center justify-center text-muted-foreground">
         Loading data...
@@ -74,21 +56,33 @@ const DisplayDataset = ({ fileId, pageSize = 50 }) => {
     );
   }
 
-  if (!data || data.length === 0) {
-    return (
-      <div className="flex h-48 items-center justify-center text-muted-foreground">
-        Dataset is empty.
-      </div>
-    );
+  if (!rows.length) {
+    return <div className="flex h-48 items-center justify-center text-muted-foreground">No rows found.</div>;
   }
 
+  const { total, offset, limit } = pagination;
+  const start = total === 0 ? 0 : offset + 1;
+  const end = Math.min(offset + rows.length, total);
+  const hasPrev = offset > 0;
+  const hasNext = offset + limit < total;
+
+  const handlePrevious = () => {
+    if (!hasPrev) return;
+    fetchData(Math.max(0, offset - limit));
+  };
+
+  const handleNext = () => {
+    if (!hasNext) return;
+    fetchData(offset + limit);
+  };
+
   return (
-    <div className="flex flex-col space-y-4">
+    <div className="space-y-3">
       <div className="max-h-[500px] w-full overflow-auto">
         <table className="w-full border-collapse">
           <thead>
             <tr className="border-b">
-              {Object.keys(data[0]).map((key) => (
+              {columns.map((key) => (
                 <th key={key} className="border px-3 py-2 text-left font-semibold">
                   {key.trim()}
                 </th>
@@ -96,11 +90,11 @@ const DisplayDataset = ({ fileId, pageSize = 50 }) => {
             </tr>
           </thead>
           <tbody>
-            {data.map((row, index) => (
-              <tr key={`row-${pagination?.page}-${index}`} className="border-b">
-                {Object.values(row).map((value, idx) => (
-                  <td key={`cell-${pagination?.page}-${index}-${idx}`} className="border px-3 py-2">
-                    {value != null ? String(value) : ""}
+            {rows.map((row, index) => (
+              <tr key={`${offset}-${index}`} className="border-b">
+                {columns.map((column) => (
+                  <td key={column} className="border px-3 py-2">
+                    {String(row[column] ?? "")}
                   </td>
                 ))}
               </tr>
@@ -110,29 +104,14 @@ const DisplayDataset = ({ fileId, pageSize = 50 }) => {
       </div>
 
       <div className="flex items-center justify-between text-sm text-muted-foreground">
-        <div>
-          Showing {pagination ? (pagination.page - 1) * pagination.page_size + 1 : 0} to{" "}
-          {pagination ? Math.min(pagination.page * pagination.page_size, pagination.total_rows) : 0}{" "}
-          of {pagination ? pagination.total_rows : 0} Total rows
-        </div>
-        <div className="flex items-center space-x-2">
-          <div>
-            Page {pagination?.page || 1} of {pagination?.total_pages || 1}
-          </div>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => Math.max(1, p - 1))}
-            disabled={!pagination || pagination.page <= 1}
-          >
+        <span>
+          Showing {start}-{end} of {total}
+        </span>
+        <div className="flex items-center gap-2">
+          <Button variant="outline" size="sm" onClick={handlePrevious} disabled={!hasPrev || loading}>
             Previous
           </Button>
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => setPage((p) => p + 1)}
-            disabled={!pagination || pagination.page >= pagination.total_pages}
-          >
+          <Button variant="outline" size="sm" onClick={handleNext} disabled={!hasNext || loading}>
             Next
           </Button>
         </div>
@@ -143,7 +122,6 @@ const DisplayDataset = ({ fileId, pageSize = 50 }) => {
 
 DisplayDataset.propTypes = {
   fileId: PropTypes.string.isRequired,
-  pageSize: PropTypes.number,
 };
 
 export default DisplayDataset;

--- a/tensormap-frontend/src/services/FileServices.js
+++ b/tensormap-frontend/src/services/FileServices.js
@@ -94,19 +94,19 @@ export const getCorrelationMatrix = async (file_id) =>
     });
 
 /**
- * Fetches the raw data content of a file as a JSON string.
+ * Fetches a paginated dataset preview for a file.
  *
  * @param {string} file_id - ID of the uploaded file.
- * @param {number} page - Page number.
- * @param {number} pageSize - Number of rows per page.
- * @param {AbortSignal} [signal] - Optional AbortController signal to cancel the request.
- * @returns {Promise<object>} Response data containing data array and pagination metadata.
+ * @param {{ offset?: number, limit?: number }} [params]
+ * @returns {Promise<{ rows: Array<object>, columns: string[], pagination: { total: number, offset: number, limit: number } }>}
  */
-export const getFileData = async (file_id, page = 1, pageSize = 50, signal) => {
+export const getFileData = async (file_id, params = {}) => {
   try {
-    const params = { page, page_size: pageSize };
-    const response = await axios.get(urls.BACKEND_GET_FILE_DATA + file_id, { params, signal });
-    return response.data;
+    const response = await axios.get(urls.BACKEND_GET_FILE_DATA + file_id, { params });
+    if (response.data.success === true) {
+      return response.data.data;
+    }
+    throw new Error(response.data.message || "Failed to fetch dataset");
   } catch (error) {
     logger.error(error);
     throw error;


### PR DESCRIPTION
## Summary
- add `offset` and `limit` query params to `/data/process/file/{file_id}`
- return paginated payloads (`rows`, `columns`, `pagination`) instead of a full JSON string
- cache CSV metadata while serving preview data to reduce repeated reads
- add Previous/Next pagination controls in the dataset preview table

## Why
Large CSV previews currently load the entire file at once, which can make the UI lag or freeze.

## Testing
- updated backend service tests for paginated file preview
- verified modified backend modules compile with `python -m compileall`