### PR TITLE
Scope model name uniqueness per project

### DIFF
--- a/tensormap-backend/app/models/ml.py
+++ b/tensormap-backend/app/models/ml.py
@@ -16,7 +16,7 @@ class ModelBasic(SQLModel, table=True):
     __tablename__ = "model_basic"
 
     id: int | None = Field(default=None, primary_key=True)
-    model_name: str = Field(max_length=50, nullable=False, unique=True)
+    model_name: str = Field(max_length=50, nullable=False)
     file_id: uuid_pkg.UUID | None = Field(
         default=None, sa_column=Column(PgUUID(as_uuid=True), ForeignKey("data_file.id"), index=True, nullable=True)
     )

--- a/tensormap-backend/app/services/code_generation.py
+++ b/tensormap-backend/app/services/code_generation.py
@@ -28,10 +28,18 @@ from app.shared.logging_config import get_logger
 logger = get_logger(__name__)
 
 
-def generate_code(model_name: str, db: Session) -> str:
+def generate_code(model_name: str, db: Session, model_id: int | None = None) -> str:
     """Generate TensorFlow Python code from a saved model configuration."""
-    model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    if model_id is not None:
+        model_configs = db.get(ModelBasic, model_id)
+    else:
+        model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    if model_configs is None:
+        raise ValueError("Model not found")
+
     file = db.exec(select(DataFile).where(DataFile.id == model_configs.file_id)).first()
+    if file is None:
+        raise ValueError("Dataset file not found")
 
     data = {
         DATASET: {

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -53,6 +53,42 @@ def _sanitize_model_name(name: str) -> str:
     return name
 
 
+def _find_existing_model_in_scope(db: Session, model_name: str, project_id: uuid_pkg.UUID | None) -> ModelBasic | None:
+    """Find an existing model name within the same uniqueness scope."""
+    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
+    if project_id is None:
+        stmt = stmt.where(ModelBasic.project_id.is_(None))
+    else:
+        stmt = stmt.where(ModelBasic.project_id == project_id)
+    return db.exec(stmt).first()
+
+
+def _get_single_model_by_name(
+    db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None
+) -> tuple[ModelBasic | None, tuple | None]:
+    """Resolve one model by name, handling ambiguous names safely."""
+    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
+    if project_id is not None:
+        model = db.exec(stmt.where(ModelBasic.project_id == project_id)).first()
+        if not model:
+            return None, _resp(404, False, "Model not found in this project")
+        return model, None
+
+    matches = db.exec(stmt).all()
+    if not matches:
+        return None, _resp(404, False, "Model not found")
+    if len(matches) > 1:
+        return (
+            None,
+            _resp(
+                409,
+                False,
+                "Multiple models share this name across projects. Please provide project_id.",
+            ),
+        )
+    return matches[0], None
+
+
 # Maximum size (in bytes) for the serialised graph JSON stored in the DB.
 _MAX_GRAPH_JSON_BYTES = 512 * 1024  # 512 KB
 
@@ -130,9 +166,9 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
     except ValueError as e:
         return _resp(400, False, str(e))
 
-    existing = db.exec(select(ModelBasic).where(ModelBasic.model_name == code[DL_MODEL][MODEL_NAME])).first()
+    existing = _find_existing_model_in_scope(db, code[DL_MODEL][MODEL_NAME], project_id)
     if existing:
-        return _resp(400, False, "Model name already used. Use a different name")
+        return _resp(400, False, "Model name already used in this project. Use a different name")
 
     if code[PROBLEM_TYPE] in (ProblemType.CLASSIFICATION, ProblemType.IMAGE_CLASSIFICATION):
         loss = "sparse_categorical_crossentropy"
@@ -211,9 +247,9 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
     except ValueError as e:
         return _resp(400, False, str(e))
 
-    existing = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    existing = _find_existing_model_in_scope(db, model_name, project_id)
     if existing:
-        return _resp(400, False, "Model name already used. Use a different name")
+        return _resp(400, False, "Model name already used in this project. Use a different name")
 
     graph_data = _extract_graph(incoming)
     size_err = _validate_graph_size(graph_data)
@@ -266,12 +302,9 @@ def update_training_config_service(
     db: Session, model_name: str, config: dict, project_id: uuid_pkg.UUID | None = None
 ) -> tuple:
     """Set training configuration on a previously saved model."""
-    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
-    if project_id is not None:
-        stmt = stmt.where(ModelBasic.project_id == project_id)
-    model = db.exec(stmt).first()
-    if not model:
-        return _resp(404, False, "Model not found")
+    model, err = _get_single_model_by_name(db, model_name, project_id)
+    if err:
+        return err
 
     problem_type_id = config["problem_type_id"]
     if problem_type_id in (ProblemType.CLASSIFICATION, ProblemType.IMAGE_CLASSIFICATION):
@@ -301,23 +334,13 @@ def update_training_config_service(
     return _resp(200, True, "Training configuration saved successfully")
 
 
-def _verify_model_project(db: Session, model_name: str, project_id: uuid_pkg.UUID | None) -> tuple | None:
-    """If project_id is provided, verify the model belongs to that project. Returns an error response or None."""
-    if project_id is None:
-        return None
-    model = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
-    if not model or model.project_id != project_id:
-        return _resp(404, False, "Model not found in this project")
-    return None
-
-
 def get_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
     """Generate a downloadable Python training script for the named model."""
-    err = _verify_model_project(db, model_name, project_id)
+    model, err = _get_single_model_by_name(db, model_name, project_id)
     if err:
         return err
     try:
-        python_code = generate_code(model_name, db)
+        python_code = generate_code(model_name, db, model_id=model.id)
     except ValueError as e:
         return _resp(400, False, str(e))
     return {"content": python_code, "file_name": model_name + ".py"}, 200
@@ -325,16 +348,13 @@ def get_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | N
 
 def run_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None, loop=None) -> tuple:
     """Train a saved model and emit progress events via Socket.IO."""
-    err = _verify_model_project(db, model_name, project_id)
+    model, err = _get_single_model_by_name(db, model_name, project_id)
     if err:
         return err
-    model = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
-    if not model:
-        return _resp(404, False, "Model not found")
     if model.file_id is None or model.epochs is None:
         return _resp(400, False, "Training configuration not set. Please configure training parameters first.")
     try:
-        model_run(model_name, db, loop=loop)
+        model_run(model_name, db, loop=loop, model_id=model.id)
         logger.info("Model '%s' training completed", model_name)
         return _resp(200, True, "Model executed successfully.")
     except Exception as e:
@@ -352,12 +372,9 @@ def get_model_graph_service(db: Session, model_name: str, project_id: uuid_pkg.U
     added), the raw ReactFlow JSON is returned directly.  Older models fall back
     to reconstructing the graph from the flattened ``ModelConfigs`` rows.
     """
-    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
-    if project_id is not None:
-        stmt = stmt.where(ModelBasic.project_id == project_id)
-    model = db.exec(stmt).first()
-    if not model:
-        return _resp(404, False, "Model not found")
+    model, err = _get_single_model_by_name(db, model_name, project_id)
+    if err:
+        return err
 
     # Fast path: graph was stored directly in the JSON column
     if model.graph_json is not None:

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -102,20 +102,27 @@ def _helper_generate_json_model_file_location(model_name: str) -> str:
     return path
 
 
-def model_run(model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None) -> None:
+def model_run(
+    model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None, model_id: int | None = None
+) -> None:
     """Load, compile, and train a Keras model, emitting progress via Socket.IO."""
     global _main_loop
     _main_loop = loop
     try:
-        _run(model_name, db)
+        _run(model_name, db, model_id=model_id)
     except Exception as e:
         logger.exception("Training failed for model '%s': %s", model_name, str(e))
         _model_result(f"Training failed: {e}", -1)
         raise
 
 
-def _run(model_name: str, db: Session) -> None:
-    model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+def _run(model_name: str, db: Session, model_id: int | None = None) -> None:
+    if model_id is not None:
+        model_configs = db.get(ModelBasic, model_id)
+    else:
+        model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    if model_configs is None:
+        raise ValueError("Model not found")
 
     if model_configs.model_type == ProblemType.IMAGE_CLASSIFICATION:
         image_properties = db.exec(select(ImageProperties).where(ImageProperties.id == model_configs.file_id)).first()

--- a/tensormap-backend/migrations/versions/e1d7ac9f5b21_make_model_name_unique_per_project.py
+++ b/tensormap-backend/migrations/versions/e1d7ac9f5b21_make_model_name_unique_per_project.py
@@ -1,0 +1,41 @@
+"""make_model_name_unique_per_project
+
+Revision ID: e1d7ac9f5b21
+Revises: c3a1d9e02f45, d4b7f1a03e82
+Create Date: 2026-03-14 11:05:00.000000
+"""
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "e1d7ac9f5b21"
+down_revision = ("c3a1d9e02f45", "d4b7f1a03e82")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Old schema had a global UNIQUE(model_name). Drop it so names can repeat
+    # across different projects.
+    op.execute("ALTER TABLE model_basic DROP CONSTRAINT IF EXISTS model_basic_model_name_key")
+    op.execute("ALTER TABLE model_basic DROP CONSTRAINT IF EXISTS uq_model_basic_model_name")
+
+    # Keep names unique per project.
+    op.create_index(
+        "uq_model_basic_project_id_model_name",
+        "model_basic",
+        ["project_id", "model_name"],
+        unique=True,
+    )
+
+    # For legacy/global models (project_id IS NULL), keep model_name unique.
+    op.execute(
+        "CREATE UNIQUE INDEX IF NOT EXISTS uq_model_basic_null_project_model_name "
+        "ON model_basic (model_name) WHERE project_id IS NULL"
+    )
+
+
+def downgrade():
+    op.execute("DROP INDEX IF EXISTS uq_model_basic_null_project_model_name")
+    op.drop_index("uq_model_basic_project_id_model_name", table_name="model_basic")
+    op.create_unique_constraint("uq_model_basic_model_name", "model_basic", ["model_name"])

--- a/tensormap-backend/tests/test_model_run.py
+++ b/tensormap-backend/tests/test_model_run.py
@@ -1,3 +1,4 @@
+import uuid
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -101,3 +102,60 @@ class TestGetCodeServiceOnFailure:
 
         assert result["success"] is False
         assert result["message"] == "file missing"
+
+
+class TestModelNameScoping:
+    def test_get_code_requires_project_id_when_name_is_ambiguous(self):
+        m1 = MagicMock()
+        m1.id = 1
+        m2 = MagicMock()
+        m2.id = 2
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [m1, m2]
+
+        result, status_code = get_code_service(db, "shared_name")
+
+        assert status_code == 409
+        assert result["success"] is False
+        assert "project_id" in result["message"]
+
+    def test_get_code_uses_project_scoped_model_id(self):
+        project_id = uuid.uuid4()
+        model = MagicMock()
+        model.id = 42
+        db = MagicMock()
+        db.exec.return_value.first.return_value = model
+
+        with patch("app.services.deep_learning.generate_code", return_value="# code") as mock_generate:
+            result, status_code = get_code_service(db, "shared_name", project_id=project_id)
+
+        assert status_code == 200
+        assert result["file_name"] == "shared_name.py"
+        mock_generate.assert_called_once_with("shared_name", db, model_id=42)
+
+    def test_get_code_returns_400_when_generation_raises_value_error(self):
+        model = MagicMock()
+        model.id = 9
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [model]
+
+        with patch("app.services.deep_learning.generate_code", side_effect=ValueError("file missing")):
+            result, status_code = get_code_service(db, "shared_name")
+
+        assert status_code == 400
+        assert result["success"] is False
+        assert result["message"] == "file missing"
+
+    def test_run_code_requires_project_id_when_name_is_ambiguous(self):
+        m1 = MagicMock()
+        m1.id = 1
+        m2 = MagicMock()
+        m2.id = 2
+        db = MagicMock()
+        db.exec.return_value.all.return_value = [m1, m2]
+
+        result, status_code = run_code_service(db, "shared_name")
+
+        assert status_code == 409
+        assert result["success"] is False
+        assert "project_id" in result["message"]


### PR DESCRIPTION
## Summary
- change model-name uniqueness from global to per-project scope
- add migration for `(project_id, model_name)` uniqueness and legacy null-project handling
- resolve model-by-name operations safely when names are duplicated across projects
- improve error handling for ambiguous requests by returning a clear `project_id` hint

## Why
Different projects should be able to use the same model name without conflicts.

## Testing
- extended unit tests around code/run behavior for ambiguous model names
- verified backend modules compile with `python -m compileall`