### PR TITLE
feat: add Dropout layer support to backend

### DIFF
--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -101,5 +101,9 @@ def _build_layer(node: dict, input_tensor):
             name=name,
         )(input_tensor)
 
+    elif node_type == "customdropout":
+        rate = float(params.get("rate", 0.5))
+        return tf.keras.layers.Dropout(rate=rate, name=name)(input_tensor)
+
     else:
         raise ValueError(f"Unknown node type: {node_type}")


### PR DESCRIPTION
## Description

Adds support for the Dropout layer in the TensorMap backend model generation service.

This change allows ReactFlow graphs to include Dropout nodes that are translated into
`tf.keras.layers.Dropout` when constructing the Keras functional model.

The implementation adds handling for a new node type (`customdropout`) in
`app/services/model_generation.py`, enabling TensorMap to support dropout-based
regularization in generated deep learning models.

This contribution aligns with the TensorMap GSoC project goal of expanding the
supported layer types in the backend.

Fixes #N/A

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

All existing backend tests were executed locally after implementing the change
to ensure no regressions were introduced.

Command used:
python -m pytest


Results:
130 passed in ~3 seconds


- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing

## Screenshots (if applicable)

N/A

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [ ] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally