### PR TITLE
feat(backend): add backend-driven layer schema endpoint for canvas/compiler syn

### DIFF
--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -7,7 +7,13 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from sqlmodel import Session
 
 from app.database import get_db
-from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
+from app.schemas.deep_learning import (
+    LayerSchemaItem,
+    ModelNameRequest,
+    ModelSaveRequest,
+    ModelValidateRequest,
+    TrainingConfigRequest,
+)
 from app.services.deep_learning import (
     delete_model_service,
     get_available_model_list,
@@ -19,6 +25,7 @@ from app.services.deep_learning import (
     run_code_service,
     update_training_config_service,
 )
+from app.services.layer_registry import get_layer_schema
 from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -124,3 +131,9 @@ def get_training_history(
     """Return a paginated list of models with enriched metadata for training history view."""
     body, status_code = get_training_history_service(db, project_id=project_id, offset=offset, limit=limit)
     return JSONResponse(status_code=status_code, content=body)
+
+
+@router.get("/model/layers/schema", response_model=list[LayerSchemaItem])
+def get_layers_schema():
+    """Return backend-driven layer schema for frontend canvas and validation."""
+    return get_layer_schema()

--- a/tensormap-backend/app/schemas/deep_learning.py
+++ b/tensormap-backend/app/schemas/deep_learning.py
@@ -107,3 +107,25 @@ class TrainingConfigRequest(BaseModel):
     epochs: int = Field(gt=0)
     batch_size: int = Field(default=32, gt=0)
     project_id: uuid_pkg.UUID | None = None
+
+
+class LayerParamSchema(BaseModel):
+    """A single layer parameter definition shared with API clients."""
+
+    name: str
+    type: str
+    required: bool
+    default: Any | None = None
+    min: float | int | None = None
+    max: float | int | None = None
+    options: list[str] | None = None
+
+
+class LayerSchemaItem(BaseModel):
+    """Metadata contract for one visual layer type."""
+
+    type: str
+    label: str
+    category: str
+    compiler_supported: bool = True
+    params: list[LayerParamSchema]

--- a/tensormap-backend/app/services/layer_registry.py
+++ b/tensormap-backend/app/services/layer_registry.py
@@ -1,0 +1,85 @@
+"""Canonical layer registry exposed to API clients.
+
+This module centralizes layer metadata so frontend forms and backend
+validation can rely on a shared contract.
+"""
+
+from typing import Any
+
+_LAYER_SCHEMA: list[dict[str, Any]] = [
+    {
+        "type": "custominput",
+        "label": "Input",
+        "category": "core",
+        "compiler_supported": True,
+        "params": [
+            {"name": "dim-1", "type": "int", "required": True, "default": 28, "min": 1},
+            {"name": "dim-2", "type": "int", "required": False, "default": 28, "min": 0},
+            {"name": "dim-3", "type": "int", "required": False, "default": 1, "min": 0},
+        ],
+    },
+    {
+        "type": "customdense",
+        "label": "Dense",
+        "category": "core",
+        "compiler_supported": True,
+        "params": [
+            {"name": "units", "type": "int", "required": True, "default": 64, "min": 1},
+            {
+                "name": "activation",
+                "type": "select",
+                "required": True,
+                "default": "relu",
+                "options": ["none", "relu", "sigmoid", "tanh", "softmax", "elu", "selu"],
+            },
+        ],
+    },
+    {
+        "type": "customflatten",
+        "label": "Flatten",
+        "category": "core",
+        "compiler_supported": True,
+        "params": [],
+    },
+    {
+        "type": "customconv",
+        "label": "Conv2D",
+        "category": "cnn",
+        "compiler_supported": True,
+        "params": [
+            {"name": "filter", "type": "int", "required": True, "default": 16, "min": 1},
+            {"name": "kernelX", "type": "int", "required": True, "default": 3, "min": 1},
+            {"name": "kernelY", "type": "int", "required": True, "default": 3, "min": 1},
+            {"name": "strideX", "type": "int", "required": True, "default": 1, "min": 1},
+            {"name": "strideY", "type": "int", "required": True, "default": 1, "min": 1},
+            {
+                "name": "padding",
+                "type": "select",
+                "required": True,
+                "default": "valid",
+                "options": ["valid", "same"],
+            },
+            {
+                "name": "activation",
+                "type": "select",
+                "required": True,
+                "default": "relu",
+                "options": ["none", "relu", "sigmoid", "tanh", "softmax", "elu", "selu"],
+            },
+        ],
+    },
+    {
+        "type": "customdropout",
+        "label": "Dropout",
+        "category": "regularization",
+        "compiler_supported": True,
+        "params": [
+            {"name": "rate", "type": "float", "required": True, "default": 0.2, "min": 0.0, "max": 0.999},
+        ],
+    },
+]
+
+
+def get_layer_schema() -> list[dict[str, Any]]:
+    """Return canonical layer schema metadata for API clients."""
+    return _LAYER_SCHEMA

--- a/tensormap-backend/tests/test_api_integration.py
+++ b/tensormap-backend/tests/test_api_integration.py
@@ -154,3 +154,22 @@ def test_validate_model_valid(client: TestClient):
     assert resp.status_code == 200
     body = resp.json()
     assert body["success"] is True
+
+
+def test_get_layer_schema(client: TestClient):
+    resp = client.get("/api/v1/model/layers/schema")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert isinstance(body, list)
+    assert len(body) >= 5
+
+    by_type = {item["type"]: item for item in body}
+    assert "customdense" in by_type
+    assert "customconv" in by_type
+    assert "customdropout" in by_type
+
+    dropout = by_type["customdropout"]
+    assert dropout["compiler_supported"] is True
+    assert len(dropout["params"]) == 1
+    assert dropout["params"][0]["name"] == "rate"
+    assert dropout["params"][0]["min"] == 0.0


### PR DESCRIPTION
Closes #271

## Summary
This PR adds a backend-driven layer schema contract so frontend layer forms and backend model compiler stay aligned.

## What changed
- Added canonical layer registry:
  - `tensormap-backend/app/services/layer_registry.py`
- Added new endpoint:
  - `GET /api/v1/model/layers/schema`
  - in `tensormap-backend/app/routers/deep_learning.py`
- Added schema response models:
  - `LayerParamSchema`
  - `LayerSchemaItem`
  - in `tensormap-backend/app/schemas/deep_learning.py`
- Added API integration coverage:
  - `tests/test_api_integration.py::test_get_layer_schema`

## Response includes
For each layer:
- `type`, `label`, `category`
- `compiler_supported`
- `params[]` with metadata:
  - `name`, `type`, `required`, `default`, `min`, `max`, `options`

Current schema includes:
- `custominput`
- `customdense`
- `customflatten`
- `customconv`
- `customdropout`

## Why
Layer definitions are currently split across frontend and backend, which can cause UI/compiler drift.  
This endpoint provides a single backend source of truth for layer metadata and validation constraints.

## Notes
- This PR establishes the backend contract.
- Frontend migration to consume this endpoint can be done in follow-up PRs.