### PR TITLE
fix: prevent training result overwrite and blank cards in Training.jsx

### DIFF
--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -183,11 +183,7 @@ export default function Training() {
           fetchModelsRef.current();
         }
       } else {
-        setResultValues((prev) => {
-          let newValues = [...prev];
-          newValues[parseInt(resp.test)] = resp.message;
-          return newValues;
-        });
+        setResultValues((prev) => [...prev, resp.message]);
       }
     };
 


### PR DESCRIPTION
## Problem
Closes #242

The Socket.IO result listener in Training.jsx used resp.test directly 
as an array index causing two bugs:

1. Silent result overwriting — if backend emits same index twice, 
   previous epoch results are permanently lost
2. Sparse array holes — non-sequential indices create undefined gaps, 
   rendering blank Result cards in the UI

## Fix
Replaced index-based assignment with safe sequential append:

// Before (buggy)
setResultValues((prev) => {
  let newValues = [...prev];
  newValues[parseInt(resp.test)] = resp.message;
  return newValues;
});

// After (fixed)
setResultValues((prev) => [...prev, resp.message]);

## Testing
- Ran training with 10 epochs
- All results displayed sequentially with no overwrites
- No blank cards appeared in results panel
