### PR TITLE
feat: add MaxPooling2D layer to sidebar

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
@@ -47,6 +47,13 @@ function Sidebar() {
         >
           Dropout
         </div>
+        <div
+          className="cursor-grab rounded-md border border-l-4 border-l-node-conv bg-white px-3 py-2 text-xs font-medium"
+          onDragStart={(e) => onDragStart(e, "custommaxpool")}
+          draggable
+        >
+          MaxPooling2D
+        </div>
       </CardContent>
     </Card>
   );


### PR DESCRIPTION
Description
Adds MaxPooling2D layer support to the TensorMap neural network model builder.
Changes:

Add MaxPooling2D drag item to the Sidebar with custommaxpool node type
Add border-l-node-conv color styling for the MaxPooling2D layer item

Testing:

Verified MaxPooling2D appears in the Sidebar layer list
Verified drag and drop functionality works correctly

Checklist:

 My code follows the project style guidelines
 I have performed a self-review of my code
 I have added/updated documentation as needed
 My changes generate no new warnings
 Tests pass locally
