### PR TITLE
fix: validate target_field before tabular model training to prevent K…

### DIFF
--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -162,6 +162,12 @@ def _run(model_name: str, db: Session) -> None:
         # Shuffle data to prevent issues with ordered datasets
         features = features.sample(frac=1, random_state=42).reset_index(drop=True)
 
+        if model_configs.target_field is None:
+        raise ValueError(
+            "Training configuration incomplete: target field is required "
+            "for tabular models. Please set the target field before training."
+        )
+
         X = features.drop(model_configs.target_field, axis=1)
         y = features[model_configs.target_field]
 

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -95,18 +95,14 @@ def _helper_generate_file_location(db: Session, file_id) -> str:
 
 def _helper_generate_json_model_file_location(model_name: str) -> str:
     """Construct the path to the model's JSON file, validating against path traversal."""
-    path = os.path.realpath(
-        os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE)
-    )
+    path = os.path.realpath(os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE))
     base_dir = os.path.realpath(MODEL_GENERATION_LOCATION)
     if not path.startswith(base_dir + os.sep) and path != base_dir:
         raise ValueError("Invalid model path: escapes model directory")
     return path
 
 
-def model_run(
-    model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None
-) -> None:
+def model_run(model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None) -> None:
     """Load, compile, and train a Keras model, emitting progress via Socket.IO."""
     global _main_loop
     _main_loop = loop
@@ -119,14 +115,10 @@ def model_run(
 
 
 def _run(model_name: str, db: Session) -> None:
-    model_configs = db.exec(
-        select(ModelBasic).where(ModelBasic.model_name == model_name)
-    ).first()
+    model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
 
     if model_configs.model_type == ProblemType.IMAGE_CLASSIFICATION:
-        image_properties = db.exec(
-            select(ImageProperties).where(ImageProperties.id == model_configs.file_id)
-        ).first()
+        image_properties = db.exec(select(ImageProperties).where(ImageProperties.id == model_configs.file_id)).first()
         image_size = (image_properties.image_size, image_properties.image_size)
         batch_size = image_properties.batch_size
         color_mode = image_properties.color_mode
@@ -164,9 +156,7 @@ def _run(model_name: str, db: Session) -> None:
             label_mode=label_mode,
         )
     else:
-        file_location = _helper_generate_file_location(
-            db, file_id=model_configs.file_id
-        )
+        file_location = _helper_generate_file_location(db, file_id=model_configs.file_id)
         features = pd.read_csv(file_location)
         features.dropna(inplace=True)
         # Shuffle data to prevent issues with ordered datasets
@@ -187,9 +177,7 @@ def _run(model_name: str, db: Session) -> None:
         x_testing = X[split_index:]
         y_testing = y[split_index:]
 
-        batch_size = (
-            model_configs.batch_size if model_configs.batch_size is not None else 32
-        )
+        batch_size = model_configs.batch_size if model_configs.batch_size is not None else 32
 
     with open(_helper_generate_json_model_file_location(model_name=model_name)) as f:
         json_string = f.read()

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -95,14 +95,18 @@ def _helper_generate_file_location(db: Session, file_id) -> str:
 
 def _helper_generate_json_model_file_location(model_name: str) -> str:
     """Construct the path to the model's JSON file, validating against path traversal."""
-    path = os.path.realpath(os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE))
+    path = os.path.realpath(
+        os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE)
+    )
     base_dir = os.path.realpath(MODEL_GENERATION_LOCATION)
     if not path.startswith(base_dir + os.sep) and path != base_dir:
         raise ValueError("Invalid model path: escapes model directory")
     return path
 
 
-def model_run(model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None) -> None:
+def model_run(
+    model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None
+) -> None:
     """Load, compile, and train a Keras model, emitting progress via Socket.IO."""
     global _main_loop
     _main_loop = loop
@@ -115,10 +119,14 @@ def model_run(model_name: str, db: Session, loop: asyncio.AbstractEventLoop | No
 
 
 def _run(model_name: str, db: Session) -> None:
-    model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    model_configs = db.exec(
+        select(ModelBasic).where(ModelBasic.model_name == model_name)
+    ).first()
 
     if model_configs.model_type == ProblemType.IMAGE_CLASSIFICATION:
-        image_properties = db.exec(select(ImageProperties).where(ImageProperties.id == model_configs.file_id)).first()
+        image_properties = db.exec(
+            select(ImageProperties).where(ImageProperties.id == model_configs.file_id)
+        ).first()
         image_size = (image_properties.image_size, image_properties.image_size)
         batch_size = image_properties.batch_size
         color_mode = image_properties.color_mode
@@ -156,17 +164,19 @@ def _run(model_name: str, db: Session) -> None:
             label_mode=label_mode,
         )
     else:
-        file_location = _helper_generate_file_location(db, file_id=model_configs.file_id)
+        file_location = _helper_generate_file_location(
+            db, file_id=model_configs.file_id
+        )
         features = pd.read_csv(file_location)
         features.dropna(inplace=True)
         # Shuffle data to prevent issues with ordered datasets
         features = features.sample(frac=1, random_state=42).reset_index(drop=True)
 
         if model_configs.target_field is None:
-        raise ValueError(
-            "Training configuration incomplete: target field is required "
-            "for tabular models. Please set the target field before training."
-        )
+            raise ValueError(
+                "Training configuration incomplete: target field is required "
+                "for tabular models. Please set the target field before training."
+            )
 
         X = features.drop(model_configs.target_field, axis=1)
         y = features[model_configs.target_field]
@@ -177,7 +187,9 @@ def _run(model_name: str, db: Session) -> None:
         x_testing = X[split_index:]
         y_testing = y[split_index:]
 
-        batch_size = model_configs.batch_size if model_configs.batch_size is not None else 32
+        batch_size = (
+            model_configs.batch_size if model_configs.batch_size is not None else 32
+        )
 
     with open(_helper_generate_json_model_file_location(model_name=model_name)) as f:
         json_string = f.read()


### PR DESCRIPTION
## Description
When training a tabular model without setting the target field, 
the backend crashed with a cryptic `KeyError: None` from pandas 
instead of a helpful validation message.

Added a None-check for `model_configs.target_field` before the 
pandas drop/select operations, raising a clear ValueError with 
an actionable message.

Fixes #212

## Type of Change
- [x] Bug fix

## How Has This Been Tested?
- [x] Manual testing
- [x] Existing tests pass

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] My changes generate no new warnings