### PR TITLE
feat: add request ID middleware for request tracing

### DIFF
--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -12,7 +12,7 @@ from fastapi.middleware.cors import CORSMiddleware
 
 from app.config import get_settings
 from app.exceptions import AppException, app_exception_handler, generic_exception_handler
-from app.middleware import RequestLoggingMiddleware
+from app.middleware import RequestIDMiddleware, RequestLoggingMiddleware
 from app.routers import data_process, data_upload, deep_learning, project
 from app.shared.logging_config import get_logger
 from app.socketio_instance import sio
@@ -43,6 +43,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 
 app.add_exception_handler(AppException, app_exception_handler)

--- a/tensormap-backend/app/middleware.py
+++ b/tensormap-backend/app/middleware.py
@@ -1,7 +1,8 @@
-"""HTTP request/response logging middleware."""
+"""HTTP request/response logging and tracing middleware."""
 
 import re
 import time
+import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -20,6 +21,21 @@ def _sanitize_path(path: str) -> str:
     path = _UUID_RE.sub("{id}", path)
     path = _INT_SEGMENT_RE.sub("{id}", path)
     return path
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Add a unique request ID to each request for tracing."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = request.headers.get("X-Request-ID")
+        if not request_id:
+            request_id = str(uuid.uuid4())
+
+        request.state.request_id = request_id
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+
+        return response
 
 
 class RequestLoggingMiddleware(BaseHTTPMiddleware):


### PR DESCRIPTION
Add request ID middleware to track requests across services.

Changes:
- app/middleware.py: Add RequestIDMiddleware class
- app/main.py: Register the middleware

The middleware generates a UUID for each request if not provided,
and adds X-Request-ID header to responses.
