### PR TITLE
feat: add MaxPooling2D layer to sidebar and canvas

### DIFF
--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -90,6 +90,18 @@ def _build_layer(node: dict, input_tensor):
     elif node_type == "customflatten":
         return tf.keras.layers.Flatten(name=name)(input_tensor)
 
+    elif node_type == "customdropout":
+        return tf.keras.layers.Dropout(
+            rate=float(params.get("rate", 0.5)),
+            name=name,
+        )(input_tensor)
+    elif node_type == "custommaxpool":
+        return tf.keras.layers.MaxPooling2D(
+            pool_size=int(params.get("pool_size", 2)),
+            strides=int(params.get("stride", 2)),
+            padding=params.get("padding", "valid"),
+            name=name,
+        )(input_tensor)
     elif node_type == "customconv":
         activation = params["activation"]
         return tf.keras.layers.Conv2D(

--- a/tensormap-backend/tests/test_model_generation.py
+++ b/tensormap-backend/tests/test_model_generation.py
@@ -263,3 +263,48 @@ class TestModelGeneration:
         result = model_generation(params)
         model = tf.keras.models.model_from_json(json.dumps(result))
         assert model.input_shape == (None, 28, 28, 1)
+
+
+def _maxpool_node(node_id: str, pool_size: int = 2, stride: int = 2, padding: str = "valid") -> dict:
+    return {
+        "id": node_id,
+        "type": "custommaxpool",
+        "data": {"params": {"pool_size": pool_size, "stride": stride, "padding": padding}},
+    }
+
+
+class TestMaxPoolingLayer:
+    """Unit and integration tests for the MaxPooling2D layer."""
+
+    def test_maxpool_output_shape(self):
+        input_t = tf.keras.Input(shape=(28, 28, 16), name="inp")
+        node = _maxpool_node("mp1")
+        output = _build_layer(node, input_t)
+        assert output.shape == (None, 14, 14, 16)
+
+    def test_maxpool_default_params(self):
+        input_t = tf.keras.Input(shape=(16, 16, 8), name="inp")
+        node = _maxpool_node("mp1")
+        output = _build_layer(node, input_t)
+        assert output is not None
+
+    def test_maxpool_in_model(self):
+        """input → conv → maxpool → flatten → dense end-to-end."""
+        params = {
+            "nodes": [
+                _input_node("x", [28, 28, 1]),
+                _conv_node("c1", filters=16, kernel=(3, 3), stride=(1, 1), padding="same"),
+                _maxpool_node("mp1"),
+                _flatten_node("flat"),
+                _dense_node("out", 10, "softmax"),
+            ],
+            "edges": [
+                _edge("x", "c1"),
+                _edge("c1", "mp1"),
+                _edge("mp1", "flat"),
+                _edge("flat", "out"),
+            ],
+        }
+        result = model_generation(params)
+        model = tf.keras.models.model_from_json(json.dumps(result))
+        assert model.output_shape == (None, 10)

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -30,6 +30,7 @@ import DenseNode from "./CustomNodes/DenseNode/DenseNode";
 import FlattenNode from "./CustomNodes/FlattenNode/FlattenNode";
 import ConvNode from "./CustomNodes/ConvNode/ConvNode";
 import DropoutNode from "./CustomNodes/DropoutNode/DropoutNode";
+import MaxPoolingNode from "./CustomNodes/MaxPoolingNode/MaxPoolingNode";
 import Sidebar from "./Sidebar";
 import NodePropertiesPanel from "./NodePropertiesPanel";
 import { canSaveModel, generateModelJSON } from "./Helpers";
@@ -52,6 +53,7 @@ const nodeTypes = {
   customflatten: FlattenNode,
   customconv: ConvNode,
   customdropout: DropoutNode,
+  custommaxpool: MaxPoolingNode,
 };
 
 function Canvas() {
@@ -515,6 +517,7 @@ function Canvas() {
           kernelY: "",
         },
         customdropout: { rate: "" },
+        custommaxpool: { pool_size: "", stride: "", padding: "valid" },
       };
 
       const newNode = {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/MaxPoolingNode/MaxPoolingNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/MaxPoolingNode/MaxPoolingNode.jsx
@@ -1,0 +1,33 @@
+import PropTypes from "prop-types";
+import { Handle, Position } from "reactflow";
+
+function MaxPoolingNode({ data, id }) {
+  const { pool_size, stride, padding } = data.params;
+  const isConfigured =
+    pool_size !== "" && pool_size !== undefined && stride !== "" && stride !== undefined;
+  return (
+    <div className="w-44 rounded-lg border bg-white shadow-sm">
+      <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
+      <div className="rounded-t-lg bg-node-maxpool px-3 py-1.5 text-xs font-bold text-white">
+        MaxPooling2D
+      </div>
+      <div className="px-3 py-2 text-xs text-muted-foreground">
+        {isConfigured ? `Pool: ${pool_size} | Stride: ${stride} | ${padding}` : "Not configured"}
+      </div>
+      <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />
+    </div>
+  );
+}
+
+MaxPoolingNode.propTypes = {
+  data: PropTypes.shape({
+    params: PropTypes.shape({
+      pool_size: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      stride: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      padding: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+  id: PropTypes.string.isRequired,
+};
+
+export default MaxPoolingNode;

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/MaxPoolingNode/MaxPoolingNode.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/MaxPoolingNode/MaxPoolingNode.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "reactflow";
+import MaxPoolingNode from "./MaxPoolingNode";
+
+describe("MaxPoolingNode", () => {
+  it("renders not configured when params are empty", () => {
+    render(
+      <ReactFlowProvider>
+        <MaxPoolingNode id="1" data={{ params: { pool_size: "", stride: "", padding: "valid" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("Not configured")).toBeInTheDocument();
+  });
+
+  it("renders params when configured", () => {
+    render(
+      <ReactFlowProvider>
+        <MaxPoolingNode id="1" data={{ params: { pool_size: 2, stride: 2, padding: "valid" } }} />
+      </ReactFlowProvider>,
+    );
+    expect(screen.getByText("Pool: 2 | Stride: 2 | valid")).toBeInTheDocument();
+  });
+});

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Helpers.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Helpers.jsx
@@ -5,7 +5,6 @@
 export const canSaveModel = (modelName, modelData) => {
   if (!modelName || modelName.trim() === "") return false;
   if (!modelData.nodes || modelData.nodes.length === 0) return false;
-
   for (const node of modelData.nodes) {
     if (node.type === "customdense") {
       if (
@@ -25,27 +24,28 @@ export const canSaveModel = (modelName, modelData) => {
       if (!p.filter || !p.kernelX || !p.kernelY || !p.strideX || !p.strideY) {
         return false;
       }
+    } else if (node.type === "custommaxpool") {
+      const p = node.data.params;
+      if (!p.pool_size || !p.stride) {
+        return false;
+      }
     }
-    // customflatten has no params to validate
+    // customflatten and customdropout have no required params to validate
   }
-
   return isGraphConnected(modelData);
 };
 
 const isGraphConnected = (graph) => {
   if (!graph.nodes || graph.nodes.length === 0) return false;
-
   const visited = new Set();
   const firstNodeId = graph.nodes[0].id;
   const queue = [firstNodeId];
   visited.add(firstNodeId);
-
   while (queue.length > 0) {
     const currentNodeId = queue.shift();
     const adjacentNodes = graph.edges
       .filter((edge) => edge.source === currentNodeId || edge.target === currentNodeId)
       .map((edge) => (edge.source === currentNodeId ? edge.target : edge.source));
-
     for (const nodeId of adjacentNodes) {
       if (!visited.has(nodeId)) {
         queue.push(nodeId);
@@ -67,11 +67,9 @@ export const generateModelJSON = (modelData) => {
     position: node.position,
     data: { params: node.data.params },
   }));
-
   const edges = modelData.edges.map((edge) => ({
     source: edge.source,
     target: edge.target,
   }));
-
   return { nodes, edges };
 };

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -270,6 +270,53 @@ function NodePropertiesPanel({
       </Card>
     );
   }
+  if (type === "custommaxpool") {
+    return (
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-sm">MaxPooling2D Layer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label>Pool Size</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Pool size"
+              value={params.pool_size}
+              onChange={(e) => updateParam("pool_size", Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Stride</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Stride"
+              value={params.stride}
+              onChange={(e) => updateParam("stride", Number(e.target.value))}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Padding</Label>
+            <Select value={params.padding} onValueChange={(v) => updateParam("padding", v)}>
+              <SelectTrigger>
+                <SelectValue placeholder="Padding" />
+              </SelectTrigger>
+              <SelectContent>
+                {convPaddings.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return null;
 }
 

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
@@ -1,11 +1,9 @@
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-
 function Sidebar() {
   const onDragStart = (event, nodeType) => {
     event.dataTransfer.setData("application/reactflow", nodeType);
     event.dataTransfer.effectAllowed = "move";
   };
-
   return (
     <Card className="h-full w-48 shrink-0">
       <CardHeader className="pb-3">
@@ -47,9 +45,15 @@ function Sidebar() {
         >
           Dropout
         </div>
+        <div
+          className="cursor-grab rounded-md border border-l-4 border-l-node-conv bg-white px-3 py-2 text-xs font-medium"
+          onDragStart={(e) => onDragStart(e, "custommaxpool")}
+          draggable
+        >
+          MaxPooling2D
+        </div>
       </CardContent>
     </Card>
   );
 }
-
 export default Sidebar;

--- a/tensormap-frontend/tailwind.config.js
+++ b/tensormap-frontend/tailwind.config.js
@@ -44,6 +44,7 @@ export default {
         "node-flatten": { DEFAULT: "rgb(247, 173, 20)", header: "rgb(170, 121, 24)" },
         "node-conv": { DEFAULT: "rgb(255, 128, 43)", header: "rgb(255, 128, 43)" },
         "node-dropout": { DEFAULT: "rgb(220, 80, 80)", header: "rgb(180, 50, 50)" },
+        "node-maxpool": { DEFAULT: "rgb(34, 182, 176)", header: "rgb(20, 140, 135)" },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Description

Adds MaxPooling2D layer support to the TensorMap drag-and-drop canvas so users can visually include pooling layers when designing CNN architectures.

Changes:
- `MaxPoolingNode.jsx` — new canvas node component displaying pool_size, stride, and padding
- `Canvas.jsx` — registers `custommaxpool` in nodeTypes and defaultParams
- `NodePropertiesPanel.jsx` — adds MaxPooling2D configuration panel with pool_size, stride, and padding inputs
- `Sidebar.jsx` — adds MaxPooling2D entry to the layers list

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing — dragged MaxPooling2D node onto canvas, configured pool_size/stride/padding via properties panel, verified node renders correctly

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally