### PR TITLE
fix: add backend support for Dropout layer node (customdropout)

### DIFF
--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -113,7 +113,10 @@ def _build_model_summary(keras_model) -> dict:
 
 def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUID | None = None) -> tuple:
     """Validate a model graph with Keras, persist the configuration, and save the JSON file."""
-    model_generated = model_generation(model_params=incoming["model"])
+    try:
+        model_generated = model_generation(model_params=incoming["model"])
+    except ValueError as e:
+        return _resp(400, False, str(e))
 
     try:
         keras_model = tf.keras.models.model_from_json(json.dumps(model_generated))
@@ -195,7 +198,10 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
 
 def model_save_service(db: Session, incoming: dict, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
     """Validate a model graph with Keras and save architecture only (no training config)."""
-    model_generated = model_generation(model_params=incoming)
+    try:
+        model_generated = model_generation(model_params=incoming)
+    except ValueError as e:
+        return _resp(400, False, str(e))
 
     try:
         keras_model = tf.keras.models.model_from_json(json.dumps(model_generated))

--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -113,5 +113,11 @@ def _build_layer(node: dict, input_tensor):
             name=name,
         )(input_tensor)
 
+    elif node_type == "customdropout":
+        rate = float(params.get("rate", 0.5))
+        if not 0.0 <= rate < 1.0:
+            raise ValueError(f"Dropout rate must be in [0, 1), got {rate!r}.")
+        return tf.keras.layers.Dropout(rate=rate, name=name)(input_tensor)
+
     else:
         raise ValueError(f"Unknown node type: {node_type}")

--- a/tensormap-backend/tests/test_model_generation.py
+++ b/tensormap-backend/tests/test_model_generation.py
@@ -265,12 +265,26 @@ class TestModelGeneration:
         assert model.input_shape == (None, 28, 28, 1)
 
 
+# ===================================================================
+# Helper Builders for New Layer Types
+# ===================================================================
+
+
 def _maxpool_node(node_id: str, pool_size: int = 2, stride: int = 2, padding: str = "valid") -> dict:
     return {
         "id": node_id,
         "type": "custommaxpool",
         "data": {"params": {"pool_size": pool_size, "stride": stride, "padding": padding}},
     }
+
+
+def _dropout_node(node_id: str, rate: float | str = 0.5) -> dict:
+    return {"id": node_id, "type": "customdropout", "data": {"params": {"rate": rate}}}
+
+
+# ===================================================================
+# Tests for MaxPooling layer support
+# ===================================================================
 
 
 class TestMaxPoolingLayer:
@@ -308,3 +322,87 @@ class TestMaxPoolingLayer:
         result = model_generation(params)
         model = tf.keras.models.model_from_json(json.dumps(result))
         assert model.output_shape == (None, 10)
+
+
+# ===================================================================
+# Tests for Dropout layer support
+# ===================================================================
+
+
+class TestDropoutBuildLayer:
+    """Unit tests for the Dropout node handler in _build_layer."""
+
+    def test_dropout_preserves_output_shape(self):
+        """Dropout must not change the tensor shape."""
+        input_t = tf.keras.Input(shape=(10,), name="inp")
+        node = _dropout_node("drop1", rate="0.5")
+        output = _build_layer(node, input_t)
+        assert output.shape == (None, 10)
+
+    def test_dropout_default_rate_when_param_missing(self):
+        """Dropout defaults to rate=0.5 when the key is absent from params."""
+        input_t = tf.keras.Input(shape=(8,), name="inp")
+        node = {"id": "drop2", "type": "customdropout", "data": {"params": {}}}
+        output = _build_layer(node, input_t)
+        assert output.shape == (None, 8)
+
+    def test_dropout_rate_zero_is_valid(self):
+        """Rate of 0.0 (no dropout) is a legal value."""
+        input_t = tf.keras.Input(shape=(4,), name="inp")
+        node = _dropout_node("drop3", rate=0.0)
+        output = _build_layer(node, input_t)
+        assert output.shape == (None, 4)
+
+    def test_dropout_invalid_rate_raises_value_error(self):
+        """Rate >= 1.0 must raise ValueError with a clear message."""
+        input_t = tf.keras.Input(shape=(4,), name="inp")
+        node = _dropout_node("drop4", rate="1.0")
+        with pytest.raises(ValueError, match="rate"):
+            _build_layer(node, input_t)
+
+    def test_dropout_negative_rate_raises_value_error(self):
+        """Negative rate must raise ValueError."""
+        input_t = tf.keras.Input(shape=(4,), name="inp")
+        node = _dropout_node("drop5", rate="-0.1")
+        with pytest.raises(ValueError, match="rate"):
+            _build_layer(node, input_t)
+
+
+class TestDropoutInModelGeneration:
+    """End-to-end tests for Dropout inside a full model graph."""
+
+    def test_dense_dropout_dense_pipeline(self):
+        """input → dense → dropout → dense should build and round-trip through JSON."""
+        params = {
+            "nodes": [
+                _input_node("x", [20]),
+                _dense_node("h1", 64, "relu"),
+                _dropout_node("dropout1", rate=0.3),
+                _dense_node("out", 1, "sigmoid"),
+            ],
+            "edges": [
+                _edge("x", "h1"),
+                _edge("h1", "dropout1"),
+                _edge("dropout1", "out"),
+            ],
+        }
+        result = model_generation(params)
+        model = tf.keras.models.model_from_json(json.dumps(result))
+        assert model.output_shape == (None, 1)
+        assert any("dropout" in layer.name.lower() for layer in model.layers)
+
+    def test_model_generation_raises_for_unknown_type(self):
+        """An unsupported node type still raises ValueError (regression guard)."""
+        params = {
+            "nodes": [
+                _input_node("x", [5]),
+                _dense_node("out", 1),
+                {"id": "bad", "type": "customunknown", "data": {"params": {}}},
+            ],
+            "edges": [
+                _edge("x", "out"),
+                _edge("out", "bad"),
+            ],
+        }
+        with pytest.raises(ValueError, match="Unknown node type"):
+            model_generation(params)


### PR DESCRIPTION
## Description

Fixes #281

The frontend ships a complete Dropout layer UI — sidebar drag item, `DropoutNode`
component, and a properties panel with a rate input. The backend `_build_layer()` in
`model_generation.py` had no handler for `customdropout`, causing any model containing
a Dropout node to crash with **HTTP 500** rather than a helpful error.

The root cause is two-fold:
1. Missing `customdropout` branch in `_build_layer()`
2. The `model_generation()` call in both `model_validate_service` and
   `model_save_service` was outside `try/except`, so the `ValueError` escaped
   all error handling and hit the generic 500 handler

## Changes

| File | Change |
|---|---|
| `app/services/model_generation.py` | Add `customdropout` → `tf.keras.layers.Dropout`; validate rate ∈ [0, 1); default to 0.5 |
| `app/services/deep_learning.py` | Wrap `model_generation()` call in `try/except ValueError` in both service functions |
| `tests/test_model_generation.py` | 7 new tests: shape preservation, default rate, boundary values, invalid rates, full pipeline |

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- [x] Existing tests pass (`uv run pytest tests/test_model_generation.py -v`)
- [x] 7 new tests added covering all branches of the dropout handler
- [x] `uv run ruff check` passes with no warnings

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally