### PR TITLE
Feature/add batchnorm layer clean

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,224 @@
+name: Lint
+
+on:
+  pull_request_target:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: >-
+    ci-${{
+      github.event_name == 'pull_request_target'
+        && format('pr-{0}', github.event.pull_request.number)
+        || github.ref
+    }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  frontend-lint:
+    name: Frontend Lint
+    runs-on: ubuntu-latest
+    outputs:
+      eslint: ${{ steps.eslint.outcome }}
+      prettier: ${{ steps.prettier.outcome }}
+    defaults:
+      run:
+        working-directory: tensormap-frontend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || '' }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: tensormap-frontend/package-lock.json
+      - run: npm ci
+
+      - name: ESLint
+        id: eslint
+        continue-on-error: true
+        run: npx eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0
+
+      - name: Prettier
+        id: prettier
+        continue-on-error: true
+        run: npx prettier --check "src/**/*.{js,jsx,json,css}"
+
+      - name: Fail if checks failed
+        if: steps.eslint.outcome == 'failure' || steps.prettier.outcome == 'failure'
+        run: exit 1
+
+  backend-lint:
+    name: Backend Lint
+    runs-on: ubuntu-latest
+    outputs:
+      ruff-lint: ${{ steps.ruff-lint.outcome }}
+      ruff-format: ${{ steps.ruff-format.outcome }}
+    defaults:
+      run:
+        working-directory: tensormap-backend
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.sha || '' }}
+      - uses: astral-sh/setup-uv@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --frozen --extra dev
+
+      - name: Ruff lint
+        id: ruff-lint
+        continue-on-error: true
+        run: uv run ruff check .
+
+      - name: Ruff format
+        id: ruff-format
+        continue-on-error: true
+        run: uv run ruff format --check .
+
+      - name: Fail if checks failed
+        if: steps.ruff-lint.outcome == 'failure' || steps.ruff-format.outcome == 'failure'
+        run: exit 1
+
+  rebase-check:
+    name: Rebase Check
+    if: github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    outputs:
+      behind_count: ${{ steps.rebase.outputs.behind_count }}
+      merge_commits: ${{ steps.rebase.outputs.merge_commits }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Fetch PR head
+        env:
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: git fetch origin "+refs/pull/${PR_NUMBER}/head:refs/remotes/origin/pr-head"
+
+      - name: Check rebase status
+        id: rebase
+        run: |
+          MERGE_COMMITS=$(git log --merges origin/main..origin/pr-head --oneline)
+          BEHIND_COUNT=$(git rev-list --count origin/pr-head..origin/main)
+
+          echo "merge_commits<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$MERGE_COMMITS" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+          echo "behind_count=$BEHIND_COUNT" >> "$GITHUB_OUTPUT"
+
+  pr-comment:
+    name: PR Comment
+    needs: [frontend-lint, backend-lint, rebase-check]
+    if: always() && github.event_name == 'pull_request_target'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Post or delete combined comment
+        uses: actions/github-script@v7
+        env:
+          ESLINT: ${{ needs.frontend-lint.outputs.eslint }}
+          PRETTIER: ${{ needs.frontend-lint.outputs.prettier }}
+          RUFF_LINT: ${{ needs.backend-lint.outputs.ruff-lint }}
+          RUFF_FORMAT: ${{ needs.backend-lint.outputs.ruff-format }}
+          BEHIND_COUNT: ${{ needs.rebase-check.outputs.behind_count }}
+          MERGE_COMMITS: ${{ needs.rebase-check.outputs.merge_commits }}
+          PR_COMMITS: ${{ github.event.pull_request.commits }}
+        with:
+          script: |
+            const marker = '<!-- ci-bot -->';
+            const oldMarkers = ['<!-- lint-frontend-bot -->', '<!-- lint-backend-bot -->', '<!-- rebase-bot -->'];
+            const prNumber = context.payload.pull_request.number;
+
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner, repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            // Clean up old individual comments from previous workflow version
+            for (const old of oldMarkers) {
+              const c = comments.find(c => c.body.includes(old));
+              if (c) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: c.id,
+                });
+              }
+            }
+
+            // Build combined comment sections
+            const sections = [];
+
+            const eslintFailed = process.env.ESLINT === 'failure';
+            const prettierFailed = process.env.PRETTIER === 'failure';
+            if (eslintFailed || prettierFailed) {
+              let s = '### Frontend\n\n';
+              if (eslintFailed) s += '- **ESLint:** Run `npx eslint --fix . --ext js,jsx` in `tensormap-frontend/`\n';
+              if (prettierFailed) s += '- **Prettier:** Run `npx prettier --write "src/**/*.{js,jsx,json,css}"` in `tensormap-frontend/`\n';
+              sections.push(s);
+            }
+
+            const ruffLintFailed = process.env.RUFF_LINT === 'failure';
+            const ruffFormatFailed = process.env.RUFF_FORMAT === 'failure';
+            if (ruffLintFailed || ruffFormatFailed) {
+              let s = '### Backend\n\n';
+              if (ruffLintFailed) s += '- **Ruff lint:** Run `uv run ruff check --fix .` in `tensormap-backend/`\n';
+              if (ruffFormatFailed) s += '- **Ruff format:** Run `uv run ruff format .` in `tensormap-backend/`\n';
+              sections.push(s);
+            }
+
+            const behind = parseInt(process.env.BEHIND_COUNT || '0');
+            const mergeCommits = (process.env.MERGE_COMMITS || '').trim();
+            if (behind > 0 || mergeCommits) {
+              let s = '### Rebase\n\n';
+              if (behind > 0) s += `Your branch is **${behind} commit(s) behind \`main\`**. Please rebase.\n\n`;
+              if (mergeCommits) s += '**Merge commits detected** — please use rebase instead of merge:\n\n```\n' + mergeCommits + '\n```\n\n';
+              sections.push(s);
+            }
+
+            const prCommits = parseInt(process.env.PR_COMMITS || '1');
+            if (prCommits > 1) {
+              sections.push(`### Squash\n\nYour PR has **${prCommits} commits**. Please squash into a single commit.\n`);
+            }
+
+            const existing = comments.find(c => c.body.includes(marker));
+
+            if (sections.length === 0) {
+              if (existing) {
+                await github.rest.issues.deleteComment({
+                  owner: context.repo.owner, repo: context.repo.repo,
+                  comment_id: existing.id,
+                });
+              }
+              return;
+            }
+
+            let body = marker + '\n## PR Review\n\n';
+            body += sections.join('\n');
+
+            if (behind > 0 || mergeCommits || prCommits > 1) {
+              body += '\n### How to fix\n```bash\ngit fetch origin\ngit rebase -i origin/main   # mark all but first commit as "squash"\ngit push --force-with-lease\n```\n';
+            }
+
+            body += '\n---\n*This comment updates automatically on each push.*\n';
+
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                comment_id: existing.id, body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner, repo: context.repo.repo,
+                issue_number: prNumber, body,
+              });
+            }

--- a/tensormap-backend/Dockerfile
+++ b/tensormap-backend/Dockerfile
@@ -16,7 +16,9 @@ RUN groupadd -r appuser && useradd -r -g appuser appuser
 COPY --from=builder /app/.venv /app/.venv
 COPY . .
 
-RUN chown -R appuser:appuser /app
+RUN chown -R appuser:appuser /app \
+    # chmod ensures appuser can write Keras JSON during seed migration (f4a8c2e91b37)
+    && chmod u+w /app/templates/json-model
 
 ENV PATH="/app/.venv/bin:$PATH"
 

--- a/tensormap-backend/app/middleware.py
+++ b/tensormap-backend/app/middleware.py
@@ -11,9 +11,7 @@ from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 
-_UUID_RE = re.compile(
-    r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE
-)
+_UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
 _INT_SEGMENT_RE = re.compile(r"(?<=/)\d+(?=/|$)")
 
 

--- a/tensormap-backend/app/models/data.py
+++ b/tensormap-backend/app/models/data.py
@@ -2,7 +2,7 @@ import uuid as uuid_pkg
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import CheckConstraint, Column, DateTime, ForeignKey, func
+from sqlalchemy import JSON, CheckConstraint, Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import UUID as PgUUID
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -19,6 +19,8 @@ class DataFile(SQLModel, table=True):
     id: uuid_pkg.UUID = Field(sa_column=Column(PgUUID(as_uuid=True), primary_key=True, default=uuid_pkg.uuid4))
     file_name: str = Field(max_length=100, nullable=False)
     file_type: str = Field(max_length=10, nullable=False)
+    columns: list[str] | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    row_count: int | None = Field(default=None, nullable=True)
     project_id: uuid_pkg.UUID | None = Field(
         sa_column=Column(PgUUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), index=True, nullable=True)
     )

--- a/tensormap-backend/app/models/ml.py
+++ b/tensormap-backend/app/models/ml.py
@@ -2,7 +2,7 @@ import uuid as uuid_pkg
 from datetime import datetime
 from typing import TYPE_CHECKING, Optional
 
-from sqlalchemy import Column, DateTime, ForeignKey, func
+from sqlalchemy import JSON, Column, DateTime, ForeignKey, func
 from sqlalchemy.dialects.postgresql import UUID as PgUUID
 from sqlmodel import Field, Relationship, SQLModel
 
@@ -29,7 +29,13 @@ class ModelBasic(SQLModel, table=True):
     optimizer: str | None = Field(default=None, max_length=50, nullable=True)
     metric: str | None = Field(default=None, max_length=50, nullable=True)
     epochs: int | None = Field(default=None, nullable=True)
+    batch_size: int | None = Field(default=None, nullable=True)
     loss: str | None = Field(default=None, max_length=50, nullable=True)
+    # sa_column is required here because SQLModel infers nullable from the
+    # Python type hint alone, which does not produce the correct DDL for JSON
+    # columns.  Explicit Column(JSON, nullable=True) ensures the database
+    # column is created with the right type and NULL constraint.
+    graph_json: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
     created_on: datetime | None = Field(default=None, sa_column=Column(DateTime, server_default=func.now()))
     updated_on: datetime | None = Field(
         default=None, sa_column=Column(DateTime, server_default=func.now(), onupdate=func.now())

--- a/tensormap-backend/app/routers/data_process.py
+++ b/tensormap-backend/app/routers/data_process.py
@@ -28,7 +28,7 @@ router = APIRouter(tags=["data-process"])
 
 
 @router.post("/data/process/target")
-async def add_target(request: TargetAddRequest, db: Session = Depends(get_db)):
+def add_target(request: TargetAddRequest, db: Session = Depends(get_db)):
     """Set the target field for a dataset file."""
     logger.debug("Adding target field '%s' for file_id=%s", request.target, request.file_id)
     body, status_code = add_target_service(db, file_id=request.file_id, target=request.target)
@@ -36,7 +36,7 @@ async def add_target(request: TargetAddRequest, db: Session = Depends(get_db)):
 
 
 @router.get("/data/process/target")
-async def get_all_targets(
+def get_all_targets(
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
     db: Session = Depends(get_db),
@@ -47,14 +47,14 @@ async def get_all_targets(
 
 
 @router.get("/data/process/target/{file_id}")
-async def get_target_by_file(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def get_target_by_file(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Retrieve the target field for a specific file."""
     body, status_code = get_one_target_by_id_service(db, file_id=file_id)
     return JSONResponse(status_code=status_code, content=body)
 
 
 @router.delete("/data/process/target/{file_id}")
-async def delete_target(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def delete_target(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Remove the target field assignment for a file."""
     logger.debug("Deleting target field for file_id=%s", file_id)
     body, status_code = delete_one_target_by_id_service(db, file_id=file_id)
@@ -62,7 +62,7 @@ async def delete_target(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
 
 
 @router.get("/data/process/data_metrics/{file_id}")
-async def get_metrics(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def get_metrics(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Return descriptive statistics and correlation matrix for a CSV file."""
     body, status_code = get_data_metrics(db, file_id=file_id)
     return JSONResponse(status_code=status_code, content=body)
@@ -83,14 +83,19 @@ async def get_correlation(file_id: uuid_pkg.UUID, db: Session = Depends(get_db))
 
 
 @router.get("/data/process/file/{file_id}")
-async def get_file(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
-    """Return the full contents of a CSV file as JSON records."""
-    body, status_code = get_file_data(db, file_id=file_id)
+async def get_file(
+    file_id: uuid_pkg.UUID,
+    page: int = Query(1, ge=1),
+    page_size: int = Query(50, ge=1, le=1000),
+    db: Session = Depends(get_db),
+):
+    """Return a paginated slice of a CSV file's contents with pagination metadata."""
+    body, status_code = get_file_data(db, file_id=file_id, page=page, page_size=page_size)
     return JSONResponse(status_code=status_code, content=body)
 
 
 @router.post("/data/process/preprocess/{file_id}")
-async def preprocess(file_id: uuid_pkg.UUID, request: PreprocessRequest, db: Session = Depends(get_db)):
+def preprocess(file_id: uuid_pkg.UUID, request: PreprocessRequest, db: Session = Depends(get_db)):
     """Apply transformations to a CSV file, overwriting it in place."""
     logger.debug("Preprocessing file_id=%s with %d transformations", file_id, len(request.transformations))
     body, status_code = preprocess_data(db, file_id=file_id, transformations=request.transformations)

--- a/tensormap-backend/app/routers/data_upload.py
+++ b/tensormap-backend/app/routers/data_upload.py
@@ -33,7 +33,7 @@ class _UploadFileWrapper:
 
 
 @router.post("/data/upload/file")
-async def upload_file(
+def upload_file(
     data: UploadFile,
     project_id: uuid_pkg.UUID | None = Form(None),
     db: Session = Depends(get_db),
@@ -63,7 +63,7 @@ async def upload_file(
 
 
 @router.get("/data/upload/file")
-async def get_all_files(
+def get_all_files(
     project_id: uuid_pkg.UUID | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
@@ -75,7 +75,7 @@ async def get_all_files(
 
 
 @router.delete("/data/upload/file/{file_id}")
-async def delete_file(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def delete_file(file_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Delete an uploaded file by ID, removing both the DB record and the file on disk."""
     logger.debug("Deleting file with id: %s", file_id)
     body, status_code = delete_one_file_by_id_service(db, file_id=file_id)

--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -9,6 +9,7 @@ from sqlmodel import Session
 from app.database import get_db
 from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
 from app.services.deep_learning import (
+    delete_model_service,
     get_available_model_list,
     get_code_service,
     get_model_graph_service,
@@ -25,7 +26,7 @@ router = APIRouter(tags=["deep-learning"])
 
 
 @router.post("/model/validate")
-async def validate_model(request: ModelValidateRequest, db: Session = Depends(get_db)):
+def validate_model(request: ModelValidateRequest, db: Session = Depends(get_db)):
     """Validate a ReactFlow graph as a Keras model and persist the configuration."""
     logger.debug("Validating model for project_id=%s", request.project_id)
     body, status_code = model_validate_service(db, incoming=request.model_dump(), project_id=request.project_id)
@@ -33,7 +34,7 @@ async def validate_model(request: ModelValidateRequest, db: Session = Depends(ge
 
 
 @router.post("/model/save")
-async def save_model(request: ModelSaveRequest, db: Session = Depends(get_db)):
+def save_model(request: ModelSaveRequest, db: Session = Depends(get_db)):
     """Save a model architecture from the canvas (no training config)."""
     logger.debug("Saving model architecture: model_name=%s", request.model_name)
     body, status_code = model_save_service(
@@ -43,7 +44,7 @@ async def save_model(request: ModelSaveRequest, db: Session = Depends(get_db)):
 
 
 @router.patch("/model/training-config")
-async def update_training_config(request: TrainingConfigRequest, db: Session = Depends(get_db)):
+def update_training_config(request: TrainingConfigRequest, db: Session = Depends(get_db)):
     """Set training configuration on a previously saved model."""
     logger.debug("Updating training config for model_name=%s", request.model_name)
     body, status_code = update_training_config_service(
@@ -53,7 +54,7 @@ async def update_training_config(request: TrainingConfigRequest, db: Session = D
 
 
 @router.post("/model/code")
-async def get_code(request: ModelNameRequest, db: Session = Depends(get_db)):
+def get_code(request: ModelNameRequest, db: Session = Depends(get_db)):
     """Generate and download a Python training script for a saved model."""
     logger.debug("Generating code for model_name=%s", request.model_name)
     result, status_code = get_code_service(db, model_name=request.model_name, project_id=request.project_id)
@@ -79,7 +80,7 @@ async def run_model(request: ModelNameRequest, db: Session = Depends(get_db)):
 
 
 @router.get("/model/{model_name}/graph")
-async def get_model_graph(
+def get_model_graph(
     model_name: str,
     project_id: uuid_pkg.UUID | None = Query(None),
     db: Session = Depends(get_db),
@@ -89,8 +90,19 @@ async def get_model_graph(
     return JSONResponse(status_code=status_code, content=body)
 
 
+@router.delete("/model/{model_id}")
+async def delete_model(
+    model_id: int,
+    db: Session = Depends(get_db),
+):
+    """Delete a saved model and its associated configuration records."""
+    logger.info("Deleting model id=%s", model_id)
+    body, status_code = delete_model_service(db, model_id=model_id)
+    return JSONResponse(status_code=status_code, content=body)
+
+
 @router.get("/model/model-list")
-async def get_model_list(
+def get_model_list(
     project_id: uuid_pkg.UUID | None = Query(None),
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),

--- a/tensormap-backend/app/routers/project.py
+++ b/tensormap-backend/app/routers/project.py
@@ -21,7 +21,7 @@ router = APIRouter(tags=["project"])
 
 
 @router.post("/project")
-async def create_project(request: ProjectCreateRequest, db: Session = Depends(get_db)):
+def create_project(request: ProjectCreateRequest, db: Session = Depends(get_db)):
     """Create a new project with a name and optional description."""
     logger.debug("Creating project: name=%s", request.name)
     body, status_code = create_project_service(db, data=request)
@@ -29,7 +29,7 @@ async def create_project(request: ProjectCreateRequest, db: Session = Depends(ge
 
 
 @router.get("/project")
-async def get_all_projects(
+def get_all_projects(
     offset: int = Query(0, ge=0),
     limit: int = Query(50, ge=1, le=100),
     db: Session = Depends(get_db),
@@ -40,14 +40,14 @@ async def get_all_projects(
 
 
 @router.get("/project/{project_id}")
-async def get_project(project_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def get_project(project_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Retrieve a single project by its ID."""
     body, status_code = get_project_by_id_service(db, project_id=project_id)
     return JSONResponse(status_code=status_code, content=body)
 
 
 @router.patch("/project/{project_id}")
-async def update_project(project_id: uuid_pkg.UUID, request: ProjectUpdateRequest, db: Session = Depends(get_db)):
+def update_project(project_id: uuid_pkg.UUID, request: ProjectUpdateRequest, db: Session = Depends(get_db)):
     """Partially update a project's name and/or description."""
     logger.debug("Updating project_id=%s", project_id)
     body, status_code = update_project_service(db, project_id=project_id, data=request)
@@ -55,7 +55,7 @@ async def update_project(project_id: uuid_pkg.UUID, request: ProjectUpdateReques
 
 
 @router.delete("/project/{project_id}")
-async def delete_project(project_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
+def delete_project(project_id: uuid_pkg.UUID, db: Session = Depends(get_db)):
     """Delete a project and cascade-delete its files and models."""
     logger.debug("Deleting project_id=%s", project_id)
     body, status_code = delete_project_service(db, project_id=project_id)

--- a/tensormap-backend/app/schemas/deep_learning.py
+++ b/tensormap-backend/app/schemas/deep_learning.py
@@ -39,12 +39,20 @@ class NodeData(BaseModel):
     params: dict[str, Any]  # varies per node type; validated downstream by model_generation + TensorFlow
 
 
+class NodePosition(BaseModel):
+    """X/Y canvas coordinates for a ReactFlow node."""
+
+    x: float
+    y: float
+
+
 class GraphNode(BaseModel):
     """A single node in the ReactFlow model graph."""
 
     id: str
     type: str
     data: NodeData
+    position: NodePosition | None = None
 
 
 class GraphEdge(BaseModel):
@@ -97,4 +105,5 @@ class TrainingConfigRequest(BaseModel):
     optimizer: str = Field(min_length=1)
     metric: str = Field(min_length=1)
     epochs: int = Field(gt=0)
+    batch_size: int = Field(default=32, gt=0)
     project_id: uuid_pkg.UUID | None = None

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -1,4 +1,5 @@
 import uuid as uuid_pkg
+from collections.abc import Callable
 from typing import Any
 
 import numpy as np
@@ -16,6 +17,17 @@ logger = get_logger(__name__)
 def _resp(status_code: int, success: bool, message: str, data: Any = None) -> tuple:
     """Build a standard API response tuple of (body_dict, status_code)."""
     return {"success": success, "message": message, "data": data}, status_code
+
+
+def _paginated_resp(data: list, pagination: dict) -> tuple:
+    """Build a standard API response tuple for paginated data."""
+    body = {
+        "success": True,
+        "message": "Data sent successfully",
+        "data": data,
+        "pagination": pagination,
+    }
+    return body, 200
 
 
 def _get_file_path(file: DataFile) -> str:
@@ -208,15 +220,36 @@ def get_correlation_matrix(db: Session, file_id: uuid_pkg.UUID) -> tuple:
     return _resp(200, True, "Correlation matrix computed successfully", {"columns": columns, "matrix": matrix})
 
 
-def get_file_data(db: Session, file_id: uuid_pkg.UUID) -> tuple:
-    """Read and return the full contents of a CSV file as JSON."""
+def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size: int = 50) -> tuple:
+    """Read and return the paginated contents of a CSV file as JSON."""
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if not file:
         return _resp(400, False, "Unable to open file")
 
     file_path = _get_file_path(file)
+
     try:
-        df = pd.read_csv(file_path)
+        with open(file_path, "rb") as f:
+            total_rows = sum(1 for _ in f) - 1
+        total_rows = max(total_rows, 0)
+    except FileNotFoundError:
+        return _resp(500, False, f"File not found: {file_path}")
+    except Exception as e:
+        return _resp(500, False, f"Error reading file count: {e}")
+
+    total_pages = (total_rows + page_size - 1) // page_size if page_size > 0 else 0
+
+    if total_rows > 0 and page > total_pages:
+        return _resp(400, False, f"Page {page} exceeds total pages ({total_pages})")
+
+    if total_rows == 0:
+        return _paginated_resp([], {"page": page, "page_size": page_size, "total_rows": 0, "total_pages": 0})
+
+    start_idx = (page - 1) * page_size
+    skip = list(range(1, start_idx + 1)) if start_idx > 0 else None
+
+    try:
+        df_page = pd.read_csv(file_path, skiprows=skip, nrows=page_size)
     except FileNotFoundError:
         return _resp(500, False, f"File not found: {file_path}")
     except pd.errors.ParserError as e:
@@ -226,11 +259,86 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID) -> tuple:
         logger.exception("Error reading file: %s", str(e))
         return _resp(500, False, f"Error reading CSV: {e}")
 
-    data_json = df.to_json(orient="records")
-    return _resp(200, True, "Data sent successfully", data_json)
+    # For empty or any dataframe slice, to_dict will convert to list of plain dict elements avoiding json strings
+    data_list = df_page.to_dict(orient="records")
+
+    return _paginated_resp(
+        data_list, {"page": page, "page_size": page_size, "total_rows": total_rows, "total_pages": total_pages}
+    )
 
 
-_VALID_TRANSFORMATIONS = {"One Hot Encoding", "Categorical to Numerical", "Drop Column"}
+# Transformation handler functions
+def _handle_one_hot_encoding(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Apply one-hot encoding to a categorical column."""
+    return pd.get_dummies(df, columns=[feature])
+
+
+def _handle_categorical_to_numerical(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Convert categorical values to numerical codes."""
+    df[feature] = pd.Categorical(df[feature]).codes
+    return df
+
+
+def _handle_drop_column(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Drop a column from the dataframe."""
+    return df.drop(columns=[feature])
+
+
+def _handle_min_max_normalization(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Apply min-max normalization to a numeric column."""
+    col_min = df[feature].min()
+    col_max = df[feature].max()
+    df[feature] = 0.0 if np.isclose(col_min, col_max) else (df[feature] - col_min) / (col_max - col_min)
+    return df
+
+
+def _handle_z_score_standardization(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Apply z-score standardization to a numeric column."""
+    std = df[feature].std()
+    df[feature] = 0.0 if std == 0 else (df[feature] - df[feature].mean()) / std
+    return df
+
+
+def _handle_log_transform(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Apply log transformation to a numeric column."""
+    s = df[feature]
+    if (s < -1).any():
+        logger.warning(
+            "Log Transform skipped for column '%s': %d value(s) below -1",
+            feature,
+            int((s < -1).sum()),
+        )
+    else:
+        df[feature] = np.log1p(s)
+    return df
+
+
+def _handle_fill_missing_values(df: pd.DataFrame, feature: str, params: dict = None) -> pd.DataFrame:
+    """Fill missing values in a column using specified strategy."""
+    strategy = (params or {}).get("strategy", "mean")
+    if strategy == "median":
+        df[feature] = df[feature].fillna(df[feature].median())
+    elif strategy == "mode":
+        mode_vals = df[feature].mode()
+        df[feature] = df[feature].fillna(mode_vals[0] if not mode_vals.empty else df[feature].mean())
+    else:
+        df[feature] = df[feature].fillna(df[feature].mean())
+    return df
+
+
+# Dispatch dictionary mapping transformation names to handler functions
+_TRANSFORMATION_HANDLERS: dict[str, Callable] = {
+    "One Hot Encoding": _handle_one_hot_encoding,
+    "Categorical to Numerical": _handle_categorical_to_numerical,
+    "Drop Column": _handle_drop_column,
+    "Min-Max Normalization": _handle_min_max_normalization,
+    "Z-score Standardization": _handle_z_score_standardization,
+    "Log Transform": _handle_log_transform,
+    "Fill Missing Values": _handle_fill_missing_values,
+}
+
+# Derived automatically — no manual sync needed
+_VALID_TRANSFORMATIONS = set(_TRANSFORMATION_HANDLERS.keys())
 
 
 def preprocess_data(db: Session, file_id: uuid_pkg.UUID, transformations: list) -> tuple:
@@ -247,54 +355,48 @@ def preprocess_data(db: Session, file_id: uuid_pkg.UUID, transformations: list) 
         # Validate all transformations before applying any, so the request either
         # fully succeeds or fully fails — no partial mutations.
         for t in transformations:
-            if t.transformation not in _VALID_TRANSFORMATIONS:
+            # Handle both dict-like and object attribute access
+            if hasattr(t, "transformation"):
+                name = t.transformation
+                feature = t.feature
+                params = getattr(t, "params", None)
+            else:
+                name = t.get("transformation")
+                feature = t.get("feature")
+                params = t.get("params")
+
+            if name.casefold() not in {t.casefold() for t in _VALID_TRANSFORMATIONS}:
                 return _resp(
                     422,
                     False,
-                    f"Unknown transformation '{t.transformation}'. "
-                    f"Valid options: {sorted(_VALID_TRANSFORMATIONS)}",
+                    f"Unsupported transformation '{name}'. Valid options: {sorted(_VALID_TRANSFORMATIONS)}",
                 )
-            if t.feature not in df.columns:
+            if feature not in df.columns:
                 return _resp(
                     422,
                     False,
-                    f"Column '{t.feature}' not found. "
-                    f"Available columns: {list(df.columns)}",
+                    f"Column '{feature}' not found. Available columns: {list(df.columns)}",
                 )
 
         for t in transformations:
-            if t.transformation == "One Hot Encoding":
-                df = pd.get_dummies(df, columns=[t.feature])
-            if t.transformation == "Categorical to Numerical":
-                df[t.feature] = pd.Categorical(df[t.feature]).codes
-            if t.transformation == "Drop Column":
-                df = df.drop(columns=[t.feature])
-            if t.transformation == "Min-Max Normalization":
-                col_min = df[t.feature].min()
-                col_max = df[t.feature].max()
-                df[t.feature] = 0.0 if np.isclose(col_min, col_max) else (df[t.feature] - col_min) / (col_max - col_min)
-            if t.transformation == "Z-score Standardization":
-                std = df[t.feature].std()
-                df[t.feature] = 0.0 if std == 0 else (df[t.feature] - df[t.feature].mean()) / std
-            if t.transformation == "Log Transform":
-                s = df[t.feature]
-                if (s < -1).any():
-                    logger.warning(
-                        "Log Transform skipped for column '%s': %d value(s) below -1",
-                        t.feature,
-                        int((s < -1).sum()),
-                    )
-                else:
-                    df[t.feature] = np.log1p(s)
-            if t.transformation == "Fill Missing Values":
-                strategy = (t.params or {}).get("strategy", "mean")
-                if strategy == "median":
-                    df[t.feature] = df[t.feature].fillna(df[t.feature].median())
-                elif strategy == "mode":
-                    mode_vals = df[t.feature].mode()
-                    df[t.feature] = df[t.feature].fillna(mode_vals[0] if not mode_vals.empty else df[t.feature].mean())
-                else:
-                    df[t.feature] = df[t.feature].fillna(df[t.feature].mean())
+            # Handle both dict-like and object attribute access
+            if hasattr(t, "transformation"):
+                name = t.transformation
+                feature = t.feature
+                params = getattr(t, "params", None)
+            else:
+                name = t.get("transformation")
+                feature = t.get("feature")
+                params = t.get("params")
+
+            # Find the matching transformation name (case-insensitive)
+            actual_name = next(
+                (valid_name for valid_name in _VALID_TRANSFORMATIONS if valid_name.casefold() == name.casefold()), None
+            )
+
+            if actual_name and actual_name in _TRANSFORMATION_HANDLERS:
+                handler = _TRANSFORMATION_HANDLERS[actual_name]
+                df = handler(df, feature, params)
 
         df.to_csv(file_path, index=False)
         return _resp(200, True, "Dataset preprocessed successfully")

--- a/tensormap-backend/app/services/data_upload.py
+++ b/tensormap-backend/app/services/data_upload.py
@@ -4,6 +4,7 @@ from typing import Any
 
 import pandas as pd
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 from werkzeug.utils import secure_filename
 
@@ -32,7 +33,25 @@ def add_file_service(db: Session, file_wrapper: Any, project_id: uuid_pkg.UUID |
     file_name_db = secure_filename(file_wrapper.filename.rsplit(".", 1)[0].lower())
     file_type_db = file_wrapper.filename.rsplit(".", 1)[1].lower()
     logger.info("Saving file: %s", file_name_db)
-    record = DataFile(file_name=file_name_db, file_type=file_type_db, project_id=project_id)
+
+    # Cache column names and row count at upload time (CSV only)
+    columns_list: list[str] | None = None
+    row_count: int | None = None
+    if file_type_db == "csv":
+        try:
+            df_header = pd.read_csv(file_path, nrows=0)
+            columns_list = list(df_header.columns)
+            row_count = sum(chunk.shape[0] for chunk in pd.read_csv(file_path, chunksize=10_000))
+        except (pd.errors.ParserError, OSError, UnicodeDecodeError, MemoryError):
+            logger.warning("Could not extract columns/row_count from %s", file_path)
+
+    record = DataFile(
+        file_name=file_name_db,
+        file_type=file_type_db,
+        project_id=project_id,
+        columns=columns_list,
+        row_count=row_count,
+    )
     db.add(record)
     db.commit()
     return _resp(201, True, "File saved successfully")
@@ -55,19 +74,36 @@ def get_all_files_service(
         files = db.exec(base_filter.offset(offset).limit(limit)).all()
         data = []
         for file in files:
-            try:
-                df = pd.read_csv(f"{upload_folder}/{file.file_name}.{file.file_type}")
-                fields = list(df.columns)
-            except Exception:
-                logger.warning("Failed to read CSV for file %s (id=%s)", file.file_name, file.id)
+            # Prefer cached columns/row_count from the DB
+            if file.columns is not None:
+                fields = file.columns
+                row_count = file.row_count or 0
+            elif file.file_type == "csv":
+                # Backfill: read header + count rows, then persist the cache
+                try:
+                    file_path = f"{upload_folder}/{file.file_name}.{file.file_type}"
+                    df_header = pd.read_csv(file_path, nrows=0)
+                    fields = list(df_header.columns)
+                    row_count = sum(chunk.shape[0] for chunk in pd.read_csv(file_path, chunksize=10_000))
+                    file.columns = fields
+                    file.row_count = row_count
+                    db.add(file)
+                    db.commit()
+                except (pd.errors.ParserError, OSError, UnicodeDecodeError, MemoryError):
+                    logger.warning("Failed to read CSV for file %s (id=%s)", file.file_name, file.id)
+                    fields = []
+                    row_count = 0
+            else:
+                # Non-CSV files (e.g. ZIP) have no columns to cache
                 fields = []
+                row_count = 0
             data.append(
                 {
                     "file_name": file.file_name,
                     "file_type": file.file_type,
                     "file_id": str(file.id),
                     "fields": fields,
-                    "row_count": len(df) if fields else 0,
+                    "row_count": row_count,
                     "error": fields == [],
                 }
             )
@@ -77,7 +113,7 @@ def get_all_files_service(
     except pd.errors.ParserError:
         logger.exception("CSV parsing error")
         return _resp(500, False, "An error occurred while parsing a CSV file")
-    except Exception:
+    except (SQLAlchemyError, OSError, UnicodeDecodeError, MemoryError):
         logger.exception("Error fetching files")
         return _resp(500, False, "An error occurred while fetching the files")
 
@@ -94,13 +130,13 @@ def delete_one_file_by_id_service(db: Session, file_id: uuid_pkg.UUID) -> tuple:
 
         file_path = os.path.join(upload_folder, f"{file.file_name}.{file.file_type}")
 
-        if os.path.isfile(file_path):
+        try:
             os.remove(file_path)
-            db.delete(file)
-            db.commit()
-            return _resp(200, True, "File deleted successfully")
-        else:
-            return _resp(400, False, "File not found")
-    except Exception:
+        except FileNotFoundError:
+            logger.warning("File already absent on disk: %s", file_path)
+        db.delete(file)
+        db.commit()
+        return _resp(200, True, "File deleted successfully")
+    except (SQLAlchemyError, OSError):
         logger.exception("Error deleting file")
         return _resp(500, False, "An error occurred while deleting the file")

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -1,7 +1,9 @@
 import contextlib
+import copy
 import json
 import os
 import re
+import sys
 import uuid as uuid_pkg
 from typing import Any
 
@@ -50,12 +52,70 @@ def _sanitize_model_name(name: str) -> str:
     return name
 
 
+# Maximum size (in bytes) for the serialised graph JSON stored in the DB.
+_MAX_GRAPH_JSON_BYTES = 512 * 1024  # 512 KB
+
+
+def _extract_graph(payload: dict) -> dict | None:
+    """Extract the graph portion (nodes + edges) from a request payload.
+
+    Both ``model_validate_service`` (which receives the full request body) and
+    ``model_save_service`` (which receives only the ``model`` sub-object) call
+    this helper so that ``graph_json`` always stores the same shape:
+    ``{"nodes": [...], "edges": [...], "model_name": ...}``.
+    """
+    if payload is None:
+        return None
+    # If the payload wraps the graph under a "model" key, unwrap it.
+    if "nodes" not in payload and "model" in payload and isinstance(payload["model"], dict):
+        return payload["model"]
+    return payload
+
+
+def _validate_graph_size(graph: dict | None) -> str | None:
+    """Return an error message if the serialised graph exceeds the size limit, else None."""
+    if graph is None:
+        return None
+    raw = json.dumps(graph)
+    size = sys.getsizeof(raw)
+    if size > _MAX_GRAPH_JSON_BYTES:
+        return f"Graph payload too large ({size} bytes > {_MAX_GRAPH_JSON_BYTES})"
+    return None
+
+
+def _build_model_summary(keras_model) -> dict:
+    """Extract a structured architecture summary from a built Keras model."""
+    layers = []
+    for layer in keras_model.layers:
+        try:
+            output_shape = str(layer.output_shape)
+        except AttributeError:
+            output_shape = "unknown"
+        layers.append(
+            {
+                "name": layer.name,
+                "type": layer.__class__.__name__,
+                "output_shape": output_shape,
+                "param_count": int(layer.count_params()),
+            }
+        )
+
+    total = int(keras_model.count_params())
+    trainable = int(sum(w.numpy().size for w in keras_model.trainable_weights))
+    return {
+        "layers": layers,
+        "total_params": total,
+        "trainable_params": trainable,
+        "non_trainable_params": total - trainable,
+    }
+
+
 def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUID | None = None) -> tuple:
     """Validate a model graph with Keras, persist the configuration, and save the JSON file."""
     model_generated = model_generation(model_params=incoming["model"])
 
     try:
-        tf.keras.models.model_from_json(json.dumps(model_generated))
+        keras_model = tf.keras.models.model_from_json(json.dumps(model_generated))
     except Exception as e:
         logger.error("Model validation error: %s", str(e))
         for error in errors.err_msgs:
@@ -89,7 +149,12 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
         metric=code[DL_MODEL][MODEL_METRIC],
         epochs=code[DL_MODEL][MODEL_EPOCHS],
         loss=loss,
+        graph_json=_extract_graph(incoming),
     )
+
+    size_err = _validate_graph_size(model.graph_json)
+    if size_err:
+        return _resp(413, False, size_err)
 
     configs = []
     params = flatten(incoming, separator=".")
@@ -124,7 +189,7 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
         return _resp(400, False, "Model validated but failed to save")
 
     logger.info("Model '%s' validated and saved successfully", code[DL_MODEL][MODEL_NAME])
-    return _resp(200, True, "Model Validation and saving successful")
+    return _resp(200, True, "Model Validation and saving successful", {"summary": _build_model_summary(keras_model)})
 
 
 def model_save_service(db: Session, incoming: dict, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
@@ -132,7 +197,7 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
     model_generated = model_generation(model_params=incoming)
 
     try:
-        tf.keras.models.model_from_json(json.dumps(model_generated))
+        keras_model = tf.keras.models.model_from_json(json.dumps(model_generated))
     except Exception as e:
         logger.error("Model validation error: %s", str(e))
         for error in errors.err_msgs:
@@ -149,9 +214,15 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
     if existing:
         return _resp(400, False, "Model name already used. Use a different name")
 
+    graph_data = _extract_graph(incoming)
+    size_err = _validate_graph_size(graph_data)
+    if size_err:
+        return _resp(413, False, size_err)
+
     model = ModelBasic(
         model_name=model_name,
         project_id=project_id,
+        graph_json=graph_data,
     )
 
     configs = []
@@ -187,7 +258,7 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
         return _resp(400, False, "Model validated but failed to save")
 
     logger.info("Model '%s' validated and saved successfully", model_name)
-    return _resp(200, True, "Model validated and saved successfully")
+    return _resp(200, True, "Model validated and saved successfully", {"summary": _build_model_summary(keras_model)})
 
 
 def update_training_config_service(
@@ -214,6 +285,7 @@ def update_training_config_service(
     model.optimizer = config["optimizer"]
     model.metric = config["metric"]
     model.epochs = config["epochs"]
+    model.batch_size = config.get("batch_size", 32)
     model.loss = loss
 
     try:
@@ -270,7 +342,12 @@ def run_code_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | N
 
 
 def get_model_graph_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
-    """Retrieve the full ReactFlow graph for a saved model by unflattening its ModelConfigs."""
+    """Retrieve the full ReactFlow graph for a saved model.
+
+    If ``graph_json`` is populated (models created/saved after the column was
+    added), the raw ReactFlow JSON is returned directly.  Older models fall back
+    to reconstructing the graph from the flattened ``ModelConfigs`` rows.
+    """
     stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
     if project_id is not None:
         stmt = stmt.where(ModelBasic.project_id == project_id)
@@ -278,18 +355,39 @@ def get_model_graph_service(db: Session, model_name: str, project_id: uuid_pkg.U
     if not model:
         return _resp(404, False, "Model not found")
 
+    # Fast path: graph was stored directly in the JSON column
+    if model.graph_json is not None:
+        # Deep-copy to avoid mutating the ORM-tracked dict (which could trigger
+        # an unintended UPDATE on the next flush/commit in the same session).
+        graph = copy.deepcopy(model.graph_json)
+        _apply_auto_layout(graph)
+        return _resp(200, True, "Model graph retrieved successfully", {"model_name": model_name, "graph": graph})
+
+    # Legacy path: reconstruct graph from flattened ModelConfigs
     configs = db.exec(select(ModelConfigs).where(ModelConfigs.model_id == model.id)).all()
     if not configs:
         return _resp(404, False, "No graph configuration found for this model")
 
     graph = _unflatten_model_configs(configs)
-
-    # Ensure every node has a position (auto-layout fallback)
-    for i, node in enumerate(graph.get("nodes", [])):
-        if "position" not in node:
-            node["position"] = {"x": 100, "y": i * 200}
+    _apply_auto_layout(graph)
 
     return _resp(200, True, "Model graph retrieved successfully", {"model_name": model_name, "graph": graph})
+
+
+def _apply_auto_layout(graph: dict) -> None:
+    """Assign default positions to nodes that lack one.
+
+    This is a simple vertical-stack layout used as a fallback so that the
+    ReactFlow canvas can render the graph without crashing.  For a more
+    sophisticated layout (e.g. dagre), see:
+    https://reactflow.dev/docs/examples/layout/dagre/
+
+    TODO: Replace with a proper auto-layout algorithm (e.g. dagre) in a
+    follow-up issue.
+    """
+    for i, node in enumerate(graph.get("nodes", [])):
+        if "position" not in node:
+            node["position"] = {"x": 100.0, "y": float(i * 200)}
 
 
 def _unflatten_model_configs(configs: list[ModelConfigs]) -> dict:
@@ -360,7 +458,31 @@ def get_available_model_list(
     total = db.exec(select(func.count()).select_from(base_filter.subquery())).one()
 
     models = db.exec(base_filter.offset(offset).limit(limit)).all()
-    data = [m.model_name for m in models]
+    data = [{"id": m.id, "model_name": m.model_name} for m in models]
     body = {"success": True, "message": "Model list generated successfully.", "data": data}
     body["pagination"] = {"total": total, "offset": offset, "limit": limit}
     return body, 200
+
+
+def delete_model_service(db: Session, model_id: int) -> tuple:
+    """Delete a model and its associated ModelConfigs (cascade), and remove the JSON file."""
+    model = db.get(ModelBasic, model_id)
+    if not model:
+        return _resp(404, False, "Model not found")
+
+    model_name = model.model_name
+    try:
+        db.delete(model)
+        db.commit()
+    except Exception:
+        db.rollback()
+        logger.exception("Failed to delete model id=%s", model_id)
+        return _resp(500, False, "Failed to delete model")
+
+    # Best-effort removal of the JSON file — do not fail if already gone
+    model_path = os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE)
+    with contextlib.suppress(OSError):
+        os.remove(model_path)
+
+    logger.info("Model '%s' (id=%s) deleted successfully", model_name, model_id)
+    return _resp(200, True, f"Model '{model_name}' deleted successfully")

--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -80,9 +80,10 @@ def _build_layer(node: dict, input_tensor):
     name = node["id"]
 
     if node_type == "customdense":
+        activation = params["activation"]
         return tf.keras.layers.Dense(
             units=int(params["units"]),
-            activation=params["activation"],
+            activation="linear" if activation == "none" else activation,
             name=name,
         )(input_tensor)
 

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -171,6 +171,8 @@ def _run(model_name: str, db: Session) -> None:
         x_testing = X[split_index:]
         y_testing = y[split_index:]
 
+        batch_size = model_configs.batch_size if model_configs.batch_size is not None else 32
+
     with open(_helper_generate_json_model_file_location(model_name=model_name)) as f:
         json_string = f.read()
     model = tf.keras.models.model_from_json(json_string, custom_objects=None)
@@ -199,6 +201,7 @@ def _run(model_name: str, db: Session) -> None:
             x_training,
             y_training,
             epochs=model_configs.epochs,
+            batch_size=batch_size,
             callbacks=[CustomProgressBar()],
             verbose=0,
         )

--- a/tensormap-backend/app/services/project.py
+++ b/tensormap-backend/app/services/project.py
@@ -3,6 +3,7 @@ from datetime import datetime
 from typing import Any
 
 from sqlalchemy import func
+from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 
 from app.models.data import DataFile
@@ -26,23 +27,24 @@ def create_project_service(db: Session, data: ProjectCreateRequest) -> tuple:
         db.add(project)
         db.commit()
         db.refresh(project)
-        logger.info("Project created: id=%s, name=%s", project.id, project.name)
-        return _resp(
-            201,
-            True,
-            "Project created successfully",
-            {
-                "id": str(project.id),
-                "name": project.name,
-                "description": project.description,
-                "created_on": project.created_on.isoformat() if project.created_on else None,
-                "updated_on": project.updated_on.isoformat() if project.updated_on else None,
-            },
-        )
-    except Exception:
+    except SQLAlchemyError:
         db.rollback()
         logger.exception("Error creating project")
         return _resp(500, False, "An error occurred while creating the project")
+
+    logger.info("Project created: id=%s, name=%s", project.id, project.name)
+    return _resp(
+        201,
+        True,
+        "Project created successfully",
+        {
+            "id": str(project.id),
+            "name": project.name,
+            "description": project.description,
+            "created_on": project.created_on.isoformat() if project.created_on else None,
+            "updated_on": project.updated_on.isoformat() if project.updated_on else None,
+        },
+    )
 
 
 def get_all_projects_service(db: Session, offset: int = 0, limit: int = 50) -> tuple:
@@ -68,47 +70,49 @@ def get_all_projects_service(db: Session, offset: int = 0, limit: int = 50) -> t
             .limit(limit)
         )
         rows = db.exec(stmt).all()
-        data = [
-            {
-                "id": str(row.id),
-                "name": row.name,
-                "description": row.description,
-                "created_on": row.created_on.isoformat() if row.created_on else None,
-                "updated_on": row.updated_on.isoformat() if row.updated_on else None,
-                "file_count": row.file_count,
-                "model_count": row.model_count,
-            }
-            for row in rows
-        ]
-        body = {"success": True, "message": "Projects retrieved successfully", "data": data}
-        body["pagination"] = {"total": total, "offset": offset, "limit": limit}
-        return body, 200
-    except Exception:
+    except SQLAlchemyError:
         logger.exception("Error fetching projects")
         return _resp(500, False, "An error occurred while fetching projects")
+
+    data = [
+        {
+            "id": str(row.id),
+            "name": row.name,
+            "description": row.description,
+            "created_on": row.created_on.isoformat() if row.created_on else None,
+            "updated_on": row.updated_on.isoformat() if row.updated_on else None,
+            "file_count": row.file_count,
+            "model_count": row.model_count,
+        }
+        for row in rows
+    ]
+    body = {"success": True, "message": "Projects retrieved successfully", "data": data}
+    body["pagination"] = {"total": total, "offset": offset, "limit": limit}
+    return body, 200
 
 
 def get_project_by_id_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
     """Fetch a single project by its UUID."""
     try:
         project = db.get(Project, project_id)
-        if not project:
-            return _resp(404, False, "Project not found")
-        return _resp(
-            200,
-            True,
-            "Project retrieved successfully",
-            {
-                "id": str(project.id),
-                "name": project.name,
-                "description": project.description,
-                "created_on": project.created_on.isoformat() if project.created_on else None,
-                "updated_on": project.updated_on.isoformat() if project.updated_on else None,
-            },
-        )
-    except Exception:
+    except SQLAlchemyError:
         logger.exception("Error fetching project")
         return _resp(500, False, "An error occurred while fetching the project")
+
+    if not project:
+        return _resp(404, False, "Project not found")
+    return _resp(
+        200,
+        True,
+        "Project retrieved successfully",
+        {
+            "id": str(project.id),
+            "name": project.name,
+            "description": project.description,
+            "created_on": project.created_on.isoformat() if project.created_on else None,
+            "updated_on": project.updated_on.isoformat() if project.updated_on else None,
+        },
+    )
 
 
 def update_project_service(db: Session, project_id: uuid_pkg.UUID, data: ProjectUpdateRequest) -> tuple:
@@ -126,23 +130,24 @@ def update_project_service(db: Session, project_id: uuid_pkg.UUID, data: Project
         db.add(project)
         db.commit()
         db.refresh(project)
-        logger.info("Project updated: id=%s", project_id)
-        return _resp(
-            200,
-            True,
-            "Project updated successfully",
-            {
-                "id": str(project.id),
-                "name": project.name,
-                "description": project.description,
-                "created_on": project.created_on.isoformat() if project.created_on else None,
-                "updated_on": project.updated_on.isoformat() if project.updated_on else None,
-            },
-        )
-    except Exception:
+    except SQLAlchemyError:
         db.rollback()
         logger.exception("Error updating project")
         return _resp(500, False, "An error occurred while updating the project")
+
+    logger.info("Project updated: id=%s", project_id)
+    return _resp(
+        200,
+        True,
+        "Project updated successfully",
+        {
+            "id": str(project.id),
+            "name": project.name,
+            "description": project.description,
+            "created_on": project.created_on.isoformat() if project.created_on else None,
+            "updated_on": project.updated_on.isoformat() if project.updated_on else None,
+        },
+    )
 
 
 def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
@@ -154,9 +159,10 @@ def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
 
         db.delete(project)
         db.commit()
-        logger.info("Project deleted: id=%s", project_id)
-        return _resp(200, True, "Project deleted successfully")
-    except Exception:
+    except SQLAlchemyError:
         db.rollback()
         logger.exception("Error deleting project")
         return _resp(500, False, "An error occurred while deleting the project")
+
+    logger.info("Project deleted: id=%s", project_id)
+    return _resp(200, True, "Project deleted successfully")

--- a/tensormap-backend/migrations/versions/c3a1d9e02f45_add_batch_size_to_model_basic.py
+++ b/tensormap-backend/migrations/versions/c3a1d9e02f45_add_batch_size_to_model_basic.py
@@ -1,0 +1,27 @@
+"""add_batch_size_to_model_basic
+
+Revision ID: c3a1d9e02f45
+Revises: f1a2b3c4d5e6
+Create Date: 2026-02-27 00:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "c3a1d9e02f45"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "model_basic",
+        sa.Column("batch_size", sa.Integer(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("model_basic", "batch_size")

--- a/tensormap-backend/migrations/versions/d4b7f1a03e82_add_graph_json_to_model_basic.py
+++ b/tensormap-backend/migrations/versions/d4b7f1a03e82_add_graph_json_to_model_basic.py
@@ -1,0 +1,27 @@
+"""add_graph_json_to_model_basic
+
+Revision ID: d4b7f1a03e82
+Revises: f1a2b3c4d5e6
+Create Date: 2026-02-27 14:32:08.473291
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "d4b7f1a03e82"
+down_revision = "f1a2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        "model_basic",
+        sa.Column("graph_json", sa.JSON(), nullable=True),
+    )
+
+
+def downgrade():
+    op.drop_column("model_basic", "graph_json")

--- a/tensormap-backend/migrations/versions/f1a2b3c4d5e6_add_columns_json_to_data_file.py
+++ b/tensormap-backend/migrations/versions/f1a2b3c4d5e6_add_columns_json_to_data_file.py
@@ -1,0 +1,26 @@
+"""add columns json and row_count to data_file
+
+Revision ID: f1a2b3c4d5e6
+Revises: f4a8c2e91b37
+Create Date: 2026-02-22 12:00:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision = "f1a2b3c4d5e6"
+down_revision = "f4a8c2e91b37"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column("data_file", sa.Column("columns", sa.JSON(), nullable=True))
+    op.add_column("data_file", sa.Column("row_count", sa.Integer(), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column("data_file", "row_count")
+    op.drop_column("data_file", "columns")

--- a/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
+++ b/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
@@ -7,6 +7,7 @@ Create Date: 2026-02-23 22:00:00.000000
 """
 
 import json
+import logging
 import os
 import shutil
 
@@ -18,6 +19,8 @@ revision = "f4a8c2e91b37"
 down_revision = "2e66fba94864"
 branch_labels = None
 depends_on = None
+
+log = logging.getLogger(__name__)
 
 # Fixed UUIDs for idempotency
 PROJECT_UUID = "00000000-0000-4000-a000-000000000001"
@@ -118,7 +121,18 @@ def upgrade():
         )
 
     # 8. Generate Keras JSON model definition
-    _generate_keras_json()
+    # NOTE: The Dockerfile chmod ensures write access in normal operation.
+    # This guard surfaces permission failures clearly if that fix is ever bypassed.
+    try:
+        _generate_keras_json()
+    except OSError as exc:
+        log.error(
+            "Cannot write Keras JSON to 'templates/json-model/iris-classifier.json': %s. "
+            "Ensure 'appuser' has write access to templates/json-model/. "
+            "Fix permissions and re-run migrations.",
+            exc,
+        )
+        raise
 
 
 def downgrade():
@@ -166,19 +180,19 @@ def _build_model_configs():
                 "id": "n0",
                 "type": "custominput",
                 "data": {"params": {"dim-1": "4"}},
-                "position": {"x": 100, "y": 200},
+                "position": {"x": 100.0, "y": 200.0},
             },
             {
                 "id": "n1",
                 "type": "customdense",
                 "data": {"params": {"units": "16", "activation": "relu"}},
-                "position": {"x": 100, "y": 400},
+                "position": {"x": 100.0, "y": 400.0},
             },
             {
                 "id": "n2",
                 "type": "customdense",
                 "data": {"params": {"units": "3", "activation": "softmax"}},
-                "position": {"x": 100, "y": 600},
+                "position": {"x": 100.0, "y": 600.0},
             },
         ],
         "edges": [

--- a/tensormap-backend/tests/conftest.py
+++ b/tensormap-backend/tests/conftest.py
@@ -1,0 +1,47 @@
+import atexit
+import os
+import shutil
+import tempfile
+
+_upload_dir = tempfile.mkdtemp(prefix="tensormap_test_")
+atexit.register(shutil.rmtree, _upload_dir, True)
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ.setdefault("SECRET_KEY", "test-secret-key")
+os.environ.setdefault("UPLOAD_FOLDER", _upload_dir)
+
+from unittest.mock import patch  # noqa: E402
+
+import pytest  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+from sqlmodel import Session, SQLModel, create_engine  # noqa: E402
+
+import app.database as db_module  # noqa: E402
+import app.models  # noqa: E402, F401
+from app.database import get_db  # noqa: E402
+from app.main import app  # noqa: E402
+
+_TEST_ENGINE = create_engine(
+    "sqlite:///:memory:",
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+
+db_module.engine = _TEST_ENGINE
+
+
+@pytest.fixture(name="client", scope="function")
+def client_fixture():
+    SQLModel.metadata.drop_all(_TEST_ENGINE)
+    SQLModel.metadata.create_all(_TEST_ENGINE)
+
+    def override_get_db():
+        with Session(_TEST_ENGINE) as session:
+            yield session
+
+    app.dependency_overrides[get_db] = override_get_db
+
+    with patch("alembic.command.upgrade"), TestClient(app) as c:
+        yield c
+
+    app.dependency_overrides.pop(get_db, None)

--- a/tensormap-backend/tests/test_api_integration.py
+++ b/tensormap-backend/tests/test_api_integration.py
@@ -1,0 +1,156 @@
+import io
+import uuid
+from unittest.mock import MagicMock, mock_open, patch
+
+from fastapi.testclient import TestClient
+
+CSV_BYTES = b"col1,col2\nval1,val2\nval3,val4\n"
+
+
+def _create_project(client: TestClient, name: str = "TestProject") -> dict:
+    resp = client.post("/api/v1/project", json={"name": name})
+    assert resp.status_code == 201, resp.text
+    return resp.json()
+
+
+def test_create_project_valid(client: TestClient):
+    resp = client.post("/api/v1/project", json={"name": "MyProj"})
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["name"] == "MyProj"
+    assert "id" in body["data"]
+
+
+def test_create_project_missing_name(client: TestClient):
+    resp = client.post("/api/v1/project", json={})
+    assert resp.status_code == 422
+
+
+def test_list_projects_empty(client: TestClient):
+    resp = client.get("/api/v1/project")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"] == []
+    assert "pagination" in body
+    assert body["pagination"]["total"] == 0
+
+
+def test_get_project_by_id(client: TestClient):
+    created = _create_project(client, name="FetchMe")
+    project_id = created["data"]["id"]
+
+    resp = client.get(f"/api/v1/project/{project_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"]["id"] == project_id
+    assert body["data"]["name"] == "FetchMe"
+
+
+def test_get_project_not_found(client: TestClient):
+    random_id = str(uuid.uuid4())
+    resp = client.get(f"/api/v1/project/{random_id}")
+    assert resp.status_code == 404
+    body = resp.json()
+    assert body["success"] is False
+
+
+def test_delete_project(client: TestClient):
+    created = _create_project(client, name="DeleteMe")
+    project_id = created["data"]["id"]
+
+    resp = client.delete(f"/api/v1/project/{project_id}")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+
+    resp2 = client.get(f"/api/v1/project/{project_id}")
+    assert resp2.status_code == 404
+
+
+def test_upload_valid_csv(client: TestClient):
+    resp = client.post(
+        "/api/v1/data/upload/file",
+        files={"data": ("test.csv", io.BytesIO(CSV_BYTES), "text/csv")},
+    )
+    assert resp.status_code == 201
+    body = resp.json()
+    assert body["success"] is True
+
+
+def test_upload_non_csv_extension(client: TestClient):
+    resp = client.post(
+        "/api/v1/data/upload/file",
+        files={"data": ("test.txt", io.BytesIO(b"some text"), "text/plain")},
+    )
+    assert resp.status_code == 400
+    body = resp.json()
+    assert body["success"] is False
+
+
+def test_upload_no_filename(client: TestClient):
+    resp = client.post(
+        "/api/v1/data/upload/file",
+        files={"data": ("", io.BytesIO(b""), "text/csv")},
+    )
+    assert resp.status_code in (400, 422)
+
+
+def test_list_files_empty(client: TestClient):
+    resp = client.get("/api/v1/data/upload/file")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"] == []
+    assert "pagination" in body
+
+
+def test_model_list_empty(client: TestClient):
+    resp = client.get("/api/v1/model/model-list")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True
+    assert body["data"] == []
+    assert "pagination" in body
+
+
+def test_validate_model_missing_body(client: TestClient):
+    resp = client.post("/api/v1/model/validate", json={})
+    assert resp.status_code == 422
+
+
+def test_validate_model_valid(client: TestClient):
+    payload = {
+        "model": {
+            "nodes": [{"id": "input-1", "type": "custominput", "data": {"params": {"dim-1": 4}}}],
+            "edges": [],
+            "model_name": "ValidModel",
+        },
+        "code": {
+            "dataset": {
+                "file_id": str(uuid.uuid4()),
+                "target_field": "col1",
+                "training_split": 80,
+            },
+            "dl_model": {
+                "model_name": "ValidModel",
+                "optimizer": "adam",
+                "metric": "mse",
+                "epochs": 10,
+            },
+            "problem_type_id": 1,
+        },
+    }
+    with (
+        patch("app.services.deep_learning.model_generation", return_value={}),
+        patch("app.services.deep_learning.tf") as mock_tf,
+        patch("app.services.deep_learning.open", mock_open()),
+    ):
+        mock_tf.keras.models.model_from_json.return_value = MagicMock()
+        resp = client.post("/api/v1/model/validate", json=payload)
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["success"] is True

--- a/tensormap-backend/tests/test_data_process_service.py
+++ b/tensormap-backend/tests/test_data_process_service.py
@@ -1,0 +1,458 @@
+"""Unit tests for the data_process service.
+
+All database interactions use MagicMock — no running DB required.
+CSV-based tests use pytest's tmp_path fixture for realistic temp files.
+"""
+
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from app.models.data import DataFile, DataProcess
+from app.services.data_process import (
+    add_target_service,
+    delete_one_target_by_id_service,
+    get_all_targets_service,
+    get_data_metrics,
+    get_file_data,
+    get_one_target_by_id_service,
+    preprocess_data,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def file_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_file(file_id):
+    """A DataFile-shaped mock."""
+    f = MagicMock(spec=DataFile)
+    f.id = file_id
+    f.file_name = "iris"
+    f.file_type = "csv"
+    f.row_count = None
+    return f
+
+
+@pytest.fixture()
+def sample_target(file_id):
+    """A DataProcess-shaped mock."""
+    t = MagicMock(spec=DataProcess)
+    t.id = 1
+    t.file_id = file_id
+    t.target = "species"
+    return t
+
+
+@pytest.fixture()
+def classification_csv(tmp_path):
+    """Create a small classification CSV and return the directory."""
+    df = pd.DataFrame(
+        {
+            "sepal_length": [5.1, 4.9, 7.0, 6.3],
+            "sepal_width": [3.5, 3.0, 3.2, 3.3],
+            "species": ["setosa", "setosa", "versicolor", "virginica"],
+        }
+    )
+    df.to_csv(tmp_path / "iris.csv", index=False)
+    return tmp_path
+
+
+@pytest.fixture()
+def regression_csv(tmp_path):
+    """Create a small regression CSV and return the directory."""
+    df = pd.DataFrame(
+        {
+            "size": [1500, 2000, 2500, 3000],
+            "bedrooms": [3, 4, 4, 5],
+            "price": [300000, 400000, 500000, 600000],
+        }
+    )
+    df.to_csv(tmp_path / "housing.csv", index=False)
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# add_target_service
+# ---------------------------------------------------------------------------
+
+
+class TestAddTargetService:
+    def test_success(self, mock_db, file_id, sample_file):
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = add_target_service(mock_db, file_id, "species")
+
+        assert status == 201
+        assert body["success"] is True
+        mock_db.add.assert_called_once()
+        mock_db.commit.assert_called_once()
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = add_target_service(mock_db, file_id, "species")
+
+        assert status == 400
+        assert body["success"] is False
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# get_one_target_by_id_service
+# ---------------------------------------------------------------------------
+
+
+class TestGetOneTargetByIdService:
+    def test_success(self, mock_db, file_id, sample_file, sample_target):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=sample_target)),
+        ]
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"]["target_field"] == "species"
+        assert body["data"]["file_name"] == "iris"
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    def test_target_not_found(self, mock_db, file_id, sample_file):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+
+        body, status = get_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# delete_one_target_by_id_service
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteOneTargetByIdService:
+    def test_success(self, mock_db, file_id, sample_file, sample_target):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=sample_target)),
+        ]
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_target)
+        mock_db.commit.assert_called_once()
+
+    def test_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    def test_target_not_found(self, mock_db, file_id, sample_file):
+        mock_db.exec.side_effect = [
+            MagicMock(first=MagicMock(return_value=sample_file)),
+            MagicMock(first=MagicMock(return_value=None)),
+        ]
+
+        body, status = delete_one_target_by_id_service(mock_db, file_id)
+
+        assert status == 400
+        assert "doesn't exist" in body["message"]
+
+
+# ---------------------------------------------------------------------------
+# get_all_targets_service
+# ---------------------------------------------------------------------------
+
+
+class TestGetAllTargetsService:
+    def test_success(self, mock_db, file_id):
+        row = MagicMock()
+        row.file_id = file_id
+        row.file_name = "iris"
+        row.file_type = "csv"
+        row.target = "species"
+
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=1)),
+            MagicMock(all=MagicMock(return_value=[row])),
+        ]
+
+        body, status = get_all_targets_service(mock_db)
+
+        assert status == 200
+        assert body["success"] is True
+        assert len(body["data"]) == 1
+        assert body["data"][0]["target_field"] == "species"
+        assert body["pagination"]["total"] == 1
+
+    def test_empty(self, mock_db):
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=0)),
+            MagicMock(all=MagicMock(return_value=[])),
+        ]
+
+        body, status = get_all_targets_service(mock_db)
+
+        assert status == 200
+        assert body["data"] == []
+        assert body["pagination"]["total"] == 0
+
+
+# ---------------------------------------------------------------------------
+# get_data_metrics
+# ---------------------------------------------------------------------------
+
+
+class TestGetDataMetrics:
+    @patch("app.services.data_process.get_settings")
+    def test_classification_csv(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        data = body["data"]
+        assert "data_types" in data
+        assert "correlation_matrix" in data
+        assert "metric" in data
+        assert "sepal_length" in data["data_types"]
+
+    @patch("app.services.data_process.get_settings")
+    def test_regression_csv(self, mock_settings, mock_db, file_id, regression_csv):
+        reg_file = MagicMock(spec=DataFile)
+        reg_file.id = file_id
+        reg_file.file_name = "housing"
+        reg_file.file_type = "csv"
+
+        mock_settings.return_value.upload_folder = str(regression_csv)
+        mock_db.exec.return_value.first.return_value = reg_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert "size" in body["data"]["correlation_matrix"]
+        assert "price" in body["data"]["metric"]
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_file_not_on_disk(self, mock_settings, mock_db, file_id, sample_file, tmp_path):
+        mock_settings.return_value.upload_folder = str(tmp_path / "nonexistent")
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 500
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_empty_csv(self, mock_settings, mock_db, file_id, tmp_path):
+        """Metrics on a CSV with headers but no data rows."""
+        pd.DataFrame(columns=["a", "b"]).to_csv(tmp_path / "empty.csv", index=False)
+
+        empty_file = MagicMock(spec=DataFile)
+        empty_file.file_name = "empty"
+        empty_file.file_type = "csv"
+
+        mock_settings.return_value.upload_folder = str(tmp_path)
+        mock_db.exec.return_value.first.return_value = empty_file
+
+        body, status = get_data_metrics(mock_db, file_id)
+
+        assert status == 200
+        assert body["data"]["metric"]["a"]["count"] == "0"
+
+
+# ---------------------------------------------------------------------------
+# get_file_data
+# ---------------------------------------------------------------------------
+
+
+class TestGetFileData:
+    @patch("app.services.data_process.get_settings")
+    def test_get_file_data_page1(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id, page=1, page_size=3)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["pagination"]["page"] == 1
+        assert body["pagination"]["total_rows"] == 4
+        assert body["pagination"]["total_pages"] == 2
+        assert len(body["data"]) == 3
+
+    @patch("app.services.data_process.get_settings")
+    def test_get_file_data_last_page_partial(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id, page=2, page_size=3)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["pagination"]["page"] == 2
+        assert len(body["data"]) == 1
+
+    @patch("app.services.data_process.get_settings")
+    def test_get_file_data_out_of_range_page(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id, page=999, page_size=2)
+
+        assert status == 400
+        assert body["success"] is False
+        assert "exceeds total pages" in body["message"]
+
+    @patch("app.services.data_process.get_settings")
+    def test_get_file_data_empty_file(self, mock_settings, mock_db, file_id, tmp_path):
+        pd.DataFrame(columns=["a", "b"]).to_csv(tmp_path / "empty.csv", index=False)
+
+        empty_file = MagicMock(spec=DataFile)
+        empty_file.file_name = "empty"
+        empty_file.file_type = "csv"
+        empty_file.row_count = None
+
+        mock_settings.return_value.upload_folder = str(tmp_path)
+        mock_db.exec.return_value.first.return_value = empty_file
+
+        body, status = get_file_data(mock_db, file_id, page=1, page_size=50)
+
+        assert status == 200
+        assert body["pagination"]["total_rows"] == 0
+        assert body["pagination"]["total_pages"] == 0
+        assert len(body["data"]) == 0
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_file_data(mock_db, file_id)
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_file_missing_on_disk(self, mock_settings, mock_db, file_id, sample_file, tmp_path):
+        mock_settings.return_value.upload_folder = str(tmp_path / "missing")
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        body, status = get_file_data(mock_db, file_id)
+
+        assert status == 500
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# preprocess_data
+# ---------------------------------------------------------------------------
+
+
+class TestPreprocessData:
+    @patch("app.services.data_process.get_settings")
+    def test_drop_column(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Drop Column"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert "species" not in df.columns
+
+    @patch("app.services.data_process.get_settings")
+    def test_categorical_to_numerical(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Categorical to Numerical"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert pd.api.types.is_integer_dtype(df["species"])
+
+    @patch("app.services.data_process.get_settings")
+    def test_one_hot_encoding(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "One Hot Encoding"
+        t.feature = "species"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 200
+        df = pd.read_csv(classification_csv / "iris.csv")
+        assert "species" not in df.columns
+        assert any("species" in col for col in df.columns)
+
+    def test_file_not_in_db(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = preprocess_data(mock_db, file_id, [])
+
+        assert status == 400
+        assert body["success"] is False
+
+    @patch("app.services.data_process.get_settings")
+    def test_missing_column(self, mock_settings, mock_db, file_id, sample_file, classification_csv):
+        """Dropping a column that doesn't exist returns a 422 error."""
+        mock_settings.return_value.upload_folder = str(classification_csv)
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        t = MagicMock()
+        t.transformation = "Drop Column"
+        t.feature = "nonexistent_column"
+
+        body, status = preprocess_data(mock_db, file_id, [t])
+
+        assert status == 422
+        assert body["success"] is False

--- a/tensormap-backend/tests/test_deep_learning_service.py
+++ b/tensormap-backend/tests/test_deep_learning_service.py
@@ -1,0 +1,113 @@
+"""Unit tests for the deep_learning service — delete_model_service.
+
+All database interactions use MagicMock — no running DB required.
+File-system interactions are patched via unittest.mock.patch.
+TensorFlow is stubbed out via sys.modules so the tests run without it installed.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Stub heavy third-party modules that deep_learning.py imports at module level
+# so the tests can run without TensorFlow / flatten_json installed.
+_tf_stub = MagicMock()
+sys.modules.setdefault("tensorflow", _tf_stub)
+sys.modules.setdefault("flatten_json", MagicMock())
+
+from app.models.ml import ModelBasic  # noqa: E402
+from app.services.deep_learning import delete_model_service  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_model():
+    m = MagicMock(spec=ModelBasic)
+    m.id = 1
+    m.model_name = "my_model"
+    return m
+
+
+# ---------------------------------------------------------------------------
+# delete_model_service
+# ---------------------------------------------------------------------------
+
+
+class TestDeleteModelService:
+    def test_success_deletes_model_and_file(self, mock_db, sample_model, tmp_path):
+        """Deleting an existing model removes the DB row and the JSON file."""
+        mock_db.get.return_value = sample_model
+
+        model_file = tmp_path / "my_model.json"
+        model_file.write_text("{}")
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_model)
+        mock_db.commit.assert_called_once()
+        assert not model_file.exists()
+
+    def test_model_not_found_returns_404(self, mock_db):
+        """Returns 404 when no model with the given ID exists."""
+        mock_db.get.return_value = None
+
+        body, status_code = delete_model_service(mock_db, model_id=999)
+
+        assert status_code == 404
+        assert body["success"] is False
+        assert "not found" in body["message"].lower()
+        mock_db.delete.assert_not_called()
+
+    def test_success_when_json_file_missing(self, mock_db, sample_model, tmp_path):
+        """Deletion succeeds even when the model JSON file is already absent."""
+        mock_db.get.return_value = sample_model
+
+        # Do NOT create the file — it is intentionally absent
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_model)
+
+    def test_db_error_rolls_back(self, mock_db, sample_model):
+        """A database exception triggers a rollback and returns 500."""
+        mock_db.get.return_value = sample_model
+        mock_db.commit.side_effect = Exception("DB failure")
+
+        body, status_code = delete_model_service(mock_db, model_id=1)
+
+        assert status_code == 500
+        assert body["success"] is False
+        mock_db.rollback.assert_called_once()
+
+    def test_get_called_with_correct_id(self, mock_db, sample_model, tmp_path):
+        """db.get is called with ModelBasic and the provided model_id."""
+        mock_db.get.return_value = sample_model
+
+        with (
+            patch("app.services.deep_learning.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.deep_learning.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            delete_model_service(mock_db, model_id=42)
+
+        mock_db.get.assert_called_once_with(ModelBasic, 42)

--- a/tensormap-backend/tests/test_graph_json.py
+++ b/tensormap-backend/tests/test_graph_json.py
@@ -1,0 +1,301 @@
+"""Unit tests for graph_json storage, retrieval, and auto-layout logic.
+
+Covers:
+- Fast path (graph_json IS NOT NULL) with and without positions
+- Legacy fallback path (graph_json IS NULL, configs present)
+- Consistent graph shape from _extract_graph helper
+- Size-guard rejection for oversized payloads
+- Deep-copy safety (ORM object not mutated)
+- get_available_model_list excludes graph_json from response
+
+All database interactions use MagicMock — no running DB required.
+TensorFlow / flatten_json are stubbed out via sys.modules.
+"""
+
+import copy
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# Stub heavy third-party modules so tests run without them installed.
+_tf_stub = MagicMock()
+sys.modules.setdefault("tensorflow", _tf_stub)
+sys.modules.setdefault("flatten_json", MagicMock())
+
+from app.models.ml import ModelBasic, ModelConfigs  # noqa: E402
+from app.services.deep_learning import (  # noqa: E402
+    _apply_auto_layout,
+    _extract_graph,
+    _validate_graph_size,
+    get_available_model_list,
+    get_model_graph_service,
+)
+
+# ---------------------------------------------------------------------------
+# Sample data
+# ---------------------------------------------------------------------------
+
+SAMPLE_GRAPH = {
+    "nodes": [
+        {"id": "n0", "type": "custominput", "data": {"params": {"dim-1": "4"}}, "position": {"x": 100.0, "y": 0.0}},
+        {
+            "id": "n1",
+            "type": "customdense",
+            "data": {"params": {"units": "16", "activation": "relu"}},
+            "position": {"x": 100.0, "y": 200.0},
+        },
+    ],
+    "edges": [{"source": "n0", "target": "n1"}],
+    "model_name": "test_model",
+}
+
+SAMPLE_GRAPH_NO_POSITIONS = {
+    "nodes": [
+        {"id": "n0", "type": "custominput", "data": {"params": {"dim-1": "4"}}},
+        {"id": "n1", "type": "customdense", "data": {"params": {"units": "16", "activation": "relu"}}},
+    ],
+    "edges": [{"source": "n0", "target": "n1"}],
+    "model_name": "test_model",
+}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+def _make_model(*, graph_json=None, model_name="test_model", model_id=1):
+    """Create a MagicMock that behaves like a ModelBasic with the given graph_json."""
+    m = MagicMock(spec=ModelBasic)
+    m.id = model_id
+    m.model_name = model_name
+    m.graph_json = graph_json
+    return m
+
+
+# ---------------------------------------------------------------------------
+# _extract_graph
+# ---------------------------------------------------------------------------
+
+
+class TestExtractGraph:
+    def test_returns_none_for_none(self):
+        assert _extract_graph(None) is None
+
+    def test_unwraps_model_key(self):
+        """When payload is the full request body with a 'model' sub-key, extract it."""
+        payload = {"model": {"nodes": [1, 2], "edges": []}, "code": {}}
+        result = _extract_graph(payload)
+        assert result == {"nodes": [1, 2], "edges": []}
+
+    def test_returns_payload_when_nodes_present(self):
+        """When payload already has 'nodes' at top level, return as-is."""
+        payload = {"nodes": [1, 2], "edges": [], "model_name": "m"}
+        result = _extract_graph(payload)
+        assert result is payload
+
+    def test_model_validate_and_save_produce_same_shape(self):
+        """Both write-path payloads should produce the same extracted graph shape."""
+        graph = {"nodes": [{"id": "n0"}], "edges": [], "model_name": "m"}
+
+        # model_validate_service receives full request body
+        validate_payload = {"model": graph, "code": {"dl_model": {}}}
+        # model_save_service receives request.model.model_dump() — the graph itself
+        save_payload = graph
+
+        assert _extract_graph(validate_payload) == _extract_graph(save_payload)
+
+
+# ---------------------------------------------------------------------------
+# _validate_graph_size
+# ---------------------------------------------------------------------------
+
+
+class TestValidateGraphSize:
+    def test_none_graph_returns_none(self):
+        assert _validate_graph_size(None) is None
+
+    def test_small_graph_returns_none(self):
+        assert _validate_graph_size(SAMPLE_GRAPH) is None
+
+    def test_oversized_graph_returns_error(self):
+        huge = {"nodes": [{"id": str(i), "data": "x" * 10000} for i in range(100)]}
+        result = _validate_graph_size(huge)
+        assert result is not None
+        assert "too large" in result.lower()
+
+
+# ---------------------------------------------------------------------------
+# _apply_auto_layout
+# ---------------------------------------------------------------------------
+
+
+class TestApplyAutoLayout:
+    def test_adds_positions_to_nodes_without_them(self):
+        graph = copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS)
+        _apply_auto_layout(graph)
+        for node in graph["nodes"]:
+            assert "position" in node
+            assert isinstance(node["position"]["x"], float)
+            assert isinstance(node["position"]["y"], float)
+
+    def test_preserves_existing_positions(self):
+        graph = copy.deepcopy(SAMPLE_GRAPH)
+        original_positions = [copy.deepcopy(n["position"]) for n in graph["nodes"]]
+        _apply_auto_layout(graph)
+        for node, orig_pos in zip(graph["nodes"], original_positions, strict=True):
+            assert node["position"] == orig_pos
+
+    def test_handles_empty_nodes(self):
+        graph = {"nodes": [], "edges": []}
+        _apply_auto_layout(graph)  # should not raise
+
+    def test_handles_missing_nodes_key(self):
+        graph = {"edges": []}
+        _apply_auto_layout(graph)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# get_model_graph_service — fast path
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelGraphFastPath:
+    def test_returns_graph_from_graph_json(self, mock_db):
+        """When graph_json is populated, it should be returned directly."""
+        model = _make_model(graph_json=copy.deepcopy(SAMPLE_GRAPH))
+        mock_db.exec.return_value.first.return_value = model
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"]["graph"]["nodes"] == SAMPLE_GRAPH["nodes"]
+        assert body["data"]["model_name"] == "test_model"
+
+    def test_adds_positions_when_missing(self, mock_db):
+        """Fast path should auto-layout nodes that lack positions."""
+        model = _make_model(graph_json=copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS))
+        mock_db.exec.return_value.first.return_value = model
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        for node in body["data"]["graph"]["nodes"]:
+            assert "position" in node
+
+    def test_does_not_mutate_orm_object(self, mock_db):
+        """The service must not modify model.graph_json in-place."""
+        original_graph = copy.deepcopy(SAMPLE_GRAPH_NO_POSITIONS)
+        model = _make_model(graph_json=copy.deepcopy(original_graph))
+        mock_db.exec.return_value.first.return_value = model
+
+        get_model_graph_service(mock_db, "test_model")
+
+        # The ORM object's graph_json should be unchanged (no positions added)
+        for node in model.graph_json["nodes"]:
+            assert "position" not in node
+
+    def test_model_not_found_returns_404(self, mock_db):
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = get_model_graph_service(mock_db, "nonexistent")
+
+        assert status == 404
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# get_model_graph_service — legacy fallback path
+# ---------------------------------------------------------------------------
+
+
+class TestGetModelGraphLegacyPath:
+    def test_falls_back_to_model_configs(self, mock_db):
+        """When graph_json is None, the service reconstructs from ModelConfigs."""
+        model = _make_model(graph_json=None)
+
+        # First .exec().first() returns the model; second .exec().all() returns configs
+        first_call = MagicMock()
+        first_call.first.return_value = model
+
+        cfg1 = MagicMock(spec=ModelConfigs)
+        cfg1.parameter = "nodes.0.id"
+        cfg1.value = "n0"
+        cfg2 = MagicMock(spec=ModelConfigs)
+        cfg2.parameter = "nodes.0.type"
+        cfg2.value = "custominput"
+        cfg3 = MagicMock(spec=ModelConfigs)
+        cfg3.parameter = "nodes.0.data.params.dim-1"
+        cfg3.value = "4"
+
+        second_call = MagicMock()
+        second_call.all.return_value = [cfg1, cfg2, cfg3]
+
+        mock_db.exec.side_effect = [first_call, second_call]
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 200
+        assert body["success"] is True
+        graph = body["data"]["graph"]
+        assert "nodes" in graph
+        # Auto-layout should have been applied
+        for node in graph["nodes"]:
+            assert "position" in node
+
+    def test_legacy_no_configs_returns_404(self, mock_db):
+        """When graph_json is None AND no ModelConfigs exist, return 404."""
+        model = _make_model(graph_json=None)
+
+        first_call = MagicMock()
+        first_call.first.return_value = model
+
+        second_call = MagicMock()
+        second_call.all.return_value = []
+
+        mock_db.exec.side_effect = [first_call, second_call]
+
+        body, status = get_model_graph_service(mock_db, "test_model")
+
+        assert status == 404
+        assert body["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# get_available_model_list — should NOT include graph_json
+# ---------------------------------------------------------------------------
+
+
+class TestGetAvailableModelList:
+    def test_excludes_graph_json_from_response(self, mock_db):
+        """The list endpoint should return only id and model_name."""
+        m1 = MagicMock(spec=ModelBasic)
+        m1.id = 1
+        m1.model_name = "model_a"
+        m1.graph_json = {"nodes": [], "edges": []}
+
+        m2 = MagicMock(spec=ModelBasic)
+        m2.id = 2
+        m2.model_name = "model_b"
+        m2.graph_json = None
+
+        # count query
+        mock_db.exec.side_effect = [
+            MagicMock(one=MagicMock(return_value=2)),  # total count
+            MagicMock(all=MagicMock(return_value=[m1, m2])),  # model list
+        ]
+
+        body, status = get_available_model_list(mock_db)
+
+        assert status == 200
+        for item in body["data"]:
+            assert "graph_json" not in item
+            assert "id" in item
+            assert "model_name" in item

--- a/tensormap-backend/tests/test_model_run.py
+++ b/tensormap-backend/tests/test_model_run.py
@@ -31,11 +31,13 @@ class TestModelRunEmitsErrorOnFailure:
         cfg = _make_model_config(ProblemType.CLASSIFICATION)
         db = _make_db(cfg)
 
-        with patch("app.services.model_run._model_result") as mock_emit, \
-             patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"), \
-             patch("app.services.model_run.pd.read_csv", side_effect=FileNotFoundError("data file missing")):
-            with pytest.raises(FileNotFoundError):
-                model_run("my_model", db)
+        with (
+            patch("app.services.model_run._model_result") as mock_emit,
+            patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"),
+            patch("app.services.model_run.pd.read_csv", side_effect=FileNotFoundError("data file missing")),
+            pytest.raises(FileNotFoundError),
+        ):
+            model_run("my_model", db)
 
         error_calls = [c for c in mock_emit.call_args_list if c.args[1] == -1]
         assert len(error_calls) == 1
@@ -44,11 +46,13 @@ class TestModelRunEmitsErrorOnFailure:
         cfg = _make_model_config(ProblemType.CLASSIFICATION)
         db = _make_db(cfg)
 
-        with patch("app.services.model_run._model_result") as mock_emit, \
-             patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"), \
-             patch("app.services.model_run.pd.read_csv", side_effect=ValueError("shape mismatch")):
-            with pytest.raises(ValueError):
-                model_run("my_model", db)
+        with (
+            patch("app.services.model_run._model_result") as mock_emit,
+            patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"),
+            patch("app.services.model_run.pd.read_csv", side_effect=ValueError("shape mismatch")),
+            pytest.raises(ValueError),
+        ):
+            model_run("my_model", db)
 
         error_calls = [c for c in mock_emit.call_args_list if c.args[1] == -1]
         assert "shape mismatch" in error_calls[0].args[0]
@@ -57,11 +61,13 @@ class TestModelRunEmitsErrorOnFailure:
         cfg = _make_model_config(ProblemType.CLASSIFICATION)
         db = _make_db(cfg)
 
-        with patch("app.services.model_run._model_result"), \
-             patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"), \
-             patch("app.services.model_run.pd.read_csv", side_effect=RuntimeError("OOM")):
-            with pytest.raises(RuntimeError, match="OOM"):
-                model_run("my_model", db)
+        with (
+            patch("app.services.model_run._model_result"),
+            patch("app.services.model_run._helper_generate_file_location", return_value="/fake/path"),
+            patch("app.services.model_run.pd.read_csv", side_effect=RuntimeError("OOM")),
+            pytest.raises(RuntimeError, match="OOM"),
+        ):
+            model_run("my_model", db)
 
 
 class TestRunCodeServiceOnFailure:

--- a/tensormap-backend/tests/test_new_transforms.py
+++ b/tensormap-backend/tests/test_new_transforms.py
@@ -21,10 +21,12 @@ def _make_db() -> MagicMock:
 def _run(df: pd.DataFrame, transformation: str, feature: str, params: dict = None):
     db = _make_db()
     items = [TransformationItem(transformation=transformation, feature=feature, params=params)]
-    with patch("app.services.data_process.select"), \
-         patch("app.services.data_process.pd.read_csv", return_value=df.copy()), \
-         patch("app.services.data_process.get_settings") as mock_settings, \
-         patch("pandas.DataFrame.to_csv"):
+    with (
+        patch("app.services.data_process.select"),
+        patch("app.services.data_process.pd.read_csv", return_value=df.copy()),
+        patch("app.services.data_process.get_settings") as mock_settings,
+        patch("pandas.DataFrame.to_csv"),
+    ):
         mock_settings.return_value.upload_folder = "/tmp"
         result, status_code = preprocess_data(db, uuid.uuid4(), items)
     return result, status_code
@@ -39,10 +41,12 @@ def _run_df(df: pd.DataFrame, transformation: str, feature: str, params: dict = 
     def capture(self_df, path, index=False):
         saved["df"] = self_df.copy()
 
-    with patch("app.services.data_process.select"), \
-         patch("app.services.data_process.pd.read_csv", return_value=df.copy()), \
-         patch("app.services.data_process.get_settings") as mock_settings, \
-         patch.object(pd.DataFrame, "to_csv", capture):
+    with (
+        patch("app.services.data_process.select"),
+        patch("app.services.data_process.pd.read_csv", return_value=df.copy()),
+        patch("app.services.data_process.get_settings") as mock_settings,
+        patch.object(pd.DataFrame, "to_csv", capture),
+    ):
         mock_settings.return_value.upload_folder = "/tmp"
         preprocess_data(db, uuid.uuid4(), items)
     return saved["df"]
@@ -95,7 +99,7 @@ class TestLogTransform:
         df = pd.DataFrame({"price": values})
         result_df = _run_df(df, "Log Transform", "price")
         expected = [np.log1p(v) for v in values]
-        for got, exp in zip(result_df["price"], expected):
+        for got, exp in zip(result_df["price"], expected, strict=False):
             assert got == pytest.approx(exp)
 
     def test_zero_input_gives_zero(self):

--- a/tensormap-backend/uv.lock
+++ b/tensormap-backend/uv.lock
@@ -269,6 +269,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ea/ab/1608e5a7578e62113506740b88066bf09888322a311cff602105e619bd87/greenlet-3.3.2-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:ac8d61d4343b799d1e526db579833d72f23759c71e07181c2d2944e429eb09cd", size = 280358, upload-time = "2026-02-20T20:17:43.971Z" },
     { url = "https://files.pythonhosted.org/packages/a5/23/0eae412a4ade4e6623ff7626e38998cb9b11e9ff1ebacaa021e4e108ec15/greenlet-3.3.2-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3ceec72030dae6ac0c8ed7591b96b70410a8be370b6a477b1dbc072856ad02bd", size = 601217, upload-time = "2026-02-20T20:47:31.462Z" },
     { url = "https://files.pythonhosted.org/packages/f8/16/5b1678a9c07098ecb9ab2dd159fafaf12e963293e61ee8d10ecb55273e5e/greenlet-3.3.2-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:a2a5be83a45ce6188c045bcc44b0ee037d6a518978de9a5d97438548b953a1ac", size = 611792, upload-time = "2026-02-20T20:55:58.423Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/c5/cc09412a29e43406eba18d61c70baa936e299bc27e074e2be3806ed29098/greenlet-3.3.2-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ae9e21c84035c490506c17002f5c8ab25f980205c3e61ddb3a2a2a2e6c411fcb", size = 626250, upload-time = "2026-02-20T21:02:46.596Z" },
     { url = "https://files.pythonhosted.org/packages/50/1f/5155f55bd71cabd03765a4aac9ac446be129895271f73872c36ebd4b04b6/greenlet-3.3.2-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:43e99d1749147ac21dde49b99c9abffcbc1e2d55c67501465ef0930d6e78e070", size = 613875, upload-time = "2026-02-20T20:21:01.102Z" },
     { url = "https://files.pythonhosted.org/packages/fc/dd/845f249c3fcd69e32df80cdab059b4be8b766ef5830a3d0aa9d6cad55beb/greenlet-3.3.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4c956a19350e2c37f2c48b336a3afb4bff120b36076d9d7fb68cb44e05d95b79", size = 1571467, upload-time = "2026-02-20T20:49:33.495Z" },
     { url = "https://files.pythonhosted.org/packages/2a/50/2649fe21fcc2b56659a452868e695634722a6655ba245d9f77f5656010bf/greenlet-3.3.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:6c6f8ba97d17a1e7d664151284cb3315fc5f8353e75221ed4324f84eb162b395", size = 1640001, upload-time = "2026-02-20T20:21:09.154Z" },
@@ -277,6 +278,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/48/f8b875fa7dea7dd9b33245e37f065af59df6a25af2f9561efa8d822fde51/greenlet-3.3.2-cp313-cp313-macosx_11_0_universal2.whl", hash = "sha256:aa6ac98bdfd716a749b84d4034486863fd81c3abde9aa3cf8eff9127981a4ae4", size = 279120, upload-time = "2026-02-20T20:19:01.9Z" },
     { url = "https://files.pythonhosted.org/packages/49/8d/9771d03e7a8b1ee456511961e1b97a6d77ae1dea4a34a5b98eee706689d3/greenlet-3.3.2-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ab0c7e7901a00bc0a7284907273dc165b32e0d109a6713babd04471327ff7986", size = 603238, upload-time = "2026-02-20T20:47:32.873Z" },
     { url = "https://files.pythonhosted.org/packages/59/0e/4223c2bbb63cd5c97f28ffb2a8aee71bdfb30b323c35d409450f51b91e3e/greenlet-3.3.2-cp313-cp313-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:d248d8c23c67d2291ffd47af766e2a3aa9fa1c6703155c099feb11f526c63a92", size = 614219, upload-time = "2026-02-20T20:55:59.817Z" },
+    { url = "https://files.pythonhosted.org/packages/94/2b/4d012a69759ac9d77210b8bfb128bc621125f5b20fc398bce3940d036b1c/greenlet-3.3.2-cp313-cp313-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:ccd21bb86944ca9be6d967cf7691e658e43417782bce90b5d2faeda0ff78a7dd", size = 628268, upload-time = "2026-02-20T21:02:48.024Z" },
     { url = "https://files.pythonhosted.org/packages/7a/34/259b28ea7a2a0c904b11cd36c79b8cef8019b26ee5dbe24e73b469dea347/greenlet-3.3.2-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6997d360a4e6a4e936c0f9625b1c20416b8a0ea18a8e19cabbefc712e7397ab", size = 616774, upload-time = "2026-02-20T20:21:02.454Z" },
     { url = "https://files.pythonhosted.org/packages/0a/03/996c2d1689d486a6e199cb0f1cf9e4aa940c500e01bdf201299d7d61fa69/greenlet-3.3.2-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:64970c33a50551c7c50491671265d8954046cb6e8e2999aacdd60e439b70418a", size = 1571277, upload-time = "2026-02-20T20:49:34.795Z" },
     { url = "https://files.pythonhosted.org/packages/d9/c4/2570fc07f34a39f2caf0bf9f24b0a1a0a47bc2e8e465b2c2424821389dfc/greenlet-3.3.2-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a9172f5bf6bd88e6ba5a84e0a68afeac9dc7b6b412b245dd64f52d83c81e55b", size = 1640455, upload-time = "2026-02-20T20:21:10.261Z" },
@@ -285,6 +287,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/3f/ae/8bffcbd373b57a5992cd077cbe8858fff39110480a9d50697091faea6f39/greenlet-3.3.2-cp314-cp314-macosx_11_0_universal2.whl", hash = "sha256:8d1658d7291f9859beed69a776c10822a0a799bc4bfe1bd4272bb60e62507dab", size = 279650, upload-time = "2026-02-20T20:18:00.783Z" },
     { url = "https://files.pythonhosted.org/packages/d1/c0/45f93f348fa49abf32ac8439938726c480bd96b2a3c6f4d949ec0124b69f/greenlet-3.3.2-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:18cb1b7337bca281915b3c5d5ae19f4e76d35e1df80f4ad3c1a7be91fadf1082", size = 650295, upload-time = "2026-02-20T20:47:34.036Z" },
     { url = "https://files.pythonhosted.org/packages/b3/de/dd7589b3f2b8372069ab3e4763ea5329940fc7ad9dcd3e272a37516d7c9b/greenlet-3.3.2-cp314-cp314-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:c2e47408e8ce1c6f1ceea0dffcdf6ebb85cc09e55c7af407c99f1112016e45e9", size = 662163, upload-time = "2026-02-20T20:56:01.295Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/ac/85804f74f1ccea31ba518dcc8ee6f14c79f73fe36fa1beba38930806df09/greenlet-3.3.2-cp314-cp314-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:e3cb43ce200f59483eb82949bf1835a99cf43d7571e900d7c8d5c62cdf25d2f9", size = 675371, upload-time = "2026-02-20T21:02:49.664Z" },
     { url = "https://files.pythonhosted.org/packages/d2/d8/09bfa816572a4d83bccd6750df1926f79158b1c36c5f73786e26dbe4ee38/greenlet-3.3.2-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:63d10328839d1973e5ba35e98cccbca71b232b14051fd957b6f8b6e8e80d0506", size = 664160, upload-time = "2026-02-20T20:21:04.015Z" },
     { url = "https://files.pythonhosted.org/packages/48/cf/56832f0c8255d27f6c35d41b5ec91168d74ec721d85f01a12131eec6b93c/greenlet-3.3.2-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:8e4ab3cfb02993c8cc248ea73d7dae6cec0253e9afa311c9b37e603ca9fad2ce", size = 1619181, upload-time = "2026-02-20T20:49:36.052Z" },
     { url = "https://files.pythonhosted.org/packages/0a/23/b90b60a4aabb4cec0796e55f25ffbfb579a907c3898cd2905c8918acaa16/greenlet-3.3.2-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:94ad81f0fd3c0c0681a018a976e5c2bd2ca2d9d94895f23e7bb1af4e8af4e2d5", size = 1687713, upload-time = "2026-02-20T20:21:11.684Z" },
@@ -293,6 +296,7 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/98/6d/8f2ef704e614bcf58ed43cfb8d87afa1c285e98194ab2cfad351bf04f81e/greenlet-3.3.2-cp314-cp314t-macosx_11_0_universal2.whl", hash = "sha256:e26e72bec7ab387ac80caa7496e0f908ff954f31065b0ffc1f8ecb1338b11b54", size = 286617, upload-time = "2026-02-20T20:19:29.856Z" },
     { url = "https://files.pythonhosted.org/packages/5e/0d/93894161d307c6ea237a43988f27eba0947b360b99ac5239ad3fe09f0b47/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8b466dff7a4ffda6ca975979bab80bdadde979e29fc947ac3be4451428d8b0e4", size = 655189, upload-time = "2026-02-20T20:47:35.742Z" },
     { url = "https://files.pythonhosted.org/packages/f5/2c/d2d506ebd8abcb57386ec4f7ba20f4030cbe56eae541bc6fd6ef399c0b41/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:b8bddc5b73c9720bea487b3bffdb1840fe4e3656fba3bd40aa1489e9f37877ff", size = 658225, upload-time = "2026-02-20T20:56:02.527Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/67/8197b7e7e602150938049d8e7f30de1660cfb87e4c8ee349b42b67bdb2e1/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:59b3e2c40f6706b05a9cd299c836c6aa2378cabe25d021acd80f13abf81181cf", size = 666581, upload-time = "2026-02-20T21:02:51.526Z" },
     { url = "https://files.pythonhosted.org/packages/8e/30/3a09155fbf728673a1dea713572d2d31159f824a37c22da82127056c44e4/greenlet-3.3.2-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b26b0f4428b871a751968285a1ac9648944cea09807177ac639b030bddebcea4", size = 657907, upload-time = "2026-02-20T20:21:05.259Z" },
     { url = "https://files.pythonhosted.org/packages/f3/fd/d05a4b7acd0154ed758797f0a43b4c0962a843bedfe980115e842c5b2d08/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:1fb39a11ee2e4d94be9a76671482be9398560955c9e568550de0224e41104727", size = 1618857, upload-time = "2026-02-20T20:49:37.309Z" },
     { url = "https://files.pythonhosted.org/packages/6f/e1/50ee92a5db521de8f35075b5eff060dd43d39ebd46c2181a2042f7070385/greenlet-3.3.2-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:20154044d9085151bc309e7689d6f7ba10027f8f5a8c0676ad398b951913d89e", size = 1680010, upload-time = "2026-02-20T20:21:13.427Z" },
@@ -1165,6 +1169,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-mock"
+version = "3.15.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/68/14/eb014d26be205d38ad5ad20d9a80f7d201472e08167f0bb4361e251084a9/pytest_mock-3.15.1.tar.gz", hash = "sha256:1849a238f6f396da19762269de72cb1814ab44416fa73a8686deac10b0d87a0f", size = 34036, upload-time = "2025-09-16T16:37:27.081Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/cc/06253936f4a7fa2e0f48dfe6d851d9c56df896a9ab09ac019d70b760619c/pytest_mock-3.15.1-py3-none-any.whl", hash = "sha256:0a25e2eb88fe5168d535041d09a4529a188176ae608a6d249ee65abc0949630d", size = 10095, upload-time = "2025-09-16T16:37:25.734Z" },
+]
+
+[[package]]
 name = "python-dateutil"
 version = "2.9.0.post0"
 source = { registry = "https://pypi.org/simple" }
@@ -1295,27 +1311,27 @@ wheels = [
 
 [[package]]
 name = "ruff"
-version = "0.15.2"
+version = "0.15.4"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/06/04/eab13a954e763b0606f460443fcbf6bb5a0faf06890ea3754ff16523dce5/ruff-0.15.2.tar.gz", hash = "sha256:14b965afee0969e68bb871eba625343b8673375f457af4abe98553e8bbb98342", size = 4558148, upload-time = "2026-02-19T22:32:20.271Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/da/31/d6e536cdebb6568ae75a7f00e4b4819ae0ad2640c3604c305a0428680b0c/ruff-0.15.4.tar.gz", hash = "sha256:3412195319e42d634470cc97aa9803d07e9d5c9223b99bcb1518f0c725f26ae1", size = 4569550, upload-time = "2026-02-26T20:04:14.959Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/2f/70/3a4dc6d09b13cb3e695f28307e5d889b2e1a66b7af9c5e257e796695b0e6/ruff-0.15.2-py3-none-linux_armv6l.whl", hash = "sha256:120691a6fdae2f16d65435648160f5b81a9625288f75544dc40637436b5d3c0d", size = 10430565, upload-time = "2026-02-19T22:32:41.824Z" },
-    { url = "https://files.pythonhosted.org/packages/71/0b/bb8457b56185ece1305c666dc895832946d24055be90692381c31d57466d/ruff-0.15.2-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:a89056d831256099658b6bba4037ac6dd06f49d194199215befe2bb10457ea5e", size = 10820354, upload-time = "2026-02-19T22:32:07.366Z" },
-    { url = "https://files.pythonhosted.org/packages/2d/c1/e0532d7f9c9e0b14c46f61b14afd563298b8b83f337b6789ddd987e46121/ruff-0.15.2-py3-none-macosx_11_0_arm64.whl", hash = "sha256:e36dee3a64be0ebd23c86ffa3aa3fd3ac9a712ff295e192243f814a830b6bd87", size = 10170767, upload-time = "2026-02-19T22:32:13.188Z" },
-    { url = "https://files.pythonhosted.org/packages/47/e8/da1aa341d3af017a21c7a62fb5ec31d4e7ad0a93ab80e3a508316efbcb23/ruff-0.15.2-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a9fb47b6d9764677f8c0a193c0943ce9a05d6763523f132325af8a858eadc2b9", size = 10529591, upload-time = "2026-02-19T22:32:02.547Z" },
-    { url = "https://files.pythonhosted.org/packages/93/74/184fbf38e9f3510231fbc5e437e808f0b48c42d1df9434b208821efcd8d6/ruff-0.15.2-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f376990f9d0d6442ea9014b19621d8f2aaf2b8e39fdbfc79220b7f0c596c9b80", size = 10260771, upload-time = "2026-02-19T22:32:36.938Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ac/605c20b8e059a0bc4b42360414baa4892ff278cec1c91fff4be0dceedefd/ruff-0.15.2-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dcc987551952d73cbf5c88d9fdee815618d497e4df86cd4c4824cc59d5dd75f", size = 11045791, upload-time = "2026-02-19T22:32:31.642Z" },
-    { url = "https://files.pythonhosted.org/packages/fd/52/db6e419908f45a894924d410ac77d64bdd98ff86901d833364251bd08e22/ruff-0.15.2-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:42a47fd785cbe8c01b9ff45031af875d101b040ad8f4de7bbb716487c74c9a77", size = 11879271, upload-time = "2026-02-19T22:32:29.305Z" },
-    { url = "https://files.pythonhosted.org/packages/3e/d8/7992b18f2008bdc9231d0f10b16df7dda964dbf639e2b8b4c1b4e91b83af/ruff-0.15.2-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cbe9f49354866e575b4c6943856989f966421870e85cd2ac94dccb0a9dcb2fea", size = 11303707, upload-time = "2026-02-19T22:32:22.492Z" },
-    { url = "https://files.pythonhosted.org/packages/d7/02/849b46184bcfdd4b64cde61752cc9a146c54759ed036edd11857e9b8443b/ruff-0.15.2-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b7a672c82b5f9887576087d97be5ce439f04bbaf548ee987b92d3a7dede41d3a", size = 11149151, upload-time = "2026-02-19T22:32:44.234Z" },
-    { url = "https://files.pythonhosted.org/packages/70/04/f5284e388bab60d1d3b99614a5a9aeb03e0f333847e2429bebd2aaa1feec/ruff-0.15.2-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:72ecc64f46f7019e2bcc3cdc05d4a7da958b629a5ab7033195e11a438403d956", size = 11091132, upload-time = "2026-02-19T22:32:24.691Z" },
-    { url = "https://files.pythonhosted.org/packages/fa/ae/88d844a21110e14d92cf73d57363fab59b727ebeabe78009b9ccb23500af/ruff-0.15.2-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:8dcf243b15b561c655c1ef2f2b0050e5d50db37fe90115507f6ff37d865dc8b4", size = 10504717, upload-time = "2026-02-19T22:32:26.75Z" },
-    { url = "https://files.pythonhosted.org/packages/64/27/867076a6ada7f2b9c8292884ab44d08fd2ba71bd2b5364d4136f3cd537e1/ruff-0.15.2-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dab6941c862c05739774677c6273166d2510d254dac0695c0e3f5efa1b5585de", size = 10263122, upload-time = "2026-02-19T22:32:10.036Z" },
-    { url = "https://files.pythonhosted.org/packages/e7/ef/faf9321d550f8ebf0c6373696e70d1758e20ccdc3951ad7af00c0956be7c/ruff-0.15.2-py3-none-musllinux_1_2_i686.whl", hash = "sha256:1b9164f57fc36058e9a6806eb92af185b0697c9fe4c7c52caa431c6554521e5c", size = 10735295, upload-time = "2026-02-19T22:32:39.227Z" },
-    { url = "https://files.pythonhosted.org/packages/2f/55/e8089fec62e050ba84d71b70e7834b97709ca9b7aba10c1a0b196e493f97/ruff-0.15.2-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:80d24fcae24d42659db7e335b9e1531697a7102c19185b8dc4a028b952865fd8", size = 11241641, upload-time = "2026-02-19T22:32:34.617Z" },
-    { url = "https://files.pythonhosted.org/packages/23/01/1c30526460f4d23222d0fabd5888868262fd0e2b71a00570ca26483cd993/ruff-0.15.2-py3-none-win32.whl", hash = "sha256:fd5ff9e5f519a7e1bd99cbe8daa324010a74f5e2ebc97c6242c08f26f3714f6f", size = 10507885, upload-time = "2026-02-19T22:32:15.635Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/10/3d18e3bbdf8fc50bbb4ac3cc45970aa5a9753c5cb51bf9ed9a3cd8b79fa3/ruff-0.15.2-py3-none-win_amd64.whl", hash = "sha256:d20014e3dfa400f3ff84830dfb5755ece2de45ab62ecea4af6b7262d0fb4f7c5", size = 11623725, upload-time = "2026-02-19T22:32:04.947Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/78/097c0798b1dab9f8affe73da9642bb4500e098cb27fd8dc9724816ac747b/ruff-0.15.2-py3-none-win_arm64.whl", hash = "sha256:cabddc5822acdc8f7b5527b36ceac55cc51eec7b1946e60181de8fe83ca8876e", size = 10941649, upload-time = "2026-02-19T22:32:18.108Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/82/c11a03cfec3a4d26a0ea1e571f0f44be5993b923f905eeddfc397c13d360/ruff-0.15.4-py3-none-linux_armv6l.whl", hash = "sha256:a1810931c41606c686bae8b5b9a8072adac2f611bb433c0ba476acba17a332e0", size = 10453333, upload-time = "2026-02-26T20:04:20.093Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/5d/6a1f271f6e31dffb31855996493641edc3eef8077b883eaf007a2f1c2976/ruff-0.15.4-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:5a1632c66672b8b4d3e1d1782859e98d6e0b4e70829530666644286600a33992", size = 10853356, upload-time = "2026-02-26T20:04:05.808Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/d8/0fab9f8842b83b1a9c2bf81b85063f65e93fb512e60effa95b0be49bfc54/ruff-0.15.4-py3-none-macosx_11_0_arm64.whl", hash = "sha256:a4386ba2cd6c0f4ff75252845906acc7c7c8e1ac567b7bc3d373686ac8c222ba", size = 10187434, upload-time = "2026-02-26T20:03:54.656Z" },
+    { url = "https://files.pythonhosted.org/packages/85/cc/cc220fd9394eff5db8d94dec199eec56dd6c9f3651d8869d024867a91030/ruff-0.15.4-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b2496488bdfd3732747558b6f95ae427ff066d1fcd054daf75f5a50674411e75", size = 10535456, upload-time = "2026-02-26T20:03:52.738Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/0f/bced38fa5cf24373ec767713c8e4cadc90247f3863605fb030e597878661/ruff-0.15.4-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3f1c4893841ff2d54cbda1b2860fa3260173df5ddd7b95d370186f8a5e66a4ac", size = 10287772, upload-time = "2026-02-26T20:04:08.138Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/90/58a1802d84fed15f8f281925b21ab3cecd813bde52a8ca033a4de8ab0e7a/ruff-0.15.4-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:820b8766bd65503b6c30aaa6331e8ef3a6e564f7999c844e9a547c40179e440a", size = 11049051, upload-time = "2026-02-26T20:04:03.53Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/ac/b7ad36703c35f3866584564dc15f12f91cb1a26a897dc2fd13d7cb3ae1af/ruff-0.15.4-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:c9fb74bab47139c1751f900f857fa503987253c3ef89129b24ed375e72873e85", size = 11890494, upload-time = "2026-02-26T20:04:10.497Z" },
+    { url = "https://files.pythonhosted.org/packages/93/3d/3eb2f47a39a8b0da99faf9c54d3eb24720add1e886a5309d4d1be73a6380/ruff-0.15.4-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f80c98765949c518142b3a50a5db89343aa90f2c2bf7799de9986498ae6176db", size = 11326221, upload-time = "2026-02-26T20:04:12.84Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/90/bf134f4c1e5243e62690e09d63c55df948a74084c8ac3e48a88468314da6/ruff-0.15.4-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:451a2e224151729b3b6c9ffb36aed9091b2996fe4bdbd11f47e27d8f2e8888ec", size = 11168459, upload-time = "2026-02-26T20:04:00.969Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/e5/a64d27688789b06b5d55162aafc32059bb8c989c61a5139a36e1368285eb/ruff-0.15.4-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a8f157f2e583c513c4f5f896163a93198297371f34c04220daf40d133fdd4f7f", size = 11104366, upload-time = "2026-02-26T20:03:48.099Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/f6/32d1dcb66a2559763fc3027bdd65836cad9eb09d90f2ed6a63d8e9252b02/ruff-0.15.4-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:917cc68503357021f541e69b35361c99387cdbbf99bd0ea4aa6f28ca99ff5338", size = 10510887, upload-time = "2026-02-26T20:03:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/92/22d1ced50971c5b6433aed166fcef8c9343f567a94cf2b9d9089f6aa80fe/ruff-0.15.4-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:e9737c8161da79fd7cfec19f1e35620375bd8b2a50c3e77fa3d2c16f574105cc", size = 10285939, upload-time = "2026-02-26T20:04:22.42Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/f4/7c20aec3143837641a02509a4668fb146a642fd1211846634edc17eb5563/ruff-0.15.4-py3-none-musllinux_1_2_i686.whl", hash = "sha256:291258c917539e18f6ba40482fe31d6f5ac023994ee11d7bdafd716f2aab8a68", size = 10765471, upload-time = "2026-02-26T20:03:58.924Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/09/6d2f7586f09a16120aebdff8f64d962d7c4348313c77ebb29c566cefc357/ruff-0.15.4-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:3f83c45911da6f2cd5936c436cf86b9f09f09165f033a99dcf7477e34041cbc3", size = 11263382, upload-time = "2026-02-26T20:04:24.424Z" },
+    { url = "https://files.pythonhosted.org/packages/1b/fa/2ef715a1cd329ef47c1a050e10dee91a9054b7ce2fcfdd6a06d139afb7ec/ruff-0.15.4-py3-none-win32.whl", hash = "sha256:65594a2d557d4ee9f02834fcdf0a28daa8b3b9f6cb2cb93846025a36db47ef22", size = 10506664, upload-time = "2026-02-26T20:03:50.56Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/a8/c688ef7e29983976820d18710f955751d9f4d4eb69df658af3d006e2ba3e/ruff-0.15.4-py3-none-win_amd64.whl", hash = "sha256:04196ad44f0df220c2ece5b0e959c2f37c777375ec744397d21d15b50a75264f", size = 11651048, upload-time = "2026-02-26T20:04:17.191Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/0a/9e1be9035b37448ce2e68c978f0591da94389ade5a5abafa4cf99985d1b2/ruff-0.15.4-py3-none-win_arm64.whl", hash = "sha256:60d5177e8cfc70e51b9c5fad936c634872a74209f934c1e79107d11787ad5453", size = 10966776, upload-time = "2026-02-26T20:03:56.908Z" },
 ]
 
 [[package]]
@@ -1511,6 +1527,7 @@ dev = [
     { name = "httpx" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-mock" },
     { name = "ruff" },
 ]
 
@@ -1527,6 +1544,7 @@ requires-dist = [
     { name = "psycopg2-binary", specifier = ">=2.9" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
+    { name = "pytest-mock", marker = "extra == 'dev'", specifier = ">=3.14" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "python-socketio", specifier = ">=5.10" },
     { name = "pyyaml", specifier = ">=6.0" },

--- a/tensormap-frontend/.eslintrc.cjs
+++ b/tensormap-frontend/.eslintrc.cjs
@@ -23,5 +23,9 @@ module.exports = {
       files: ["**/*.test.js", "**/*.test.jsx", "**/*.spec.js", "**/*.spec.jsx"],
       env: { jest: true },
     },
+    {
+      files: ["postcss.config.js"],
+      env: { node: true },
+    },
   ],
 };

--- a/tensormap-frontend/package-lock.json
+++ b/tensormap-frontend/package-lock.json
@@ -29,17 +29,21 @@
         "tailwind-merge": "^3.5.0"
       },
       "devDependencies": {
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "autoprefixer": "^10.4.24",
         "eslint": "^8.57.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-plugin-react": "^7.34.1",
         "eslint-plugin-react-hooks": "^4.6.0",
         "eslint-plugin-react-refresh": "^0.4.6",
+        "jsdom": "^28.1.0",
         "postcss": "^8.5.6",
         "prettier": "^3.2.5",
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
-        "vite": "^5.4.14"
+        "vite": "^5.4.14",
+        "vitest": "^4.0.18"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -50,6 +54,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -75,6 +93,64 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.0.1.tgz",
+      "integrity": "sha512-2SZFvqMyvboVV1d15lMf7XiI3m7SDqXUuKaTymJYLN6dSGadqp+fVojqJlVoMlbZnlTmu3S0TLwLTJpvBMO1Aw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^3.1.1",
+        "@csstools/css-color-parser": "^4.0.2",
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.8.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+      "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.6"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.29.0",
@@ -328,6 +404,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -373,6 +459,151 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bramus/specificity": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+      "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "css-tree": "^3.0.0"
+      },
+      "bin": {
+        "specificity": "bin/cli.js"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+      "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=20.19.0"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.1.1.tgz",
+      "integrity": "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.0.2.tgz",
+      "integrity": "sha512-0GEfbBLmTFf0dJlpsNU7zwxRIH0/BGEMuXLTCvFYxuL1tNhqzTbtnFICyJLTNK4a+RechKP75e7w42ClXSnJQw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^6.0.2",
+        "@csstools/css-calc": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^4.0.0",
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+      "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^4.0.0"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.28",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.28.tgz",
+      "integrity": "sha512-1NRf1CUBjnr3K7hu8BLxjQrKCxEe8FP/xmPTenAxCRZWVLbmGotkFvG9mfNpjA6k7Bw1bw4BilZq9cu19RA5pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+      "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.19.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -630,6 +861,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/netbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
@@ -645,6 +893,23 @@
         "node": ">=12"
       }
     },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@esbuild/openbsd-x64": {
       "version": "0.21.5",
       "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
@@ -658,6 +923,23 @@
       ],
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
@@ -821,6 +1103,24 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@exodus/bytes": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.14.1.tgz",
+      "integrity": "sha512-OhkBFWI6GcRMUroChZiopRiSp2iAMvEBK47NhJooDqz1RERO4QuZIZnjP63TXX8GAiLABkYmX+fuQsdJ1dd2QQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@floating-ui/core": {
       "version": "1.7.4",
       "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.4.tgz",
@@ -922,9 +1222,10 @@
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
-      "version": "1.4.15",
-      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.15.tgz",
-      "integrity": "sha512-eF2rxCRulEKXHTRiDrDy6erMYWqNw4LPdQ8UQA4huuxaQsVeRPFl2oM8oDGxMFhJUWZf9McpLtJasDDZb/Bpeg=="
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.25",
@@ -1856,228 +2157,325 @@
       }
     },
     "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.34.6.tgz",
-      "integrity": "sha512-+GcCXtOQoWuC7hhX1P00LqjjIiS/iOouHXhMdiDSnq/1DGTox4SpUvO52Xm+div6+106r+TcvOeo/cxvyEyTgg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.59.0.tgz",
+      "integrity": "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.34.6.tgz",
-      "integrity": "sha512-E8+2qCIjciYUnCa1AiVF1BkRgqIGW9KzJeesQqVfyRITGQN+dFuoivO0hnro1DjT74wXLRZ7QF8MIbz+luGaJA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.59.0.tgz",
+      "integrity": "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "android"
       ]
     },
     "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.34.6.tgz",
-      "integrity": "sha512-z9Ib+OzqN3DZEjX7PDQMHEhtF+t6Mi2z/ueChQPLS/qUMKY7Ybn5A2ggFoKRNRh1q1T03YTQfBTQCJZiepESAg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.59.0.tgz",
+      "integrity": "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.34.6.tgz",
-      "integrity": "sha512-PShKVY4u0FDAR7jskyFIYVyHEPCPnIQY8s5OcXkdU8mz3Y7eXDJPdyM/ZWjkYdR2m0izD9HHWA8sGcXn+Qrsyg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.59.0.tgz",
+      "integrity": "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "darwin"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.34.6.tgz",
-      "integrity": "sha512-YSwyOqlDAdKqs0iKuqvRHLN4SrD2TiswfoLfvYXseKbL47ht1grQpq46MSiQAx6rQEN8o8URtpXARCpqabqxGQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.59.0.tgz",
+      "integrity": "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.34.6.tgz",
-      "integrity": "sha512-HEP4CgPAY1RxXwwL5sPFv6BBM3tVeLnshF03HMhJYCNc6kvSqBgTMmsEjb72RkZBAWIqiPUyF1JpEBv5XT9wKQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.59.0.tgz",
+      "integrity": "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "freebsd"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.34.6.tgz",
-      "integrity": "sha512-88fSzjC5xeH9S2Vg3rPgXJULkHcLYMkh8faix8DX4h4TIAL65ekwuQMA/g2CXq8W+NJC43V6fUpYZNjaX3+IIg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.59.0.tgz",
+      "integrity": "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.34.6.tgz",
-      "integrity": "sha512-wM4ztnutBqYFyvNeR7Av+reWI/enK9tDOTKNF+6Kk2Q96k9bwhDDOlnCUNRPvromlVXo04riSliMBs/Z7RteEg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.59.0.tgz",
+      "integrity": "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA==",
       "cpu": [
         "arm"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.34.6.tgz",
-      "integrity": "sha512-9RyprECbRa9zEjXLtvvshhw4CMrRa3K+0wcp3KME0zmBe1ILmvcVHnypZ/aIDXpRyfhSYSuN4EPdCCj5Du8FIA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.59.0.tgz",
+      "integrity": "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.34.6.tgz",
-      "integrity": "sha512-qTmklhCTyaJSB05S+iSovfo++EwnIEZxHkzv5dep4qoszUMX5Ca4WM4zAVUMbfdviLgCSQOu5oU8YoGk1s6M9Q==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.59.0.tgz",
+      "integrity": "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-loongarch64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loongarch64-gnu/-/rollup-linux-loongarch64-gnu-4.34.6.tgz",
-      "integrity": "sha512-4Qmkaps9yqmpjY5pvpkfOerYgKNUGzQpFxV6rnS7c/JfYbDSU0y6WpbbredB5cCpLFGJEqYX40WUmxMkwhWCjw==",
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.59.0.tgz",
+      "integrity": "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg==",
       "cpu": [
         "loong64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.34.6.tgz",
-      "integrity": "sha512-Zsrtux3PuaxuBTX/zHdLaFmcofWGzaWW1scwLU3ZbW/X+hSsFbz9wDIp6XvnT7pzYRl9MezWqEqKy7ssmDEnuQ==",
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.59.0.tgz",
+      "integrity": "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.59.0.tgz",
+      "integrity": "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA==",
       "cpu": [
         "ppc64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.59.0.tgz",
+      "integrity": "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.34.6.tgz",
-      "integrity": "sha512-aK+Zp+CRM55iPrlyKiU3/zyhgzWBxLVrw2mwiQSYJRobCURb781+XstzvA8Gkjg/hbdQFuDw44aUOxVQFycrAg==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.59.0.tgz",
+      "integrity": "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg==",
       "cpu": [
         "riscv64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.59.0.tgz",
+      "integrity": "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.34.6.tgz",
-      "integrity": "sha512-WoKLVrY9ogmaYPXwTH326+ErlCIgMmsoRSx6bO+l68YgJnlOXhygDYSZe/qbUJCSiCiZAQ+tKm88NcWuUXqOzw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.59.0.tgz",
+      "integrity": "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w==",
       "cpu": [
         "s390x"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.34.6.tgz",
-      "integrity": "sha512-Sht4aFvmA4ToHd2vFzwMFaQCiYm2lDFho5rPcvPBT5pCdC+GwHG6CMch4GQfmWTQ1SwRKS0dhDYb54khSrjDWw==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
     "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.34.6.tgz",
-      "integrity": "sha512-zmmpOQh8vXc2QITsnCiODCDGXFC8LMi64+/oPpPx5qz3pqv0s6x46ps4xoycfUiVZps5PFn1gksZzo4RGTKT+A==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.59.0.tgz",
+      "integrity": "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "linux"
       ]
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.34.6.tgz",
-      "integrity": "sha512-3/q1qUsO/tLqGBaD4uXsB6coVGB3usxw3qyeVb59aArCgedSF66MPdgRStUd7vbZOsko/CgVaY5fo2vkvPLWiA==",
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.59.0.tgz",
+      "integrity": "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.59.0.tgz",
+      "integrity": "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA==",
       "cpu": [
         "arm64"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.59.0.tgz",
+      "integrity": "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.34.6.tgz",
-      "integrity": "sha512-oLHxuyywc6efdKVTxvc0135zPrRdtYVjtVD5GUm55I3ODxhU/PwkQFD97z16Xzxa1Fz0AEe4W/2hzRtd+IfpOA==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.59.0.tgz",
+      "integrity": "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA==",
       "cpu": [
         "ia32"
       ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.59.0.tgz",
+      "integrity": "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
       ]
     },
     "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.34.6.tgz",
-      "integrity": "sha512-0PVwmgzZ8+TZ9oGBmdZoQVXflbvuwzN/HRclujpl4N/q3i+y0lqLw8n1bXA8ru3sApDjlmONaNAuYr38y1Kr9w==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.59.0.tgz",
+      "integrity": "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA==",
       "cpu": [
         "x64"
       ],
+      "license": "MIT",
       "optional": true,
       "os": [
         "win32"
@@ -2087,6 +2485,97 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.0.tgz",
       "integrity": "sha512-+9jVqKhRSpsc591z5vX+X5Yyw+he/HCB4iQ/RYxw35CEPaY1gnsNE43nf9n9AaYjAQrTiI/mOwKUKdUs9vf7Xg=="
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -2123,6 +2612,17 @@
       "integrity": "sha512-WXCyOcRtH37HAUkpXhUduaxdm82b4GSlyTqajXviN4EfiuPgNYR109xMCKvpl6zPIpua0DGlMEDCq+g8EdoheQ==",
       "dependencies": {
         "@babel/types": "^7.20.7"
+      }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
       }
     },
     "node_modules/@types/d3": {
@@ -2347,10 +2847,18 @@
         "@types/d3-selection": "*"
       }
     },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
-      "integrity": "sha512-AYnb1nQyY49te+VRAVgmzfcgjYS91mY5P0TKUDCLEM+gNnA+3T6rWITXRLYCpahpqSQbN5cE+gHpnPyXjHWxcw=="
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "license": "MIT"
     },
     "node_modules/@types/geojson": {
       "version": "7946.0.14",
@@ -2358,13 +2866,14 @@
       "integrity": "sha512-WCfD5Ht3ZesJUsONdhvm84dmzWOiOzOAqOncN0++w0lBw1o8OuDNJF2McvvCef/yBqb/HYRahp1BYtODFQ8bRg=="
     },
     "node_modules/@types/node": {
-      "version": "20.11.30",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.11.30.tgz",
-      "integrity": "sha512-dHM6ZxwlmuZaRmUPfv1p+KrdD1Dci04FbdEm/9wEMouFqxYoFl5aMkt0VMAUtYRQDyYvD41WJLukhq/ha3YuTw==",
+      "version": "25.3.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.3.3.tgz",
+      "integrity": "sha512-DpzbrH7wIcBaJibpKo9nnSQL0MTRdnWttGyE5haGwK86xgMOkFLp7vEyfQPGLOJh5wNYiJ3V9PmUMDhV9u8kkQ==",
+      "license": "MIT",
       "optional": true,
       "peer": true,
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/prop-types": {
@@ -2427,6 +2936,90 @@
         "vite": "^4.2.0 || ^5.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.0.18.tgz",
+      "integrity": "sha512-8sCWUyckXXYvx4opfzVY03EOiYVxyNrHS5QxX3DAIi5dpJAAkyJezHCP77VMX4HKA2LDT/Jpfo8i2r5BE3GnQQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.0.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "chai": "^6.2.1",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.0.18.tgz",
+      "integrity": "sha512-P24GK3GulZWC5tz87ux0m8OADrQIUVDPIjjj65vBXYG17ZeU3qD7r+MNZ1RNv4l8CGU2vtTRqixrOi9fYk/yKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.0.18.tgz",
+      "integrity": "sha512-rpk9y12PGa22Jg6g5M3UVVnTS7+zycIGk9ZNGN+m6tZHKQb7jrP7/77WfZy13Y/EUDd52NDsLRQhYKtv7XfPQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.0.18",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.0.18.tgz",
+      "integrity": "sha512-PCiV0rcl7jKQjbgYqjtakly6T1uwv/5BQ9SwBLekVg/EaYeQFPiXcgrC2Y7vDMA8dM1SUEAEV82kgSQIlXNMvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.0.18.tgz",
+      "integrity": "sha512-cbQt3PTSD7P2OARdVW3qWER5EGq7PHlvE+QfzSC0lbwO+xnt7+XH06ZzFjFRgzUX//JmpxrCu92VdwvEPlWSNw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.0.18.tgz",
+      "integrity": "sha512-msMRKLMVLWygpK3u2Hybgi4MNjcYJvwTb0Ru09+fOyCXIgT5raYP041DRRdiJiI3k/2U6SEbAETB3YtBrUkCFA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.0.18",
+        "tinyrainbow": "^3.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.11.3",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.11.3.tgz",
@@ -2446,6 +3039,16 @@
       "dev": true,
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/ajv": {
@@ -2471,6 +3074,20 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/any-promise": {
@@ -2510,6 +3127,16 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/array-buffer-byte-length": {
@@ -2651,6 +3278,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -2735,6 +3372,16 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/binary-extensions": {
@@ -2876,6 +3523,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
@@ -2986,6 +3643,27 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cssesc": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
@@ -2997,6 +3675,32 @@
       },
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.1.0.tgz",
+      "integrity": "sha512-Ml4fP2UT2K3CUBQnVlbdV/8aFDdlY69E+YnwJM+3VUWl08S3J8c8aRuJqCkD9Py8DHZ7zNNvsfKl8psocHZEFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^5.0.0",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.6"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.6",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.6.tgz",
+      "integrity": "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/csstype": {
@@ -3102,6 +3806,20 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+      "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/data-view-buffer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.1.tgz",
@@ -3169,6 +3887,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -3217,6 +3942,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-node-es": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
@@ -3248,6 +3983,14 @@
       "engines": {
         "node": ">=6.0.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3287,6 +4030,19 @@
       "integrity": "sha512-RcyUFKA93/CXH20l4SoVvzZfrSDMOTUS3bWVpTt2FuFP+XYrL8i8oonHP7WInRyVHXh0n/ORtoeiE1os+8qkSw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-abstract": {
@@ -3390,6 +4146,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -3890,6 +4653,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -3897,6 +4670,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -4332,6 +5115,47 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
@@ -4373,6 +5197,16 @@
       "dev": true,
       "engines": {
         "node": ">=0.8.19"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/inflight": {
@@ -4636,6 +5470,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-regex": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.4.tgz",
@@ -4798,6 +5639,47 @@
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
     },
+    "node_modules/jsdom": {
+      "version": "28.1.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+      "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.31",
+        "@asamuzakjp/dom-selector": "^6.8.1",
+        "@bramus/specificity": "^2.4.2",
+        "@exodus/bytes": "^1.11.0",
+        "cssstyle": "^6.0.1",
+        "data-urls": "^7.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "undici": "^7.21.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.1",
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^16.0.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -4928,6 +5810,27 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -4936,6 +5839,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -4978,6 +5888,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -5164,6 +6084,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -5217,6 +6148,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -5249,6 +6193,13 @@
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -5481,6 +6432,22 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
     "node_modules/prop-types": {
       "version": "15.8.1",
       "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
@@ -5553,6 +6520,14 @@
       "peerDependencies": {
         "react": "^18.2.0"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.14.0",
@@ -5720,6 +6695,20 @@
         }
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/reflect.getprototypeof/-/reflect.getprototypeof-1.0.6.tgz",
@@ -5757,6 +6746,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/resolve": {
@@ -5802,11 +6801,12 @@
       }
     },
     "node_modules/rollup": {
-      "version": "4.34.6",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.34.6.tgz",
-      "integrity": "sha512-wc2cBWqJgkU3Iz5oztRkQbfVkbxoz5EhnCGOrnJvnLnQ7O0WhQUYyv18qQI79O8L7DdHrrlJNeCHd4VGpnaXKQ==",
+      "version": "4.59.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.59.0.tgz",
+      "integrity": "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg==",
+      "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.6"
+        "@types/estree": "1.0.8"
       },
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -5816,25 +6816,31 @@
         "npm": ">=8.0.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.34.6",
-        "@rollup/rollup-android-arm64": "4.34.6",
-        "@rollup/rollup-darwin-arm64": "4.34.6",
-        "@rollup/rollup-darwin-x64": "4.34.6",
-        "@rollup/rollup-freebsd-arm64": "4.34.6",
-        "@rollup/rollup-freebsd-x64": "4.34.6",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.34.6",
-        "@rollup/rollup-linux-arm-musleabihf": "4.34.6",
-        "@rollup/rollup-linux-arm64-gnu": "4.34.6",
-        "@rollup/rollup-linux-arm64-musl": "4.34.6",
-        "@rollup/rollup-linux-loongarch64-gnu": "4.34.6",
-        "@rollup/rollup-linux-powerpc64le-gnu": "4.34.6",
-        "@rollup/rollup-linux-riscv64-gnu": "4.34.6",
-        "@rollup/rollup-linux-s390x-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-gnu": "4.34.6",
-        "@rollup/rollup-linux-x64-musl": "4.34.6",
-        "@rollup/rollup-win32-arm64-msvc": "4.34.6",
-        "@rollup/rollup-win32-ia32-msvc": "4.34.6",
-        "@rollup/rollup-win32-x64-msvc": "4.34.6",
+        "@rollup/rollup-android-arm-eabi": "4.59.0",
+        "@rollup/rollup-android-arm64": "4.59.0",
+        "@rollup/rollup-darwin-arm64": "4.59.0",
+        "@rollup/rollup-darwin-x64": "4.59.0",
+        "@rollup/rollup-freebsd-arm64": "4.59.0",
+        "@rollup/rollup-freebsd-x64": "4.59.0",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.59.0",
+        "@rollup/rollup-linux-arm-musleabihf": "4.59.0",
+        "@rollup/rollup-linux-arm64-gnu": "4.59.0",
+        "@rollup/rollup-linux-arm64-musl": "4.59.0",
+        "@rollup/rollup-linux-loong64-gnu": "4.59.0",
+        "@rollup/rollup-linux-loong64-musl": "4.59.0",
+        "@rollup/rollup-linux-ppc64-gnu": "4.59.0",
+        "@rollup/rollup-linux-ppc64-musl": "4.59.0",
+        "@rollup/rollup-linux-riscv64-gnu": "4.59.0",
+        "@rollup/rollup-linux-riscv64-musl": "4.59.0",
+        "@rollup/rollup-linux-s390x-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-gnu": "4.59.0",
+        "@rollup/rollup-linux-x64-musl": "4.59.0",
+        "@rollup/rollup-openbsd-x64": "4.59.0",
+        "@rollup/rollup-openharmony-arm64": "4.59.0",
+        "@rollup/rollup-win32-arm64-msvc": "4.59.0",
+        "@rollup/rollup-win32-ia32-msvc": "4.59.0",
+        "@rollup/rollup-win32-x64-gnu": "4.59.0",
+        "@rollup/rollup-win32-x64-msvc": "4.59.0",
         "fsevents": "~2.3.2"
       }
     },
@@ -5900,6 +6906,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -5989,6 +7008,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/socket.io-client": {
       "version": "4.7.5",
       "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.7.5.tgz",
@@ -6022,6 +7048,20 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.11",
@@ -6110,6 +7150,19 @@
         "node": ">=8"
       }
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -6156,6 +7209,13 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwind-merge": {
       "version": "3.5.0",
@@ -6244,6 +7304,23 @@
         "node": ">=0.8"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.2.tgz",
+      "integrity": "sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -6292,6 +7369,36 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/tinyrainbow": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.0.3.tgz",
+      "integrity": "sha512-PSkbLUoxOFRzJYjjxHJt9xro7D+iilgMX/C9lawzVuYiIdcihh9DXmVibBe8lmcFrRi/VzlPjBxbN7rH24q8/Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.23.tgz",
+      "integrity": "sha512-ASdhgQIBSay0R/eXggAkQ53G4nTJqTXqC2kbaBbdDwM7SkjyZyO0OaaN1/FH7U/yCeqOHDwFO5j8+Os/IS1dXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.23"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.23",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.23.tgz",
+      "integrity": "sha512-0g9vrtDQLrNIiCj22HSe9d4mLVG3g5ph5DZ8zCKBr4OtrspmNB6ss7hVyzArAeE88ceZocIEGkyW1Ime7fxPtQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
@@ -6302,6 +7409,32 @@
       },
       "engines": {
         "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-interface-checker": {
@@ -6417,10 +7550,21 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/undici": {
+      "version": "7.22.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.22.0.tgz",
+      "integrity": "sha512-RqslV2Us5BrllB+JeiZnK4peryVTndy9Dnqq62S3yYRRTj0tFQCwEniUy2167skdGOy3vqRzEvl1Dm4sV2ReDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT",
       "optional": true,
       "peer": true
     },
@@ -6579,6 +7723,698 @@
         }
       }
     },
+    "node_modules/vitest": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.0.18.tgz",
+      "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.0.18",
+        "@vitest/mocker": "4.0.18",
+        "@vitest/pretty-format": "4.0.18",
+        "@vitest/runner": "4.0.18",
+        "@vitest/snapshot": "4.0.18",
+        "@vitest/spy": "4.0.18",
+        "@vitest/utils": "4.0.18",
+        "es-module-lexer": "^1.7.0",
+        "expect-type": "^1.2.2",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^3.10.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.0.3",
+        "vite": "^6.0.0 || ^7.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.0.18",
+        "@vitest/browser-preview": "4.0.18",
+        "@vitest/browser-webdriverio": "4.0.18",
+        "@vitest/ui": "4.0.18",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/android-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/linux-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@esbuild/win32-x64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vitest/node_modules/@vitest/mocker": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.0.18.tgz",
+      "integrity": "sha512-HhVd0MDnzzsgevnOWCBj5Otnzobjy5wLBe4EdeeFGv8luMsGcYqDuFRMcttKWZA5vVO8RFjexVovXvAM4JoJDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.0.18",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/esbuild": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
+      }
+    },
+    "node_modules/vitest/node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/vitest/node_modules/vite": {
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
+      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.27.0",
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3",
+        "postcss": "^8.5.6",
+        "rollup": "^4.43.0",
+        "tinyglobby": "^0.2.15"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^20.19.0 || >=22.12.0",
+        "jiti": ">=1.21.0",
+        "less": "^4.0.0",
+        "lightningcss": "^1.21.0",
+        "sass": "^1.70.0",
+        "sass-embedded": "^1.70.0",
+        "stylus": ">=0.54.8",
+        "sugarss": "^5.0.0",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "16.0.1",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+      "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.11.0",
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.1"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -6679,6 +8515,23 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
@@ -6704,6 +8557,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/xmlhttprequest-ssl": {
       "version": "2.0.0",

--- a/tensormap-frontend/package.json
+++ b/tensormap-frontend/package.json
@@ -29,7 +29,8 @@
     "preview": "vite preview",
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext js,jsx --fix",
-    "prettier": "prettier . --write"
+    "prettier": "prettier . --write",
+    "test": "vitest run"
   },
   "browserslist": {
     "production": [
@@ -44,16 +45,20 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "autoprefixer": "^10.4.24",
     "eslint": "^8.57.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-react": "^7.34.1",
     "eslint-plugin-react-hooks": "^4.6.0",
     "eslint-plugin-react-refresh": "^0.4.6",
+    "jsdom": "^28.1.0",
     "postcss": "^8.5.6",
     "prettier": "^3.2.5",
     "tailwindcss": "^3.4.19",
     "tailwindcss-animate": "^1.0.7",
-    "vite": "^5.4.14"
+    "vite": "^5.4.14",
+    "vitest": "^4.0.18"
   }
 }

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -104,8 +104,16 @@ function Canvas() {
     edgesRef,
   );
 
+  /**
+   * Guard flag that suppresses snapshot-taking while undo/redo is restoring
+   * state. Set synchronously before calling undo/redo and cleared in a
+   * useEffect after the React render cycle completes.
+   */
   const isRestoringRef = useRef(false);
 
+  // Reset the restoring flag after each render so that subsequent
+  // onNodesChange / onEdgesChange callbacks triggered by the state update
+  // are no longer suppressed.
   useEffect(() => {
     isRestoringRef.current = false;
   });
@@ -162,9 +170,11 @@ function Canvas() {
     return () => document.removeEventListener("keydown", handleKeyDown, true);
   }, []);
 
+  // Auto-load the project's first saved model or draft on mount
   useEffect(() => {
     let cancelled = false;
     async function loadModel() {
+      // 1. Try loading from draft first
       try {
         const draftStr = localStorage.getItem(draftKey);
         if (draftStr) {
@@ -184,6 +194,7 @@ function Canvas() {
         logger.error("Failed to load draft:", e);
       }
 
+      // 2. Fallback to loading from DB
       try {
         const modelObjects = await getAllModels(projectId);
         if (cancelled || !modelObjects || modelObjects.length === 0) {
@@ -218,6 +229,7 @@ function Canvas() {
           setModelName(model_name);
           isLoaded.current = true;
 
+          // Populate the global model list from the fetched models
           setModelList(
             modelObjects.map((m, i) => ({
               label: m.model_name + strings.MODEL_EXTENSION,
@@ -238,6 +250,7 @@ function Canvas() {
     };
   }, [projectId, setNodes, setEdges, setModelList, draftKey]);
 
+  // Handle debounced saving of draft
   useEffect(() => {
     if (!isLoaded.current) return;
 
@@ -306,10 +319,19 @@ function Canvas() {
     [onEdgesChange, takeSnapshotAndUpdate],
   );
 
+  /**
+   * Track per-node start positions for drag operations. On the first
+   * onNodeDragStart in a gesture we capture a single snapshot of the
+   * canvas state (snapshotNodes / snapshotEdges) and begin recording
+   * each dragged node's original position. On each onNodeDragStop we
+   * remove the node from the map and, once all nodes have been dropped,
+   * commit the snapshot only if at least one node actually moved.
+   */
   const dragStartStateRef = useRef(null);
 
   const onNodeDragStart = useCallback((_event, node) => {
     if (!dragStartStateRef.current) {
+      // First node in this drag gesture — capture canvas snapshot
       dragStartStateRef.current = {
         snapshotNodes: nodesRef.current,
         snapshotEdges: edgesRef.current,
@@ -334,6 +356,7 @@ function Canvas() {
         delete state.starts[node.id];
       }
 
+      // All dragged nodes have been dropped
       if (Object.keys(state.starts).length === 0) {
         if (state.moved) {
           takeSnapshotAndUpdate(state.snapshotNodes, state.snapshotEdges);
@@ -434,6 +457,7 @@ function Canvas() {
           } catch (e) {
             logger.error("Failed to clear draft on save:", e);
           }
+          // Re-fetch the model list so the new entry has its DB id
           getAllModels(projectId)
             .then((modelObjects) => {
               setModelList(

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -1,5 +1,15 @@
 import { useState, useRef, useCallback, useEffect } from "react";
 import { useParams } from "react-router-dom";
+import { Trash2, Undo2, Redo2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import ReactFlow, {
   ReactFlowProvider,
   addEdge,
@@ -10,7 +20,6 @@ import ReactFlow, {
   BackgroundVariant,
   Panel,
 } from "reactflow";
-import { Button } from "@/components/ui/button";
 import { useRecoilState } from "recoil";
 import * as strings from "../../constants/Strings";
 import logger from "../../shared/logger";
@@ -20,18 +29,31 @@ import InputNode from "./CustomNodes/InputNode/InputNode";
 import DenseNode from "./CustomNodes/DenseNode/DenseNode";
 import FlattenNode from "./CustomNodes/FlattenNode/FlattenNode";
 import ConvNode from "./CustomNodes/ConvNode/ConvNode";
+import DropoutNode from "./CustomNodes/DropoutNode/DropoutNode";
+import BatchNormalizationNode from "./CustomNodes/BatchNormalizationNode/BatchNormalizationNode";
 import Sidebar from "./Sidebar";
 import NodePropertiesPanel from "./NodePropertiesPanel";
 import { canSaveModel, generateModelJSON } from "./Helpers";
+import ModelSummaryPanel from "./ModelSummaryPanel";
 import { getAllModels, getModelGraph, saveModel } from "../../services/ModelServices";
 import { models as allModels } from "../../shared/atoms";
 import ContextMenu from "./ContextMenu";
+import useUndoRedo from "../../hooks/useUndoRedo";
+
+const isMac =
+  typeof navigator !== "undefined"
+    ? navigator.userAgentData
+      ? navigator.userAgentData.platform.toLowerCase().includes("mac")
+      : /Mac/i.test(navigator.platform)
+    : false;
 
 const nodeTypes = {
   custominput: InputNode,
   customdense: DenseNode,
   customflatten: FlattenNode,
   customconv: ConvNode,
+  customdropout: DropoutNode,
+  custombatchnorm: BatchNormalizationNode,
 };
 
 function Canvas() {
@@ -43,6 +65,7 @@ function Canvas() {
   const [reactFlowInstance, setReactFlowInstance] = useState(null);
   const [modelName, setModelName] = useState("");
   const [selectedNodeId, setSelectedNodeId] = useState(null);
+  const [modelSummary, setModelSummary] = useState(null);
   const [feedbackDialog, setFeedbackDialog] = useState({
     open: false,
     success: false,
@@ -50,6 +73,7 @@ function Canvas() {
     detail: "",
   });
   const [contextMenu, setContextMenu] = useState({ nodeId: null, x: 0, y: 0 });
+  const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
   const defaultViewport = { x: 10, y: 15, zoom: 0.5 };
 
   const draftKey = `tensormap_draft_${projectId || "default"}`;
@@ -61,6 +85,90 @@ function Canvas() {
       return false;
     }
   });
+
+  const nodesRef = useRef(nodes);
+  const edgesRef = useRef(edges);
+
+  useEffect(() => {
+    nodesRef.current = nodes;
+  }, [nodes]);
+
+  useEffect(() => {
+    edgesRef.current = edges;
+  }, [edges]);
+
+  const { takeSnapshot, undo, redo, canUndo, canRedo } = useUndoRedo(
+    setNodes,
+    setEdges,
+    nodesRef,
+    edgesRef,
+  );
+
+  /**
+   * Guard flag that suppresses snapshot-taking while undo/redo is restoring
+   * state. Set synchronously before calling undo/redo and cleared in a
+   * useEffect after the React render cycle completes.
+   */
+  const isRestoringRef = useRef(false);
+
+  // Reset the restoring flag after each render so that subsequent
+  // onNodesChange / onEdgesChange callbacks triggered by the state update
+  // are no longer suppressed.
+  useEffect(() => {
+    isRestoringRef.current = false;
+  });
+
+  const takeSnapshotAndUpdate = useCallback(
+    (currentNodes, currentEdges) => {
+      if (isRestoringRef.current) return;
+      takeSnapshot(currentNodes, currentEdges);
+    },
+    [takeSnapshot],
+  );
+
+  const performUndo = useCallback(() => {
+    isRestoringRef.current = true;
+    undo();
+  }, [undo]);
+
+  const performRedo = useCallback(() => {
+    isRestoringRef.current = true;
+    redo();
+  }, [redo]);
+
+  const undoRef = useRef(performUndo);
+  const redoRef = useRef(performRedo);
+
+  useEffect(() => {
+    undoRef.current = performUndo;
+    redoRef.current = performRedo;
+  }, [performUndo, performRedo]);
+
+  useEffect(() => {
+    const handleKeyDown = (event) => {
+      const el = document.activeElement;
+      const tag = el?.tagName;
+      if (tag === "INPUT" || tag === "TEXTAREA" || el?.isContentEditable) return;
+
+      const modKey = isMac ? event.metaKey : event.ctrlKey;
+
+      if (modKey && !event.shiftKey && event.code === "KeyZ") {
+        event.preventDefault();
+        event.stopPropagation();
+        undoRef.current();
+      } else if (
+        (modKey && event.code === "KeyY") ||
+        (modKey && event.shiftKey && event.code === "KeyZ")
+      ) {
+        event.preventDefault();
+        event.stopPropagation();
+        redoRef.current();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown, true);
+    return () => document.removeEventListener("keydown", handleKeyDown, true);
+  }, []);
 
   // Auto-load the project's first saved model or draft on mount
   useEffect(() => {
@@ -88,13 +196,13 @@ function Canvas() {
 
       // 2. Fallback to loading from DB
       try {
-        const modelNames = await getAllModels(projectId);
-        if (cancelled || !modelNames || modelNames.length === 0) {
+        const modelObjects = await getAllModels(projectId);
+        if (cancelled || !modelObjects || modelObjects.length === 0) {
           if (!cancelled) isLoaded.current = true;
           return;
         }
 
-        const result = await getModelGraph(modelNames[0], projectId);
+        const result = await getModelGraph(modelObjects[0].model_name, projectId);
         if (cancelled || !result.success) {
           if (!cancelled) isLoaded.current = true;
           return;
@@ -120,6 +228,16 @@ function Canvas() {
           setEdges(loadedEdges);
           setModelName(model_name);
           isLoaded.current = true;
+
+          // Populate the global model list from the fetched models
+          setModelList(
+            modelObjects.map((m, i) => ({
+              label: m.model_name + strings.MODEL_EXTENSION,
+              value: m.model_name,
+              id: m.id,
+              key: i,
+            })),
+          );
         }
       } catch (err) {
         logger.error("Failed to auto-load model:", err);
@@ -130,7 +248,7 @@ function Canvas() {
     return () => {
       cancelled = true;
     };
-  }, [projectId, setNodes, setEdges, draftKey]);
+  }, [projectId, setNodes, setEdges, setModelList, draftKey]);
 
   // Handle debounced saving of draft
   useEffect(() => {
@@ -170,17 +288,92 @@ function Canvas() {
     setModelName("");
   }, [draftKey, setNodes, setEdges]);
 
-  const onConnect = useCallback((params) => setEdges((eds) => addEdge(params, eds)), [setEdges]);
+  const onConnect = useCallback(
+    (params) => {
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      setEdges((eds) => addEdge(params, eds));
+    },
+    [setEdges, takeSnapshotAndUpdate],
+  );
+
+  const handleNodesChange = useCallback(
+    (changes) => {
+      const hasRemoval = changes.some((c) => c.type === "remove");
+      const hasKeyboardMove = changes.some((c) => c.type === "position" && !c.dragging);
+      if (hasRemoval || hasKeyboardMove) {
+        takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      }
+      onNodesChange(changes);
+    },
+    [onNodesChange, takeSnapshotAndUpdate],
+  );
+
+  const handleEdgesChange = useCallback(
+    (changes) => {
+      const hasRemoval = changes.some((change) => change.type === "remove");
+      if (hasRemoval) {
+        takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+      }
+      onEdgesChange(changes);
+    },
+    [onEdgesChange, takeSnapshotAndUpdate],
+  );
+
+  /**
+   * Track per-node start positions for drag operations. On the first
+   * onNodeDragStart in a gesture we capture a single snapshot of the
+   * canvas state (snapshotNodes / snapshotEdges) and begin recording
+   * each dragged node's original position. On each onNodeDragStop we
+   * remove the node from the map and, once all nodes have been dropped,
+   * commit the snapshot only if at least one node actually moved.
+   */
+  const dragStartStateRef = useRef(null);
+
+  const onNodeDragStart = useCallback((_event, node) => {
+    if (!dragStartStateRef.current) {
+      // First node in this drag gesture — capture canvas snapshot
+      dragStartStateRef.current = {
+        snapshotNodes: nodesRef.current,
+        snapshotEdges: edgesRef.current,
+        starts: {},
+      };
+    }
+    dragStartStateRef.current.starts[node.id] = { ...node.position };
+  }, []);
+
+  const onNodeDragStop = useCallback(
+    (_event, node) => {
+      const state = dragStartStateRef.current;
+      if (!state) return;
+
+      const startPos = state.starts[node.id];
+      if (startPos) {
+        const dx = Math.abs(node.position.x - startPos.x);
+        const dy = Math.abs(node.position.y - startPos.y);
+        if (dx > 0.5 || dy > 0.5) {
+          state.moved = true;
+        }
+        delete state.starts[node.id];
+      }
+
+      // All dragged nodes have been dropped
+      if (Object.keys(state.starts).length === 0) {
+        if (state.moved) {
+          takeSnapshotAndUpdate(state.snapshotNodes, state.snapshotEdges);
+        }
+        dragStartStateRef.current = null;
+      }
+    },
+    [takeSnapshotAndUpdate],
+  );
 
   const onDragOver = useCallback((event) => {
     event.preventDefault();
     event.dataTransfer.dropEffect = "move";
   }, []);
 
-  const modelData =
-    reactFlowInstance === null ? { nodes: [], edges: [] } : reactFlowInstance.toObject();
-
   const selectedNode = selectedNodeId ? nodes.find((n) => n.id === selectedNodeId) : null;
+  const canSave = canSaveModel(modelName, { nodes, edges });
 
   const onNodeClick = useCallback((_event, node) => {
     setSelectedNodeId(node.id);
@@ -201,6 +394,7 @@ function Canvas() {
   }, []);
 
   const duplicateNode = useCallback(() => {
+    takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
     setNodes((nds) => {
       const source = nds.find((n) => n.id === contextMenu.nodeId);
       if (!source) return nds;
@@ -213,10 +407,11 @@ function Canvas() {
       return nds.concat(duplicate);
     });
     closeContextMenu();
-  }, [contextMenu.nodeId, setNodes, closeContextMenu]);
+  }, [contextMenu.nodeId, setNodes, closeContextMenu, takeSnapshotAndUpdate]);
 
   const onNodeUpdate = useCallback(
     (nodeId, newParams) => {
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
       setNodes((nds) =>
         nds.map((node) => {
           if (node.id === nodeId) {
@@ -226,12 +421,21 @@ function Canvas() {
         }),
       );
     },
-    [setNodes],
+    [setNodes, takeSnapshotAndUpdate],
   );
 
   const closeFeedback = () => {
     setFeedbackDialog((prev) => ({ ...prev, open: false }));
   };
+
+  const handleClearAll = useCallback(() => {
+    takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+    setNodes([]);
+    setEdges([]);
+    setModelName("");
+    setSelectedNodeId(null);
+    setClearConfirmOpen(false);
+  }, [setNodes, setEdges, takeSnapshotAndUpdate]);
 
   const modelSaveHandler = () => {
     const data = {
@@ -246,20 +450,26 @@ function Canvas() {
     saveModel(data)
       .then((resp) => {
         if (resp.success) {
+          setModelSummary(resp.data?.summary || null);
           try {
             localStorage.removeItem(draftKey);
             setHasDraft(false);
           } catch (e) {
             logger.error("Failed to clear draft on save:", e);
           }
-          setModelList((prevList) => [
-            ...prevList,
-            {
-              label: modelName + strings.MODEL_EXTENSION,
-              value: modelName,
-              key: prevList.length + 1,
-            },
-          ]);
+          // Re-fetch the model list so the new entry has its DB id
+          getAllModels(projectId)
+            .then((modelObjects) => {
+              setModelList(
+                modelObjects.map((m, i) => ({
+                  label: m.model_name + strings.MODEL_EXTENSION,
+                  value: m.model_name,
+                  id: m.id,
+                  key: i,
+                })),
+              );
+            })
+            .catch(() => {});
         }
         setFeedbackDialog({
           open: true,
@@ -272,6 +482,7 @@ function Canvas() {
       })
       .catch((error) => {
         logger.error(error);
+        setModelSummary(null);
         setFeedbackDialog({
           open: true,
           success: false,
@@ -310,6 +521,8 @@ function Canvas() {
           kernelX: "",
           kernelY: "",
         },
+        customdropout: { rate: "" },
+        custombatchnorm: { momentum: "0.99", epsilon: "0.001" },
       };
 
       const newNode = {
@@ -319,9 +532,10 @@ function Canvas() {
         data: { label: `${type} node`, params: defaultParams[type] || {} },
       };
 
+      takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
       setNodes((nds) => nds.concat(newNode));
     },
-    [reactFlowInstance, setNodes],
+    [reactFlowInstance, setNodes, takeSnapshotAndUpdate],
   );
 
   return (
@@ -333,41 +547,97 @@ function Canvas() {
         message={feedbackDialog.message}
         detail={feedbackDialog.detail}
       />
+      <Dialog open={clearConfirmOpen} onOpenChange={setClearConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Clear canvas</DialogTitle>
+            <DialogDescription>
+              This will remove all {nodes.length} node{nodes.length !== 1 ? "s" : ""} and their
+              connections. You can undo this with {isMac ? "⌘Z" : "Ctrl+Z"}.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setClearConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleClearAll}>
+              Clear All
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <div className="flex gap-4">
         <ReactFlowProvider>
           <Sidebar />
-          <div className="h-[62vh] flex-1" ref={reactFlowWrapper}>
-            <ReactFlow
-              nodes={nodes}
-              edges={edges}
-              onNodesChange={onNodesChange}
-              onEdgesChange={onEdgesChange}
-              onConnect={onConnect}
-              onInit={setReactFlowInstance}
-              onDrop={onDrop}
-              onDragOver={onDragOver}
-              onNodeClick={onNodeClick}
-              onPaneClick={onPaneClick}
-              onNodeContextMenu={onNodeContextMenu}
-              nodeTypes={nodeTypes}
-              defaultViewport={defaultViewport}
-            >
-              <Controls />
-              {hasDraft && (
-                <Panel position="top-right">
-                  <Button variant="destructive" onClick={handleDiscardDraft}>
-                    Discard Draft
+          <div className="flex flex-col flex-1 gap-2">
+            <div className="flex justify-end">
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={nodes.length === 0}
+                onClick={() => setClearConfirmOpen(true)}
+              >
+                <Trash2 className="mr-2 h-4 w-4" />
+                Clear All
+              </Button>
+            </div>
+            <div className="min-w-0 h-[62vh] flex-1 rounded-md border" ref={reactFlowWrapper}>
+              <ReactFlow
+                nodes={nodes}
+                edges={edges}
+                onNodesChange={handleNodesChange}
+                onEdgesChange={handleEdgesChange}
+                onConnect={onConnect}
+                onInit={setReactFlowInstance}
+                onDrop={onDrop}
+                onDragOver={onDragOver}
+                onNodeClick={onNodeClick}
+                onPaneClick={onPaneClick}
+                onNodeContextMenu={onNodeContextMenu}
+                onNodeDragStart={onNodeDragStart}
+                onNodeDragStop={onNodeDragStop}
+                nodeTypes={nodeTypes}
+                defaultViewport={defaultViewport}
+              >
+                <Panel position="top-left" className="flex gap-1">
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={performUndo}
+                    disabled={!canUndo}
+                    title={`Undo (${isMac ? "⌘Z" : "Ctrl+Z"})`}
+                    className="h-8 w-8"
+                  >
+                    <Undo2 className="h-4 w-4" />
+                  </Button>
+                  <Button
+                    variant="outline"
+                    size="icon"
+                    onClick={performRedo}
+                    disabled={!canRedo}
+                    title={`Redo (${isMac ? "⌘⇧Z" : "Ctrl+Y"})`}
+                    className="h-8 w-8"
+                  >
+                    <Redo2 className="h-4 w-4" />
                   </Button>
                 </Panel>
-              )}
-              <Background
-                id="1"
-                gap={10}
-                color="#e5e5e5"
-                style={{ backgroundColor: "#fafafa" }}
-                variant={BackgroundVariant.Dots}
-              />
-            </ReactFlow>
+                <Controls />
+                {hasDraft && (
+                  <Panel position="top-right">
+                    <Button variant="destructive" onClick={handleDiscardDraft}>
+                      Discard Draft
+                    </Button>
+                  </Panel>
+                )}
+                <Background
+                  id="1"
+                  gap={10}
+                  color="#e5e5e5"
+                  style={{ backgroundColor: "#fafafa" }}
+                  variant={BackgroundVariant.Dots}
+                />
+              </ReactFlow>
+            </div>
           </div>
           {contextMenu.nodeId && (
             <ContextMenu
@@ -377,18 +647,19 @@ function Canvas() {
               onClose={closeContextMenu}
             />
           )}
-          <div className="w-64 shrink-0">
+          <div className="w-72 shrink-0">
             <NodePropertiesPanel
               selectedNode={selectedNode || null}
               modelName={modelName}
               onModelNameChange={setModelName}
               onSave={modelSaveHandler}
-              canSave={canSaveModel(modelName, modelData)}
+              canSave={canSave}
               onNodeUpdate={onNodeUpdate}
             />
           </div>
         </ReactFlowProvider>
       </div>
+      <ModelSummaryPanel summary={modelSummary} onClose={() => setModelSummary(null)} />
     </>
   );
 }

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -104,16 +104,8 @@ function Canvas() {
     edgesRef,
   );
 
-  /**
-   * Guard flag that suppresses snapshot-taking while undo/redo is restoring
-   * state. Set synchronously before calling undo/redo and cleared in a
-   * useEffect after the React render cycle completes.
-   */
   const isRestoringRef = useRef(false);
 
-  // Reset the restoring flag after each render so that subsequent
-  // onNodesChange / onEdgesChange callbacks triggered by the state update
-  // are no longer suppressed.
   useEffect(() => {
     isRestoringRef.current = false;
   });
@@ -170,11 +162,9 @@ function Canvas() {
     return () => document.removeEventListener("keydown", handleKeyDown, true);
   }, []);
 
-  // Auto-load the project's first saved model or draft on mount
   useEffect(() => {
     let cancelled = false;
     async function loadModel() {
-      // 1. Try loading from draft first
       try {
         const draftStr = localStorage.getItem(draftKey);
         if (draftStr) {
@@ -194,7 +184,6 @@ function Canvas() {
         logger.error("Failed to load draft:", e);
       }
 
-      // 2. Fallback to loading from DB
       try {
         const modelObjects = await getAllModels(projectId);
         if (cancelled || !modelObjects || modelObjects.length === 0) {
@@ -229,7 +218,6 @@ function Canvas() {
           setModelName(model_name);
           isLoaded.current = true;
 
-          // Populate the global model list from the fetched models
           setModelList(
             modelObjects.map((m, i) => ({
               label: m.model_name + strings.MODEL_EXTENSION,
@@ -250,7 +238,6 @@ function Canvas() {
     };
   }, [projectId, setNodes, setEdges, setModelList, draftKey]);
 
-  // Handle debounced saving of draft
   useEffect(() => {
     if (!isLoaded.current) return;
 
@@ -319,19 +306,10 @@ function Canvas() {
     [onEdgesChange, takeSnapshotAndUpdate],
   );
 
-  /**
-   * Track per-node start positions for drag operations. On the first
-   * onNodeDragStart in a gesture we capture a single snapshot of the
-   * canvas state (snapshotNodes / snapshotEdges) and begin recording
-   * each dragged node's original position. On each onNodeDragStop we
-   * remove the node from the map and, once all nodes have been dropped,
-   * commit the snapshot only if at least one node actually moved.
-   */
   const dragStartStateRef = useRef(null);
 
   const onNodeDragStart = useCallback((_event, node) => {
     if (!dragStartStateRef.current) {
-      // First node in this drag gesture — capture canvas snapshot
       dragStartStateRef.current = {
         snapshotNodes: nodesRef.current,
         snapshotEdges: edgesRef.current,
@@ -356,7 +334,6 @@ function Canvas() {
         delete state.starts[node.id];
       }
 
-      // All dragged nodes have been dropped
       if (Object.keys(state.starts).length === 0) {
         if (state.moved) {
           takeSnapshotAndUpdate(state.snapshotNodes, state.snapshotEdges);
@@ -457,7 +434,6 @@ function Canvas() {
           } catch (e) {
             logger.error("Failed to clear draft on save:", e);
           }
-          // Re-fetch the model list so the new entry has its DB id
           getAllModels(projectId)
             .then((modelObjects) => {
               setModelList(

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/BatchNormalizationNode/BatchNormalizationNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/BatchNormalizationNode/BatchNormalizationNode.jsx
@@ -1,0 +1,32 @@
+import PropTypes from "prop-types";
+import { Handle, Position } from "reactflow";
+
+function BatchNormalizationNode({ data, id }) {
+  const p = data.params;
+  const summary = [p.momentum ? `Mom: ${p.momentum}` : null, p.epsilon ? `ε: ${p.epsilon}` : null]
+    .filter(Boolean)
+    .join(", ");
+
+  return (
+    <div className="w-44 rounded-lg border bg-white shadow-sm">
+      <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
+      <div className="rounded-t-lg bg-node-batchnorm px-3 py-1.5 text-xs font-bold text-white">
+        BatchNorm
+      </div>
+      <div className="px-3 py-2 text-xs text-muted-foreground">{summary || "Not configured"}</div>
+      <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />
+    </div>
+  );
+}
+
+BatchNormalizationNode.propTypes = {
+  data: PropTypes.shape({
+    params: PropTypes.shape({
+      momentum: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      epsilon: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }).isRequired,
+  }).isRequired,
+  id: PropTypes.string.isRequired,
+};
+
+export default BatchNormalizationNode;

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/BatchNormalizationNode/BatchNormalizationNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/BatchNormalizationNode/BatchNormalizationNode.test.jsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "reactflow";
+import BatchNormalizationNode from "./BatchNormalizationNode";
+
+const renderNode = (params = {}) =>
+  render(
+    <ReactFlowProvider>
+      <BatchNormalizationNode
+        id="bn-test"
+        data={{ params: { momentum: 0.99, epsilon: 0.001, ...params } }}
+      />
+    </ReactFlowProvider>,
+  );
+
+describe("BatchNormalizationNode", () => {
+  it("renders the BatchNorm label", () => {
+    renderNode();
+    expect(screen.getByText("BatchNorm")).toBeDefined();
+  });
+
+  it("displays momentum and epsilon when set", () => {
+    renderNode({ momentum: 0.99, epsilon: 0.001 });
+    expect(screen.getByText(/Mom: 0.99/)).toBeDefined();
+  });
+
+  it("shows Not configured when params empty", () => {
+    renderNode({ momentum: "", epsilon: "" });
+    expect(screen.getByText("Not configured")).toBeDefined();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/ConvNode/ConvNode.test.jsx
@@ -1,0 +1,93 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import ConvNode from "./ConvNode";
+
+vi.mock("reactflow", () => ({
+  Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+describe("ConvNode", () => {
+  const defaultProps = {
+    id: "test-node-conv",
+    data: {
+      params: {
+        filter: "",
+        padding: "",
+        activation: "",
+        kernelX: "",
+        kernelY: "",
+        strideX: "",
+        strideY: "",
+      },
+    },
+  };
+
+  it("renders the title correctly", () => {
+    render(<ConvNode {...defaultProps} />);
+    expect(screen.getByText("Conv2D")).toBeInTheDocument();
+  });
+
+  it("displays 'Not configured' when parameters are unconfigured", () => {
+    render(<ConvNode {...defaultProps} />);
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+  });
+
+  it("renders configured state and parameters when all provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          filter: 32,
+          padding: "same",
+          activation: "relu",
+          kernelX: 3,
+          kernelY: 3,
+          strideX: 1,
+          strideY: 1,
+        },
+      },
+    };
+    render(<ConvNode {...configuredProps} />);
+    expect(screen.getByText("F: 32, K: 3×3, S: 1×1, P: same, Act: relu")).toBeInTheDocument();
+  });
+
+  it("ignores 'none' activation", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          filter: 16,
+          activation: "none",
+        },
+      },
+    };
+    render(<ConvNode {...configuredProps} />);
+    expect(screen.getByText("F: 16")).toBeInTheDocument();
+  });
+
+  it("renders configured state when partial parameters are provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          filter: 64,
+          kernelX: 5,
+        }, // kernelY missing, so K: should be missing
+      },
+    };
+    render(<ConvNode {...configuredProps} />);
+    // Since kernelY is missing, only F: 64 is rendered
+    expect(screen.getByText("F: 64")).toBeInTheDocument();
+  });
+
+  it("renders correct ReactFlow handles (source and target)", () => {
+    render(<ConvNode {...defaultProps} />);
+
+    const targetHandle = screen.getByTestId("handle-target-left");
+    expect(targetHandle).toBeInTheDocument();
+
+    const sourceHandle = screen.getByTestId("handle-source-right");
+    expect(sourceHandle).toBeInTheDocument();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DenseNode/DenseNode.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import DenseNode from "./DenseNode";
+
+vi.mock("reactflow", () => ({
+  Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+describe("DenseNode", () => {
+  const defaultProps = {
+    id: "test-node-dense",
+    data: {
+      params: {
+        units: "",
+        activation: "",
+      },
+    },
+  };
+
+  it("renders the title correctly", () => {
+    render(<DenseNode {...defaultProps} />);
+    expect(screen.getByText("Dense")).toBeInTheDocument();
+  });
+
+  it("displays 'Not configured' when parameters are unconfigured", () => {
+    render(<DenseNode {...defaultProps} />);
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+  });
+
+  it("renders configured state and parameters when units and activation are provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          units: 128,
+          activation: "relu",
+        },
+      },
+    };
+    render(<DenseNode {...configuredProps} />);
+    expect(screen.getByText("Units: 128, Act: relu")).toBeInTheDocument();
+  });
+
+  it("renders configured state when only units are provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          units: 64,
+          activation: "",
+        },
+      },
+    };
+    render(<DenseNode {...configuredProps} />);
+    expect(screen.getByText("Units: 64")).toBeInTheDocument();
+  });
+
+  it("renders correct ReactFlow handles (source and target)", () => {
+    render(<DenseNode {...defaultProps} />);
+
+    // Dense node should have a target handle on the left
+    const targetHandle = screen.getByTestId("handle-target-left");
+    expect(targetHandle).toBeInTheDocument();
+
+    // and a source handle on the right
+    const sourceHandle = screen.getByTestId("handle-source-right");
+    expect(sourceHandle).toBeInTheDocument();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DropoutNode/DropoutNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DropoutNode/DropoutNode.jsx
@@ -1,0 +1,29 @@
+import PropTypes from "prop-types";
+import { Handle, Position } from "reactflow";
+
+function DropoutNode({ data, id }) {
+  const { rate } = data.params;
+  return (
+    <div className="w-44 rounded-lg border bg-white shadow-sm">
+      <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
+      <div className="rounded-t-lg bg-node-dropout px-3 py-1.5 text-xs font-bold text-white">
+        Dropout
+      </div>
+      <div className="px-3 py-2 text-xs text-muted-foreground">
+        {rate !== "" && rate !== undefined ? `Rate: ${rate}` : "Not configured"}
+      </div>
+      <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />
+    </div>
+  );
+}
+
+DropoutNode.propTypes = {
+  data: PropTypes.shape({
+    params: PropTypes.shape({
+      rate: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+    }).isRequired,
+  }).isRequired,
+  id: PropTypes.string.isRequired,
+};
+
+export default DropoutNode;

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/FlattenNode/FlattenNode.test.jsx
@@ -1,0 +1,36 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import FlattenNode from "./FlattenNode";
+
+vi.mock("reactflow", () => ({
+  Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+describe("FlattenNode", () => {
+  const defaultProps = {
+    id: "test-node-flatten",
+  };
+
+  it("renders the title correctly", () => {
+    render(<FlattenNode {...defaultProps} />);
+    expect(screen.getByText("Flatten")).toBeInTheDocument();
+  });
+
+  it("displays 'No parameters' correctly", () => {
+    render(<FlattenNode {...defaultProps} />);
+    expect(screen.getByText("No parameters")).toBeInTheDocument();
+  });
+
+  it("renders correct ReactFlow handles (source and target)", () => {
+    render(<FlattenNode {...defaultProps} />);
+
+    // Flatten node should have a target handle on the left
+    const targetHandle = screen.getByTestId("handle-target-left");
+    expect(targetHandle).toBeInTheDocument();
+
+    // and a source handle on the right
+    const sourceHandle = screen.getByTestId("handle-source-right");
+    expect(sourceHandle).toBeInTheDocument();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/InputNode/InputNode.test.jsx
@@ -1,0 +1,73 @@
+import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi } from "vitest";
+import InputNode from "./InputNode";
+
+// Mock reactflow's Handle and Position since we're testing the node purely presentationally.
+vi.mock("reactflow", () => ({
+  Handle: (props) => <div data-testid={`handle-${props.type}-${props.position}`} {...props} />,
+  Position: { Left: "left", Right: "right", Top: "top", Bottom: "bottom" },
+}));
+
+describe("InputNode", () => {
+  const defaultProps = {
+    id: "test-node-1",
+    data: {
+      params: {
+        "dim-1": "",
+        "dim-2": "",
+        "dim-3": "",
+      },
+    },
+  };
+
+  it("renders the title correctly", () => {
+    render(<InputNode {...defaultProps} />);
+    expect(screen.getByText("Input")).toBeInTheDocument();
+  });
+
+  it("displays 'No dimensions set' when parameters are unconfigured", () => {
+    render(<InputNode {...defaultProps} />);
+    expect(screen.getByText("No dimensions set")).toBeInTheDocument();
+  });
+
+  it("renders configured state and parameters when dimensions are provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          "dim-1": 28,
+          "dim-2": 28,
+          "dim-3": 1,
+        },
+      },
+    };
+    render(<InputNode {...configuredProps} />);
+    expect(screen.getByText("Dim: 28 × 28 × 1")).toBeInTheDocument();
+  });
+
+  it("renders configured state when partial dimensions are provided", () => {
+    const configuredProps = {
+      ...defaultProps,
+      data: {
+        params: {
+          "dim-1": 128,
+          "dim-2": "",
+          "dim-3": "",
+        },
+      },
+    };
+    render(<InputNode {...configuredProps} />);
+    expect(screen.getByText("Dim: 128")).toBeInTheDocument();
+  });
+
+  it("renders the correct ReactFlow handles (source only)", () => {
+    render(<InputNode {...defaultProps} />);
+    // Input node should only have a source handle on the right
+    const sourceHandle = screen.getByTestId("handle-source-right");
+    expect(sourceHandle).toBeInTheDocument();
+
+    // Should not have a target handle
+    const targetHandleLeft = screen.queryByTestId("handle-target-left");
+    expect(targetHandleLeft).not.toBeInTheDocument();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ModelSummaryPanel.jsx
@@ -1,0 +1,105 @@
+import { useState } from "react";
+import PropTypes from "prop-types";
+import { ChevronDown, ChevronUp, X } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+
+export default function ModelSummaryPanel({ summary, onClose }) {
+  const [collapsed, setCollapsed] = useState(false);
+
+  if (!summary) return null;
+
+  return (
+    <Card className="mt-4">
+      <CardHeader className="flex flex-row items-center justify-between py-3">
+        <CardTitle className="text-sm">Model Architecture Summary</CardTitle>
+        <div className="flex gap-1">
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={() => setCollapsed((c) => !c)}
+            aria-label={collapsed ? "Expand summary" : "Collapse summary"}
+          >
+            {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-6 w-6"
+            onClick={onClose}
+            aria-label="Close summary"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      </CardHeader>
+
+      {!collapsed && (
+        <CardContent className="pt-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-xs">
+              <thead>
+                <tr className="border-b">
+                  <th className="py-2 text-left font-medium">Layer</th>
+                  <th className="py-2 text-left font-medium">Type</th>
+                  <th className="py-2 text-left font-medium">Output Shape</th>
+                  <th className="py-2 text-right font-medium">Params</th>
+                </tr>
+              </thead>
+              <tbody>
+                {summary.layers.map((layer, i) => (
+                  <tr key={i} className="border-b last:border-0">
+                    <td className="py-1.5 pr-3 font-mono">{layer.name}</td>
+                    <td className="py-1.5 pr-3">{layer.type}</td>
+                    <td className="py-1.5 pr-3 font-mono text-muted-foreground">
+                      {layer.output_shape}
+                    </td>
+                    <td className="py-1.5 text-right tabular-nums">
+                      {layer.param_count.toLocaleString()}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          <div className="mt-3 flex flex-wrap gap-4 border-t pt-3 text-xs text-muted-foreground">
+            <span>
+              Total params:{" "}
+              <strong className="text-foreground">{summary.total_params.toLocaleString()}</strong>
+            </span>
+            <span>
+              Trainable:{" "}
+              <strong className="text-foreground">
+                {summary.trainable_params.toLocaleString()}
+              </strong>
+            </span>
+            <span>
+              Non-trainable:{" "}
+              <strong className="text-foreground">
+                {summary.non_trainable_params.toLocaleString()}
+              </strong>
+            </span>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+ModelSummaryPanel.propTypes = {
+  summary: PropTypes.shape({
+    layers: PropTypes.arrayOf(
+      PropTypes.shape({
+        name: PropTypes.string.isRequired,
+        type: PropTypes.string.isRequired,
+        output_shape: PropTypes.string.isRequired,
+        param_count: PropTypes.number.isRequired,
+      }),
+    ).isRequired,
+    total_params: PropTypes.number.isRequired,
+    trainable_params: PropTypes.number.isRequired,
+    non_trainable_params: PropTypes.number.isRequired,
+  }),
+  onClose: PropTypes.func.isRequired,
+};

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -11,17 +11,14 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const denseActivations = [
-  { value: "relu", label: "ReLU" },
-  { value: "linear", label: "Linear" },
-  { value: "sigmoid", label: "Sigmoid" },
-  { value: "softmax", label: "Softmax" },
-  { value: "tanh", label: "Tanh" },
-];
-
-const convActivations = [
+const ACTIVATIONS = [
   { value: "none", label: "None" },
   { value: "relu", label: "ReLU" },
+  { value: "sigmoid", label: "Sigmoid" },
+  { value: "tanh", label: "Tanh" },
+  { value: "softmax", label: "Softmax" },
+  { value: "elu", label: "ELU" },
+  { value: "selu", label: "SELU" },
 ];
 
 const convPaddings = [
@@ -133,7 +130,7 @@ function NodePropertiesPanel({
                 <SelectValue placeholder="Select activation" />
               </SelectTrigger>
               <SelectContent>
-                {denseActivations.map((a) => (
+                {ACTIVATIONS.map((a) => (
                   <SelectItem key={a.value} value={a.value}>
                     {a.label}
                   </SelectItem>
@@ -238,7 +235,7 @@ function NodePropertiesPanel({
                 <SelectValue placeholder="Activation" />
               </SelectTrigger>
               <SelectContent>
-                {convActivations.map((a) => (
+                {ACTIVATIONS.map((a) => (
                   <SelectItem key={a.value} value={a.value}>
                     {a.label}
                   </SelectItem>
@@ -251,6 +248,60 @@ function NodePropertiesPanel({
     );
   }
 
+  if (type === "custombatchnorm") {
+    return (
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-sm">BatchNormalization</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label>Momentum</Label>
+            <Input
+              type="number"
+              min="0"
+              max="1"
+              step="0.01"
+              value={params.momentum}
+              onChange={(e) => updateParam("momentum", e.target.value)}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Epsilon</Label>
+            <Input
+              type="number"
+              step="0.0001"
+              value={params.epsilon}
+              onChange={(e) => updateParam("epsilon", e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (type === "customdropout") {
+    return (
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-sm">Dropout</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label>Rate (0–1)</Label>
+            <Input
+              type="number"
+              min="0"
+              max="1"
+              step="0.1"
+              value={params.rate}
+              onChange={(e) => updateParam("rate", e.target.value)}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
   return null;
 }
 

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -302,6 +302,7 @@ function NodePropertiesPanel({
       </Card>
     );
   }
+
   return null;
 }
 

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -288,7 +288,7 @@ function NodePropertiesPanel({
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="space-y-1">
-            <Label>Rate (0–1)</Label>
+            <Label>Rate (0-1)</Label>
             <Input
               type="number"
               min="0"

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
@@ -40,6 +40,20 @@ function Sidebar() {
         >
           Conv2D
         </div>
+        <div
+          className="cursor-grab rounded-md border border-l-4 border-l-node-dropout bg-white px-3 py-2 text-xs font-medium"
+          onDragStart={(e) => onDragStart(e, "customdropout")}
+          draggable
+        >
+          Dropout
+        </div>
+        <div
+          className="cursor-grab rounded-md border border-l-4 border-l-node-batchnorm bg-white px-3 py-2 text-xs font-medium"
+          onDragStart={(e) => onDragStart(e, "custombatchnorm")}
+          draggable
+        >
+          BatchNorm
+        </div>
       </CardContent>
     </Card>
   );

--- a/tensormap-frontend/src/components/Process/ColumnStatsPanel.jsx
+++ b/tensormap-frontend/src/components/Process/ColumnStatsPanel.jsx
@@ -59,9 +59,7 @@ const ColumnStatsPanel = ({ fileId }) => {
         <span>
           Column Statistics
           {summary && (
-            <span className="ml-2 font-normal text-xs text-muted-foreground">
-              ({summary})
-            </span>
+            <span className="ml-2 font-normal text-xs text-muted-foreground">({summary})</span>
           )}
         </span>
         <span>{open ? "▲" : "▼"}</span>
@@ -102,7 +100,9 @@ const ColumnStatsPanel = ({ fileId }) => {
                       <td className="border px-3 py-2 font-medium">{row.column}</td>
                       <td className="border px-3 py-2 text-muted-foreground">{row.dtype}</td>
                       <td className="border px-3 py-2 text-muted-foreground">{fmt(row.count)}</td>
-                      <td className="border px-3 py-2 text-muted-foreground">{fmt(row.null_count)}</td>
+                      <td className="border px-3 py-2 text-muted-foreground">
+                        {fmt(row.null_count)}
+                      </td>
                       <td className="border px-3 py-2 text-muted-foreground">{fmt(row.mean)}</td>
                       <td className="border px-3 py-2 text-muted-foreground">{fmt(row.min)}</td>
                       <td className="border px-3 py-2 text-muted-foreground">{fmt(row.max)}</td>

--- a/tensormap-frontend/src/components/Process/CorrelationHeatmap.jsx
+++ b/tensormap-frontend/src/components/Process/CorrelationHeatmap.jsx
@@ -41,7 +41,7 @@ function correlationColour(value) {
  * @param {{ fileId: string }} props
  */
 const CorrelationHeatmap = ({ fileId }) => {
-  const [data, setData] = useState(null);   // { columns, matrix }
+  const [data, setData] = useState(null); // { columns, matrix }
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState(null);
   const [tooltip, setTooltip] = useState(null); // { x, y, row, col, value }
@@ -84,9 +84,7 @@ const CorrelationHeatmap = ({ fileId }) => {
         </button>
       )}
 
-      {error && (
-        <p className="text-sm text-destructive">{error}</p>
-      )}
+      {error && <p className="text-sm text-destructive">{error}</p>}
 
       {visible && data && (
         <div className="space-y-2">
@@ -124,7 +122,10 @@ const CorrelationHeatmap = ({ fileId }) => {
                 </div>
               )}
 
-              <table className="border-collapse text-xs" style={{ minWidth: (data.columns.length + 1) * CELL }}>
+              <table
+                className="border-collapse text-xs"
+                style={{ minWidth: (data.columns.length + 1) * CELL }}
+              >
                 <thead>
                   <tr>
                     {/* top-left empty corner */}

--- a/tensormap-frontend/src/components/Process/DisplayDataset.jsx
+++ b/tensormap-frontend/src/components/Process/DisplayDataset.jsx
@@ -1,7 +1,8 @@
-import { useState, useEffect, useCallback } from "react";
+import React, { useState, useEffect, useCallback } from "react";
 import PropTypes from "prop-types";
 import { getFileData } from "../../services/FileServices";
 import logger from "../../shared/logger";
+import { Button } from "../ui/button";
 
 /**
  * Tabular preview of a CSV dataset.
@@ -11,34 +12,61 @@ import logger from "../../shared/logger";
  *
  * @param {{ fileId: string }} props
  */
-const DisplayDataset = ({ fileId }) => {
+const DisplayDataset = ({ fileId, pageSize = 50 }) => {
   const [data, setData] = useState(null);
   const [error, setError] = useState(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [page, setPage] = useState(1);
+  const [pagination, setPagination] = useState(null);
+  const abortControllerRef = React.useRef(null);
 
-  const fetchData = useCallback(async (fileId) => {
-    try {
-      setError(null);
-      const fileData = await getFileData(fileId);
-      const parsedData = JSON.parse(fileData);
-      setData(parsedData);
-    } catch (e) {
-      logger.error("Error fetching dataset:", e);
-      setError("Failed to load dataset");
-      setData(null);
-    }
-  }, []);
+  const fetchData = useCallback(
+    async (currentFileId, currentPage = 1) => {
+      if (abortControllerRef.current) {
+        abortControllerRef.current.abort();
+      }
+      const controller = new AbortController();
+      abortControllerRef.current = controller;
+
+      setIsLoading(true);
+      try {
+        setError(null);
+        const fileData = await getFileData(currentFileId, currentPage, pageSize, controller.signal);
+
+        if (!controller.signal.aborted) {
+          setData(fileData.data);
+          setPagination(fileData.pagination);
+        }
+      } catch (e) {
+        if (e.name !== "CanceledError" && e.name !== "AbortError") {
+          logger.error("Error fetching dataset:", e);
+          setError("Failed to load dataset");
+          setData(null);
+        }
+      } finally {
+        if (!controller.signal.aborted) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [pageSize],
+  );
+
+  useEffect(() => {
+    setPage(1);
+  }, [fileId]);
 
   useEffect(() => {
     if (fileId) {
-      fetchData(fileId);
+      fetchData(fileId, page);
     }
-  }, [fileId, fetchData]);
+  }, [fileId, page, fetchData]);
 
   if (error) {
     return <div className="flex h-48 items-center justify-center text-destructive">{error}</div>;
   }
 
-  if (!data || data.length === 0) {
+  if (isLoading) {
     return (
       <div className="flex h-48 items-center justify-center text-muted-foreground">
         Loading data...
@@ -46,36 +74,76 @@ const DisplayDataset = ({ fileId }) => {
     );
   }
 
+  if (!data || data.length === 0) {
+    return (
+      <div className="flex h-48 items-center justify-center text-muted-foreground">
+        Dataset is empty.
+      </div>
+    );
+  }
+
   return (
-    <div className="max-h-[500px] w-full overflow-auto">
-      <table className="w-full border-collapse">
-        <thead>
-          <tr className="border-b">
-            {Object.keys(data[0]).map((key) => (
-              <th key={key} className="border px-3 py-2 text-left font-semibold">
-                {key.trim()}
-              </th>
-            ))}
-          </tr>
-        </thead>
-        <tbody>
-          {data.map((row, index) => (
-            <tr key={index} className="border-b">
-              {Object.values(row).map((value, idx) => (
-                <td key={idx} className="border px-3 py-2">
-                  {value}
-                </td>
+    <div className="flex flex-col space-y-4">
+      <div className="max-h-[500px] w-full overflow-auto">
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="border-b">
+              {Object.keys(data[0]).map((key) => (
+                <th key={key} className="border px-3 py-2 text-left font-semibold">
+                  {key.trim()}
+                </th>
               ))}
             </tr>
-          ))}
-        </tbody>
-      </table>
+          </thead>
+          <tbody>
+            {data.map((row, index) => (
+              <tr key={`row-${pagination?.page}-${index}`} className="border-b">
+                {Object.values(row).map((value, idx) => (
+                  <td key={`cell-${pagination?.page}-${index}-${idx}`} className="border px-3 py-2">
+                    {value != null ? String(value) : ""}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="flex items-center justify-between text-sm text-muted-foreground">
+        <div>
+          Showing {pagination ? (pagination.page - 1) * pagination.page_size + 1 : 0} to{" "}
+          {pagination ? Math.min(pagination.page * pagination.page_size, pagination.total_rows) : 0}{" "}
+          of {pagination ? pagination.total_rows : 0} Total rows
+        </div>
+        <div className="flex items-center space-x-2">
+          <div>
+            Page {pagination?.page || 1} of {pagination?.total_pages || 1}
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => Math.max(1, p - 1))}
+            disabled={!pagination || pagination.page <= 1}
+          >
+            Previous
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setPage((p) => p + 1)}
+            disabled={!pagination || pagination.page >= pagination.total_pages}
+          >
+            Next
+          </Button>
+        </div>
+      </div>
     </div>
   );
 };
 
 DisplayDataset.propTypes = {
   fileId: PropTypes.string.isRequired,
+  pageSize: PropTypes.number,
 };
 
 export default DisplayDataset;

--- a/tensormap-frontend/src/components/Process/TransformationCreator.jsx
+++ b/tensormap-frontend/src/components/Process/TransformationCreator.jsx
@@ -49,7 +49,10 @@ function TransformationCreator({ features, onAdd }) {
         </Select>
       </div>
       <div className="w-[40%]">
-        <Select value={selectedTransformation} onValueChange={(value) => setSelectedTransformation(value)}>
+        <Select
+          value={selectedTransformation}
+          onValueChange={(value) => setSelectedTransformation(value)}
+        >
           <SelectTrigger>
             <SelectValue placeholder="Transformation" />
           </SelectTrigger>

--- a/tensormap-frontend/src/components/ui/dropdown-menu.jsx
+++ b/tensormap-frontend/src/components/ui/dropdown-menu.jsx
@@ -1,0 +1,157 @@
+import * as React from "react";
+import * as DropdownMenuPrimitive from "@radix-ui/react-dropdown-menu";
+import { Check, ChevronRight, Circle } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+
+const DropdownMenu = DropdownMenuPrimitive.Root;
+
+const DropdownMenuTrigger = DropdownMenuPrimitive.Trigger;
+
+const DropdownMenuGroup = DropdownMenuPrimitive.Group;
+
+const DropdownMenuPortal = DropdownMenuPrimitive.Portal;
+
+const DropdownMenuSub = DropdownMenuPrimitive.Sub;
+
+const DropdownMenuRadioGroup = DropdownMenuPrimitive.RadioGroup;
+
+const DropdownMenuSubTrigger = React.forwardRef(({ className, inset, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubTrigger
+    ref={ref}
+    className={cn(
+      "flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none focus:bg-accent data-[state=open]:bg-accent [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+    <ChevronRight className="ml-auto" />
+  </DropdownMenuPrimitive.SubTrigger>
+));
+DropdownMenuSubTrigger.displayName = DropdownMenuPrimitive.SubTrigger.displayName;
+
+const DropdownMenuSubContent = React.forwardRef(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.SubContent
+    ref={ref}
+    className={cn(
+      "z-50 min-w-[8rem] overflow-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-lg data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuSubContent.displayName = DropdownMenuPrimitive.SubContent.displayName;
+
+const DropdownMenuContent = React.forwardRef(({ className, sideOffset = 4, ...props }, ref) => (
+  <DropdownMenuPrimitive.Portal>
+    <DropdownMenuPrimitive.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 max-h-[var(--radix-dropdown-menu-content-available-height)] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover p-1 text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-dropdown-menu-content-transform-origin]",
+        className,
+      )}
+      {...props}
+    />
+  </DropdownMenuPrimitive.Portal>
+));
+DropdownMenuContent.displayName = DropdownMenuPrimitive.Content.displayName;
+
+const DropdownMenuItem = React.forwardRef(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0",
+      inset && "pl-8",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = DropdownMenuPrimitive.Item.displayName;
+
+const DropdownMenuCheckboxItem = React.forwardRef(
+  ({ className, children, checked, ...props }, ref) => (
+    <DropdownMenuPrimitive.CheckboxItem
+      ref={ref}
+      className={cn(
+        "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+        className,
+      )}
+      checked={checked}
+      {...props}
+    >
+      <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+        <DropdownMenuPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </DropdownMenuPrimitive.ItemIndicator>
+      </span>
+      {children}
+    </DropdownMenuPrimitive.CheckboxItem>
+  ),
+);
+DropdownMenuCheckboxItem.displayName = DropdownMenuPrimitive.CheckboxItem.displayName;
+
+const DropdownMenuRadioItem = React.forwardRef(({ className, children, ...props }, ref) => (
+  <DropdownMenuPrimitive.RadioItem
+    ref={ref}
+    className={cn(
+      "relative flex cursor-default select-none items-center rounded-sm py-1.5 pl-8 pr-2 text-sm outline-none transition-colors focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      className,
+    )}
+    {...props}
+  >
+    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
+      <DropdownMenuPrimitive.ItemIndicator>
+        <Circle className="h-2 w-2 fill-current" />
+      </DropdownMenuPrimitive.ItemIndicator>
+    </span>
+    {children}
+  </DropdownMenuPrimitive.RadioItem>
+));
+DropdownMenuRadioItem.displayName = DropdownMenuPrimitive.RadioItem.displayName;
+
+const DropdownMenuLabel = React.forwardRef(({ className, inset, ...props }, ref) => (
+  <DropdownMenuPrimitive.Label
+    ref={ref}
+    className={cn("px-2 py-1.5 text-sm font-semibold", inset && "pl-8", className)}
+    {...props}
+  />
+));
+DropdownMenuLabel.displayName = DropdownMenuPrimitive.Label.displayName;
+
+const DropdownMenuSeparator = React.forwardRef(({ className, ...props }, ref) => (
+  <DropdownMenuPrimitive.Separator
+    ref={ref}
+    className={cn("-mx-1 my-1 h-px bg-muted", className)}
+    {...props}
+  />
+));
+DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
+
+const DropdownMenuShortcut = ({ className, ...props }) => {
+  return (
+    <span className={cn("ml-auto text-xs tracking-widest opacity-60", className)} {...props} />
+  );
+};
+DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
+
+export {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuCheckboxItem,
+  DropdownMenuRadioItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuShortcut,
+  DropdownMenuGroup,
+  DropdownMenuPortal,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuRadioGroup,
+};

--- a/tensormap-frontend/src/constants/Urls.js
+++ b/tensormap-frontend/src/constants/Urls.js
@@ -22,5 +22,6 @@ export const BACKEND_DELETE_FILE = "/data/upload/file/";
 export const BACKEND_GET_MODEL_GRAPH = "/model";
 export const BACKEND_SAVE_MODEL = "/model/save";
 export const BACKEND_UPDATE_TRAINING_CONFIG = "/model/training-config";
+export const BACKEND_DELETE_MODEL = "/model";
 export const BACKEND_PROJECT = "/project";
 export const BACKEND_GET_COLUMN_STATS = "/data/process/stats/";

--- a/tensormap-frontend/src/containers/ProjectsPage/ProjectCard.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/ProjectCard.jsx
@@ -1,4 +1,6 @@
+import { useState } from "react";
 import { useNavigate } from "react-router-dom";
+import PropTypes from "prop-types";
 import {
   Card,
   CardHeader,
@@ -8,40 +10,263 @@ import {
   CardFooter,
 } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { FileText, Brain } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Trash2, Pencil, MoreVertical, FileText, Brain } from "lucide-react";
+import { deleteProject, updateProject } from "../../services/ProjectServices";
+import logger from "../../shared/logger";
 
-export default function ProjectCard({ project }) {
+/**
+ * Card representing a single ML project.
+ *
+ * Clicking the card body navigates to the project workspace.
+ * The menu exposes Edit and Delete actions. Edit opens an inline
+ * dialog pre-filled with the current name/description; Delete shows a
+ * confirmation dialog before calling the API.
+ *
+ * @param {{ project: object, onDeleted: (id: string) => void, onUpdated: (project: object) => void }} props
+ */
+export default function ProjectCard({ project, onDeleted, onUpdated }) {
   const navigate = useNavigate();
+  const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+  const [editDialogOpen, setEditDialogOpen] = useState(false);
+  const [deleting, setDeleting] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [deleteError, setDeleteError] = useState(null);
+  const [editError, setEditError] = useState(null);
+  const [editName, setEditName] = useState(project.name);
+  const [editDescription, setEditDescription] = useState(project.description ?? "");
 
-  const handleClick = () => {
+  const handleCardClick = () => {
     navigate(`/workspace/${project.id}/datasets`);
   };
 
+  const openDeleteDialog = (e) => {
+    e.stopPropagation();
+    setDeleteError(null);
+    setDeleteDialogOpen(true);
+  };
+
+  const openEditDialog = (e) => {
+    e.stopPropagation();
+    setEditError(null);
+    setEditName(project.name);
+    setEditDescription(project.description ?? "");
+    setEditDialogOpen(true);
+  };
+
+  const handleDelete = async () => {
+    setDeleting(true);
+    try {
+      const resp = await deleteProject(project.id);
+      if (resp.data.success) {
+        onDeleted(project.id);
+        setDeleteDialogOpen(false);
+      } else {
+        setDeleteError(resp?.data?.message || "Failed to delete project. Please try again.");
+      }
+    } catch (err) {
+      logger.error("Failed to delete project:", err);
+      setDeleteError("Failed to delete project. Please try again.");
+    } finally {
+      setDeleting(false);
+    }
+  };
+
+  const handleUpdate = async (e) => {
+    e.preventDefault();
+    if (!editName.trim()) return;
+    setSaving(true);
+    try {
+      const resp = await updateProject(project.id, {
+        name: editName.trim(),
+        description: editDescription.trim() || null,
+      });
+      if (resp.data.success) {
+        if (resp?.data?.data?.id) {
+          onUpdated(resp.data.data);
+          setEditDialogOpen(false);
+        } else {
+          setEditError("Received an unexpected response from the server.");
+          logger.error("Unexpected update project response:", resp?.data);
+        }
+      } else {
+        setEditError(resp?.data?.message || "Failed to update project. Please try again.");
+      }
+    } catch (err) {
+      logger.error("Failed to update project:", err);
+      setEditError("Failed to update project. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
   return (
-    <Card className="cursor-pointer transition-shadow hover:shadow-md" onClick={handleClick}>
-      <CardHeader>
-        <CardTitle className="text-lg">{project.name}</CardTitle>
-        {project.description && (
-          <CardDescription className="line-clamp-2">{project.description}</CardDescription>
-        )}
-      </CardHeader>
-      <CardContent>
-        <div className="flex gap-3">
-          <Badge variant="secondary" className="flex items-center gap-1">
-            <FileText className="h-3 w-3" />
-            {project.file_count ?? 0} files
-          </Badge>
-          <Badge variant="secondary" className="flex items-center gap-1">
-            <Brain className="h-3 w-3" />
-            {project.model_count ?? 0} models
-          </Badge>
+    <>
+      <Card
+        className="relative cursor-pointer transition-shadow hover:shadow-md"
+        onClick={handleCardClick}
+      >
+        <div className="absolute right-3 top-3 z-10">
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-7 w-7"
+                onClick={(e) => e.stopPropagation()}
+                aria-label="Project options"
+              >
+                <MoreVertical className="h-4 w-4" />
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" onClick={(e) => e.stopPropagation()}>
+              <DropdownMenuItem onClick={openEditDialog}>
+                <Pencil className="h-3.5 w-3.5" />
+                Edit
+              </DropdownMenuItem>
+              <DropdownMenuItem className="text-destructive" onClick={openDeleteDialog}>
+                <Trash2 className="h-3.5 w-3.5" />
+                Delete
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
         </div>
-      </CardContent>
-      <CardFooter className="text-xs text-muted-foreground">
-        {project.updated_on
-          ? `Updated ${new Date(project.updated_on).toLocaleDateString()}`
-          : `Created ${new Date(project.created_on).toLocaleDateString()}`}
-      </CardFooter>
-    </Card>
+
+        <CardHeader className="pr-10">
+          <CardTitle className="text-lg">{project.name}</CardTitle>
+          {project.description && (
+            <CardDescription className="line-clamp-2">{project.description}</CardDescription>
+          )}
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-3">
+            <Badge variant="secondary" className="flex items-center gap-1">
+              <FileText className="h-3 w-3" />
+              {project.file_count ?? 0} files
+            </Badge>
+            <Badge variant="secondary" className="flex items-center gap-1">
+              <Brain className="h-3 w-3" />
+              {project.model_count ?? 0} models
+            </Badge>
+          </div>
+        </CardContent>
+        <CardFooter className="text-xs text-muted-foreground">
+          {project.updated_on
+            ? `Updated ${new Date(project.updated_on).toLocaleDateString()}`
+            : `Created ${new Date(project.created_on).toLocaleDateString()}`}
+        </CardFooter>
+      </Card>
+
+      <Dialog
+        open={deleteDialogOpen}
+        onOpenChange={(open) => {
+          if (!deleting) setDeleteDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete project</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{project.name}</strong>? This will permanently
+              remove the project along with all its datasets and models. This action cannot be
+              undone.
+            </DialogDescription>
+          </DialogHeader>
+          {deleteError && (
+            <p className="text-sm font-medium text-destructive mt-2">{deleteError}</p>
+          )}
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteDialogOpen(false)}
+              disabled={deleting}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDelete} disabled={deleting}>
+              {deleting ? "Deleting..." : "Delete project"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={editDialogOpen}
+        onOpenChange={(open) => {
+          if (!saving) setEditDialogOpen(open);
+        }}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit project</DialogTitle>
+            <DialogDescription>Update the project name or description.</DialogDescription>
+          </DialogHeader>
+          {editError && <p className="text-sm font-medium text-destructive mt-2">{editError}</p>}
+          <form onSubmit={handleUpdate}>
+            <div className="grid gap-4 py-4">
+              <div className="grid gap-2">
+                <Label htmlFor="edit-name">Project Name</Label>
+                <Input
+                  id="edit-name"
+                  value={editName}
+                  onChange={(e) => setEditName(e.target.value)}
+                  maxLength={100}
+                  required
+                />
+              </div>
+              <div className="grid gap-2">
+                <Label htmlFor="edit-description">Description (optional)</Label>
+                <Textarea
+                  id="edit-description"
+                  value={editDescription}
+                  onChange={(e) => setEditDescription(e.target.value)}
+                  maxLength={500}
+                  rows={3}
+                />
+              </div>
+            </div>
+            <DialogFooter>
+              <Button type="button" variant="outline" onClick={() => setEditDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button type="submit" disabled={saving || !editName.trim()}>
+                {saving ? "Saving..." : "Save changes"}
+              </Button>
+            </DialogFooter>
+          </form>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 }
+
+ProjectCard.propTypes = {
+  project: PropTypes.shape({
+    id: PropTypes.string.isRequired,
+    name: PropTypes.string.isRequired,
+    description: PropTypes.string,
+    file_count: PropTypes.number,
+    model_count: PropTypes.number,
+    created_on: PropTypes.string,
+    updated_on: PropTypes.string,
+  }).isRequired,
+  onDeleted: PropTypes.func.isRequired,
+  onUpdated: PropTypes.func.isRequired,
+};

--- a/tensormap-frontend/src/containers/ProjectsPage/ProjectsPage.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/ProjectsPage.jsx
@@ -43,6 +43,14 @@ export default function ProjectsPage() {
     setProjects((prev) => [newProject, ...prev]);
   };
 
+  const handleProjectDeleted = (deletedId) => {
+    setProjects((prev) => prev.filter((p) => p.id !== deletedId));
+  };
+
+  const handleProjectUpdated = (updatedProject) => {
+    setProjects((prev) => prev.map((p) => (p.id === updatedProject.id ? updatedProject : p)));
+  };
+
   return (
     <div className="min-h-[calc(100vh-3.5rem)] bg-background">
       <div className="mx-auto max-w-6xl px-6 py-8">
@@ -78,7 +86,12 @@ export default function ProjectsPage() {
         ) : (
           <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
             {projects.map((project) => (
-              <ProjectCard key={project.id} project={project} />
+              <ProjectCard
+                key={project.id}
+                project={project}
+                onDeleted={handleProjectDeleted}
+                onUpdated={handleProjectUpdated}
+              />
             ))}
           </div>
         )}

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -1,11 +1,20 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams } from "react-router-dom";
+import { Trash2 } from "lucide-react";
 import io from "socket.io-client";
 import { useRecoilState } from "recoil";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from "@/components/ui/dialog";
 import {
   Select,
   SelectContent,
@@ -16,12 +25,14 @@ import {
 import * as urls from "../../constants/Urls";
 import * as strings from "../../constants/Strings";
 import logger from "../../shared/logger";
+import FeedbackDialog from "../../components/shared/FeedbackDialog";
 import Result from "../../components/ResultPanel/Result/Result";
 import {
   download_code,
   runModel,
   getAllModels,
   updateTrainingConfig,
+  deleteModel,
 } from "../../services/ModelServices";
 import { getAllFiles } from "../../services/FileServices";
 import { models as modelListAtom } from "../../shared/atoms";
@@ -52,6 +63,12 @@ export default function Training() {
   const [resultValues, setResultValues] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [connectionError, setConnectionError] = useState(null);
+  const [deleteConfirm, setDeleteConfirm] = useState({ open: false, model: null });
+  const [deleteFeedback, setDeleteFeedback] = useState({
+    open: false,
+    success: false,
+    message: "",
+  });
   const socketRef = useRef(null);
   const timeoutRef = useRef(null);
 
@@ -128,9 +145,10 @@ export default function Training() {
 
     getAllModels(projectId)
       .then((response) => {
-        const models = response.map((file, index) => ({
-          label: file + strings.MODEL_EXTENSION,
-          value: file,
+        const models = response.map((item, index) => ({
+          label: item.model_name + strings.MODEL_EXTENSION,
+          value: item.model_name,
+          id: item.id,
           key: index,
         }));
         setModelList(models);
@@ -348,6 +366,7 @@ export default function Training() {
       optimizer: trainingConfig.optimizer,
       metric: trainingConfig.metric,
       epochs: Number(trainingConfig.epochs),
+      batch_size: trainingConfig.batch_size ? Number(trainingConfig.batch_size) : 32,
       project_id: projectId || null,
     };
 
@@ -417,8 +436,75 @@ export default function Training() {
     setIsLoading(false);
   };
 
+  const handleDeleteClick = (model, e) => {
+    e.stopPropagation();
+    setDeleteConfirm({ open: true, model });
+  };
+
+  const handleDeleteConfirm = () => {
+    const { model } = deleteConfirm;
+    setDeleteConfirm({ open: false, model: null });
+    deleteModel(model.id)
+      .then((resp) => {
+        if (resp.success) {
+          setModelList((prev) => prev.filter((m) => m.id !== model.id));
+          if (selectedModel === model.value) {
+            setSelectedModel(null);
+            setConfigSaved(false);
+          }
+        } else {
+          logger.error("Failed to delete model:", resp.message);
+          setDeleteFeedback({
+            open: true,
+            success: false,
+            message: resp.message || "Failed to delete model",
+          });
+        }
+      })
+      .catch((error) => {
+        logger.error("Error deleting model:", error);
+        setDeleteFeedback({
+          open: true,
+          success: false,
+          message: error.message || "An unexpected error occurred",
+        });
+      });
+  };
+
   return (
     <div className="space-y-6">
+      <FeedbackDialog
+        open={deleteFeedback.open}
+        onClose={() => setDeleteFeedback((prev) => ({ ...prev, open: false }))}
+        success={deleteFeedback.success}
+        message={deleteFeedback.message}
+      />
+      <Dialog
+        open={deleteConfirm.open}
+        onOpenChange={(open) => !open && setDeleteConfirm({ open: false, model: null })}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete model</DialogTitle>
+            <DialogDescription>
+              Are you sure you want to delete <strong>{deleteConfirm.model?.label}</strong>? This
+              action cannot be undone.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setDeleteConfirm({ open: false, model: null })}
+            >
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={handleDeleteConfirm}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
       <Card>
         <CardHeader>
           <CardTitle>Model Training</CardTitle>
@@ -426,14 +512,30 @@ export default function Training() {
         <CardContent>
           <div className="flex flex-wrap items-center gap-4">
             <div className="space-y-1">
-              <Select onValueChange={handleModelSelect}>
+              <Select
+                onValueChange={handleModelSelect}
+                value={selectedModel ?? ""}
+                disabled={modelList.length === 0}
+              >
                 <SelectTrigger className={`w-64 ${validationErrors.model ? "border-red-500" : ""}`}>
-                  <SelectValue placeholder="Select a model" />
+                  <SelectValue
+                    placeholder={modelList.length === 0 ? "No models created" : "Select a model"}
+                  />
                 </SelectTrigger>
                 <SelectContent>
                   {modelList.map((model) => (
                     <SelectItem key={model.key} value={model.value}>
-                      {model.label}
+                      <span className="flex items-center justify-between gap-2 w-full">
+                        <span>{model.label}</span>
+                        <button
+                          type="button"
+                          className="ml-auto text-destructive hover:text-destructive/80"
+                          onClick={(e) => handleDeleteClick(model, e)}
+                          aria-label={`Delete ${model.label}`}
+                        >
+                          <Trash2 className="h-3.5 w-3.5" />
+                        </button>
+                      </span>
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/tensormap-frontend/src/hooks/useUndoRedo.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.js
@@ -1,0 +1,162 @@
+import { useCallback, useRef, useState } from "react";
+
+const MAX_HISTORY_SIZE = 50;
+
+/**
+ * Safely deep-clone a value using structuredClone, falling back to
+ * JSON round-trip when the value contains non-cloneable data (functions,
+ * DOM nodes, Symbols, etc.).
+ *
+ * @param {*} value - The value to clone
+ * @returns {*} A deep copy of value, or null if cloning fails entirely
+ */
+function safeClone(value) {
+  try {
+    return structuredClone(value);
+  } catch {
+    try {
+      return JSON.parse(JSON.stringify(value));
+    } catch (e) {
+      console.warn("[useUndoRedo] Could not clone state; snapshot skipped.", e);
+      return null;
+    }
+  }
+}
+
+/**
+ * Push an entry to a stack, enforcing a maximum size.
+ *
+ * @param {Array} stack - The history stack (past or future)
+ * @param {object} entry - The {nodes, edges} snapshot to push
+ * @param {number} max - Maximum allowed stack length
+ */
+function cappedPush(stack, entry, max) {
+  stack.push(entry);
+  if (stack.length > max) stack.shift();
+}
+
+/**
+ * Custom hook for undo/redo functionality on ReactFlow canvas state.
+ *
+ * Uses a past/future two-stack pattern. Before each user action, the current
+ * state is pushed to the past stack. Undo pops from past (pushing the current
+ * state to future). Redo pops from future (pushing the current state to past).
+ *
+ * Rapid snapshots within 50 ms are deduplicated so that a single delete action
+ * (which fires both node-remove and edge-remove) records only one entry.
+ * The future (redo) stack is always cleared when a new action is taken, even
+ * if the snapshot itself is deduplicated.
+ *
+ * @param {Function} setNodes - ReactFlow setNodes function
+ * @param {Function} setEdges - ReactFlow setEdges function
+ * @param {React.MutableRefObject<Array>} nodesRef - Ref to current nodes
+ * @param {React.MutableRefObject<Array>} edgesRef - Ref to current edges
+ * @returns {{
+ *   takeSnapshot: (nodes: Array, edges: Array) => void,
+ *   undo: () => boolean,
+ *   redo: () => boolean,
+ *   canUndo: boolean,
+ *   canRedo: boolean,
+ * }}
+ */
+export default function useUndoRedo(setNodes, setEdges, nodesRef, edgesRef) {
+  const pastRef = useRef([]);
+  const futureRef = useRef([]);
+  const lastSnapshotTimeRef = useRef(0);
+  const [canUndo, setCanUndo] = useState(false);
+  const [canRedo, setCanRedo] = useState(false);
+
+  /** Synchronise the reactive canUndo/canRedo state with the ref stacks. */
+  const syncState = useCallback(() => {
+    setCanUndo(pastRef.current.length > 0);
+    setCanRedo(futureRef.current.length > 0);
+  }, []);
+
+  /**
+   * Saves the given state to the past stack and clears the future stack.
+   * Calls within 50 ms of each other are deduplicated to batch related
+   * change events (e.g. node deletion + connected edge deletion).
+   *
+   * The future stack is **always** cleared when a new action is taken,
+   * even if the snapshot itself is deduplicated (prevents stale redo
+   * after undo → new action within the dedup window).
+   */
+  const takeSnapshot = useCallback(
+    (nodes, edges) => {
+      // Always invalidate the redo stack on a new intentional action
+      futureRef.current = [];
+
+      const now = Date.now();
+      if (now - lastSnapshotTimeRef.current < 50) {
+        syncState();
+        return;
+      }
+      lastSnapshotTimeRef.current = now;
+
+      const clonedNodes = safeClone(nodes);
+      const clonedEdges = safeClone(edges);
+      if (clonedNodes === null || clonedEdges === null) {
+        syncState();
+        return;
+      }
+
+      cappedPush(pastRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+      syncState();
+    },
+    [syncState],
+  );
+
+  /**
+   * Undo: pushes the current canvas state to the future stack and restores
+   * the most recent past state. Data is already deep-cloned when stored, so
+   * no re-cloning is needed when restoring.
+   * @returns {boolean} true if undo was performed
+   */
+  const undo = useCallback(() => {
+    if (pastRef.current.length === 0) return false;
+
+    const clonedNodes = safeClone(nodesRef.current);
+    const clonedEdges = safeClone(edgesRef.current);
+    if (clonedNodes === null || clonedEdges === null) {
+      // Cannot preserve current state for redo — abort to avoid data loss
+      console.warn("[useUndoRedo] undo aborted: failed to clone current state");
+      return false;
+    }
+
+    cappedPush(futureRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+
+    const previous = pastRef.current.pop();
+    setNodes(previous.nodes);
+    setEdges(previous.edges);
+    syncState();
+    return true;
+  }, [setNodes, setEdges, nodesRef, edgesRef, syncState]);
+
+  /**
+   * Redo: pushes the current canvas state to the past stack and restores
+   * the most recent future state. Data is already deep-cloned when stored, so
+   * no re-cloning is needed when restoring.
+   * @returns {boolean} true if redo was performed
+   */
+  const redo = useCallback(() => {
+    if (futureRef.current.length === 0) return false;
+
+    const clonedNodes = safeClone(nodesRef.current);
+    const clonedEdges = safeClone(edgesRef.current);
+    if (clonedNodes === null || clonedEdges === null) {
+      // Cannot preserve current state for undo — abort to avoid data loss
+      console.warn("[useUndoRedo] redo aborted: failed to clone current state");
+      return false;
+    }
+
+    cappedPush(pastRef.current, { nodes: clonedNodes, edges: clonedEdges }, MAX_HISTORY_SIZE);
+
+    const next = futureRef.current.pop();
+    setNodes(next.nodes);
+    setEdges(next.edges);
+    syncState();
+    return true;
+  }, [setNodes, setEdges, nodesRef, edgesRef, syncState]);
+
+  return { takeSnapshot, undo, redo, canUndo, canRedo };
+}

--- a/tensormap-frontend/src/hooks/useUndoRedo.test.js
+++ b/tensormap-frontend/src/hooks/useUndoRedo.test.js
@@ -1,0 +1,374 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import useUndoRedo from "./useUndoRedo";
+
+/**
+ * Helper: creates mock setters and stable refs, then renders the hook.
+ * Returns { result, setNodes, setEdges, nodesRef, edgesRef }.
+ */
+function setup(initialNodes = [], initialEdges = []) {
+  const setNodes = vi.fn((val) => {
+    nodesRef.current = typeof val === "function" ? val(nodesRef.current) : val;
+  });
+  const setEdges = vi.fn((val) => {
+    edgesRef.current = typeof val === "function" ? val(edgesRef.current) : val;
+  });
+  const nodesRef = { current: initialNodes };
+  const edgesRef = { current: initialEdges };
+
+  const { result } = renderHook(() => useUndoRedo(setNodes, setEdges, nodesRef, edgesRef));
+
+  return { result, setNodes, setEdges, nodesRef, edgesRef };
+}
+
+describe("useUndoRedo", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ---------- empty-stack guards ----------
+
+  it("undo on empty stack returns false and does not throw", () => {
+    const { result } = setup();
+    let ret;
+    act(() => {
+      ret = result.current.undo();
+    });
+    expect(ret).toBe(false);
+  });
+
+  it("redo on empty stack returns false and does not throw", () => {
+    const { result } = setup();
+    let ret;
+    act(() => {
+      ret = result.current.redo();
+    });
+    expect(ret).toBe(false);
+  });
+
+  // ---------- basic undo ----------
+
+  it("undo restores the previous state", () => {
+    const { result, setNodes, setEdges } = setup([{ id: "b" }], [{ id: "e1" }]);
+
+    // Snapshot the old state ([{id:'a'}], [])
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+
+    // Simulate that the canvas moved to ({id:'b'}, {id:'e1'})
+    // nodesRef/edgesRef already point there from setup
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(setNodes).toHaveBeenCalledWith([{ id: "a" }]);
+    expect(setEdges).toHaveBeenCalledWith([]);
+  });
+
+  // ---------- basic redo ----------
+
+  it("redo restores the undone state", () => {
+    const { result, setNodes, nodesRef } = setup([{ id: "a" }], []);
+
+    // Take snapshot, advance state
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    nodesRef.current = [{ id: "b" }];
+
+    // Undo → go back to a
+    act(() => {
+      result.current.undo();
+    });
+    // After undo, nodesRef simulates the restored state
+    nodesRef.current = [{ id: "a" }];
+
+    // Redo → go forward to b
+    act(() => {
+      result.current.redo();
+    });
+    expect(setNodes).toHaveBeenLastCalledWith([{ id: "b" }]);
+  });
+
+  // ---------- redo cleared after new action ----------
+
+  it("clears redo history when a new action is taken after undo", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    act(() => {
+      result.current.takeSnapshot([], []);
+    });
+    nodesRef.current = [{ id: "1" }];
+
+    // Advance past dedup window
+    vi.advanceTimersByTime(60);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "1" }], []);
+    });
+    nodesRef.current = [{ id: "2" }];
+    edgesRef.current = [];
+
+    // Undo
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    // Advance past dedup window, then new action
+    vi.advanceTimersByTime(60);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "1" }], []);
+    });
+
+    // Redo should now be impossible
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- MAX_HISTORY_SIZE ----------
+
+  it("caps history at 50 entries (51st push drops the oldest)", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    for (let i = 0; i < 55; i++) {
+      nodesRef.current = [{ id: String(i) }];
+      edgesRef.current = [];
+
+      act(() => {
+        result.current.takeSnapshot([{ id: String(i) }], []);
+      });
+      // Advance past dedup window
+      vi.advanceTimersByTime(60);
+    }
+
+    // canUndo should still be true
+    expect(result.current.canUndo).toBe(true);
+
+    // Undo 50 times — all should succeed
+    let undoCount = 0;
+    for (let i = 0; i < 55; i++) {
+      let succeeded;
+      act(() => {
+        succeeded = result.current.undo();
+      });
+      if (succeeded) undoCount++;
+    }
+    expect(undoCount).toBe(50);
+  });
+
+  // ---------- dedup within 50 ms ----------
+
+  it("deduplicates snapshots within 50 ms (only one entry added)", () => {
+    const { result } = setup([], []);
+
+    // Take two snapshots in rapid succession (< 50 ms)
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+      result.current.takeSnapshot([{ id: "b" }], []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+
+    // Only one undo should be available
+    let count = 0;
+    act(() => {
+      if (result.current.undo()) count++;
+    });
+    act(() => {
+      if (result.current.undo()) count++;
+    });
+    expect(count).toBe(1);
+  });
+
+  // ---------- canUndo / canRedo reactive values ----------
+
+  it("canUndo and canRedo correctly reflect stack state", async () => {
+    const { result } = setup([{ id: "x" }], []);
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => {
+      result.current.takeSnapshot([{ id: "x" }], []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canUndo).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+
+    act(() => {
+      result.current.redo();
+    });
+
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- future cleared even during dedup window ----------
+
+  it("clears future stack even when snapshot is deduplicated", () => {
+    const { result, nodesRef } = setup([], []);
+
+    // Take snapshot and immediately undo
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    nodesRef.current = [{ id: "b" }];
+
+    act(() => {
+      result.current.undo();
+    });
+
+    expect(result.current.canRedo).toBe(true);
+
+    // Take a new snapshot within the dedup window — future must still clear
+    act(() => {
+      result.current.takeSnapshot([{ id: "c" }], []);
+    });
+
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  // ---------- safeClone fallback ----------
+
+  it("handles non-cloneable data gracefully via JSON fallback", () => {
+    const { result } = setup([], []);
+
+    // Functions are not structuredClone-able but JSON.stringify drops them
+    const nodesWithFn = [{ id: "a", data: { callback: () => {} } }];
+
+    // Should not throw — falls back to JSON round-trip
+    act(() => {
+      result.current.takeSnapshot(nodesWithFn, []);
+    });
+
+    expect(result.current.canUndo).toBe(true);
+  });
+
+  // ---------- redo enforces MAX_HISTORY_SIZE on past stack ----------
+
+  it("enforces MAX_HISTORY_SIZE on past stack during redo", () => {
+    const { result, nodesRef, edgesRef } = setup([], []);
+
+    // Fill past stack to 50
+    for (let i = 0; i < 50; i++) {
+      act(() => {
+        result.current.takeSnapshot([{ id: String(i) }], []);
+      });
+      vi.advanceTimersByTime(60);
+    }
+
+    // Now undo once to create a redo entry
+    nodesRef.current = [{ id: "current" }];
+    edgesRef.current = [];
+    act(() => {
+      result.current.undo();
+    });
+
+    // Redo pushes to past — should still be capped at 50, not 51
+    act(() => {
+      result.current.redo();
+    });
+
+    // Verify by counting: undo should succeed at most 50 times
+    let undoCount = 0;
+    for (let i = 0; i < 55; i++) {
+      let ok;
+      act(() => {
+        ok = result.current.undo();
+      });
+      if (ok) undoCount++;
+    }
+    expect(undoCount).toBeLessThanOrEqual(50);
+  });
+
+  // ---------- undo/redo abort when clone fails ----------
+
+  it("undo aborts and returns false when current state cannot be cloned", () => {
+    const { result } = setup([], []);
+
+    // Take a valid snapshot
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    vi.advanceTimersByTime(60);
+
+    // Stub both structuredClone and JSON.stringify to force safeClone → null
+    const origClone = globalThis.structuredClone;
+    const origStringify = JSON.stringify;
+    globalThis.structuredClone = () => {
+      throw new Error("clone fail");
+    };
+    JSON.stringify = () => {
+      throw new Error("stringify fail");
+    };
+
+    let ret;
+    act(() => {
+      ret = result.current.undo();
+    });
+
+    // Restore
+    globalThis.structuredClone = origClone;
+    JSON.stringify = origStringify;
+
+    // Undo should abort — state and stacks remain intact
+    expect(ret).toBe(false);
+    expect(result.current.canUndo).toBe(true);
+    expect(result.current.canRedo).toBe(false);
+  });
+
+  it("redo aborts and returns false when current state cannot be cloned", () => {
+    const { result, nodesRef } = setup([], []);
+
+    // Take snapshot, advance, undo to create redo entry
+    act(() => {
+      result.current.takeSnapshot([{ id: "a" }], []);
+    });
+    vi.advanceTimersByTime(60);
+    nodesRef.current = [{ id: "b" }];
+
+    act(() => {
+      result.current.undo();
+    });
+    expect(result.current.canRedo).toBe(true);
+
+    // Stub both structuredClone and JSON.stringify to force safeClone → null
+    const origClone = globalThis.structuredClone;
+    const origStringify = JSON.stringify;
+    globalThis.structuredClone = () => {
+      throw new Error("clone fail");
+    };
+    JSON.stringify = () => {
+      throw new Error("stringify fail");
+    };
+
+    let ret;
+    act(() => {
+      ret = result.current.redo();
+    });
+
+    // Restore
+    globalThis.structuredClone = origClone;
+    JSON.stringify = origStringify;
+
+    // Redo should abort — redo stack remains intact
+    expect(ret).toBe(false);
+    expect(result.current.canRedo).toBe(true);
+  });
+});

--- a/tensormap-frontend/src/index.css
+++ b/tensormap-frontend/src/index.css
@@ -24,13 +24,27 @@
     --input: 0 0% 89.8%;
     --ring: 0 0% 3.9%;
     --radius: 0.5rem;
+    --chart-1: 12 76% 61%;
+    --chart-2: 173 58% 39%;
+    --chart-3: 197 37% 24%;
+    --chart-4: 43 74% 66%;
+    --chart-5: 27 87% 67%;
+  }
+
+  * {
+    @apply border-border;
+  }
+
+  body {
+    @apply bg-background text-foreground;
   }
 }
 
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu",
-    "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell",
+    "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
 }

--- a/tensormap-frontend/src/services/FileServices.js
+++ b/tensormap-frontend/src/services/FileServices.js
@@ -97,12 +97,16 @@ export const getCorrelationMatrix = async (file_id) =>
  * Fetches the raw data content of a file as a JSON string.
  *
  * @param {string} file_id - ID of the uploaded file.
- * @returns {Promise<string>} JSON string of the file data.
+ * @param {number} page - Page number.
+ * @param {number} pageSize - Number of rows per page.
+ * @param {AbortSignal} [signal] - Optional AbortController signal to cancel the request.
+ * @returns {Promise<object>} Response data containing data array and pagination metadata.
  */
-export const getFileData = async (file_id) => {
+export const getFileData = async (file_id, page = 1, pageSize = 50, signal) => {
   try {
-    const response = await axios.get(urls.BACKEND_GET_FILE_DATA + file_id);
-    return response.data.data;
+    const params = { page, page_size: pageSize };
+    const response = await axios.get(urls.BACKEND_GET_FILE_DATA + file_id, { params, signal });
+    return response.data;
   } catch (error) {
     logger.error(error);
     throw error;
@@ -173,4 +177,3 @@ export const deleteFile = async (fileId) => {
       throw error;
     });
 };
-

--- a/tensormap-frontend/src/services/ModelServices.js
+++ b/tensormap-frontend/src/services/ModelServices.js
@@ -25,10 +25,10 @@ export const validateModel = async (data) =>
     });
 
 /**
- * Fetches the list of validated model names, optionally scoped to a project.
+ * Fetches the list of validated model objects, optionally scoped to a project.
  *
  * @param {string} [projectId]
- * @returns {Promise<string[]>} Array of model name strings.
+ * @returns {Promise<Array<{ id: number, model_name: string }>>} Array of model objects.
  */
 export const getAllModels = async (projectId) => {
   const params = projectId ? { project_id: projectId } : {};
@@ -45,6 +45,24 @@ export const getAllModels = async (projectId) => {
       throw err;
     });
 };
+
+/**
+ * Deletes a saved model by its database ID.
+ *
+ * @param {number} modelId
+ * @returns {Promise<{ success: boolean, message: string }>}
+ */
+export const deleteModel = async (modelId) =>
+  axios
+    .delete(`${urls.BACKEND_DELETE_MODEL}/${modelId}`)
+    .then((resp) => resp.data)
+    .catch((err) => {
+      logger.error(err);
+      if (err.response && err.response.data) {
+        return err.response.data;
+      }
+      return { success: false, message: "Unknown error occurred" };
+    });
 
 /**
  * Downloads the generated Python training script for a model.

--- a/tensormap-frontend/src/services/ProjectServices.js
+++ b/tensormap-frontend/src/services/ProjectServices.js
@@ -23,3 +23,20 @@ export const getProject = (id) => axios.get(`${urls.BACKEND_PROJECT}/${id}`);
  * @returns {Promise<import("axios").AxiosResponse>}
  */
 export const createProject = (data) => axios.post(urls.BACKEND_PROJECT, data);
+
+/**
+ * Partially updates a project's name and/or description.
+ *
+ * @param {string} id
+ * @param {{ name?: string, description?: string | null }} data
+ * @returns {Promise<import("axios").AxiosResponse>}
+ */
+export const updateProject = (id, data) => axios.patch(`${urls.BACKEND_PROJECT}/${id}`, data);
+
+/**
+ * Deletes a project and all its associated files and models.
+ *
+ * @param {string} id
+ * @returns {Promise<import("axios").AxiosResponse>}
+ */
+export const deleteProject = (id) => axios.delete(`${urls.BACKEND_PROJECT}/${id}`);

--- a/tensormap-frontend/src/setupTests.js
+++ b/tensormap-frontend/src/setupTests.js
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom";

--- a/tensormap-frontend/tailwind.config.js
+++ b/tensormap-frontend/tailwind.config.js
@@ -6,10 +6,45 @@ export default {
   theme: {
     extend: {
       colors: {
+        border: "hsl(var(--border))",
+        input: "hsl(var(--input))",
+        ring: "hsl(var(--ring))",
+        background: "hsl(var(--background))",
+        foreground: "hsl(var(--foreground))",
+        primary: {
+          DEFAULT: "hsl(var(--primary))",
+          foreground: "hsl(var(--primary-foreground))",
+        },
+        secondary: {
+          DEFAULT: "hsl(var(--secondary))",
+          foreground: "hsl(var(--secondary-foreground))",
+        },
+        destructive: {
+          DEFAULT: "hsl(var(--destructive))",
+          foreground: "hsl(var(--destructive-foreground))",
+        },
+        muted: {
+          DEFAULT: "hsl(var(--muted))",
+          foreground: "hsl(var(--muted-foreground))",
+        },
+        accent: {
+          DEFAULT: "hsl(var(--accent))",
+          foreground: "hsl(var(--accent-foreground))",
+        },
+        popover: {
+          DEFAULT: "hsl(var(--popover))",
+          foreground: "hsl(var(--popover-foreground))",
+        },
+        card: {
+          DEFAULT: "hsl(var(--card))",
+          foreground: "hsl(var(--card-foreground))",
+        },
         "node-dense": { DEFAULT: "rgb(43, 161, 255)", header: "rgb(50, 113, 178)" },
         "node-input": { DEFAULT: "rgb(105, 172, 61)", header: "rgb(93, 149, 34)" },
         "node-flatten": { DEFAULT: "rgb(247, 173, 20)", header: "rgb(170, 121, 24)" },
         "node-conv": { DEFAULT: "rgb(255, 128, 43)", header: "rgb(255, 128, 43)" },
+        "node-dropout": { DEFAULT: "rgb(220, 80, 80)", header: "rgb(180, 50, 50)" },
+        "node-batchnorm": { DEFAULT: "rgb(140, 90, 200)", header: "rgb(110, 60, 170)" },
       },
       borderRadius: {
         lg: "var(--radius)",

--- a/tensormap-frontend/vite.config.js
+++ b/tensormap-frontend/vite.config.js
@@ -17,4 +17,9 @@ export default defineConfig({
       "@": path.resolve(__dirname, "./src"),
     },
   },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: "./src/setupTests.js",
+  },
 });


### PR DESCRIPTION

Adds BatchNormalization and Dropout layer support to the TensorMap neural network builder.
Changes:

Add BatchNormalizationNode component with configurable momentum and epsilon parameters
Add DropoutNode component with configurable rate parameter (was imported in Canvas but never created)
Register both layers in Canvas nodeTypes and defaultParams
Add Dropout and BatchNorm drag items to the Sidebar
Add property editor panels for both layers in NodePropertiesPanel
Add node-batchnorm and node-dropout color tokens to tailwind.config.js
Fix canSaveModel call signature — was canSaveModel(nodes, edges), now correctly canSaveModel(modelName, {nodes, edges})
Pass computed canSave prop from Canvas down to NodePropertiesPanel (Save button was always disabled without this)

Fixes #201 

Type of Change

 Bug fix
 New feature
 Breaking change
 Documentation update


How Has This Been Tested?

 New tests added — BatchNormalizationNode.test.jsx covers render, param display, and unconfigured state
 Manual testing — dragged BatchNorm and Dropout nodes onto canvas, configured params, validated and saved model
 Frontend build passes with zero errors (✓ built in ~5s)
 ESLint and Prettier pass

Checklist

 My code follows the project's style guidelines
 I have performed a self-review
 I have added/updated documentation as needed
 My changes generate no new warnings
 Tests pass locally
How Has This Been Tested?

 New tests added — BatchNormalizationNode.test.jsx covers render, param display, and unconfigured state
 Manual testing — dragged BatchNorm and Dropout nodes onto canvas, configured params, validated and saved model
 Frontend build passes with zero errors (✓ built in ~5s)
 ESLint and Prettier pass

Checklist

 My code follows the project's style guidelines
 I have performed a self-review
 I have added/updated documentation as needed
 My changes generate no new warnings
 Tests pass locally