### PR TITLE
feat: add health check endpoints for Kubernetes

### DIFF
--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -13,7 +13,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from app.config import get_settings
 from app.exceptions import AppException, app_exception_handler, generic_exception_handler
 from app.middleware import RequestLoggingMiddleware
-from app.routers import data_process, data_upload, deep_learning, project
+from app.routers import data_process, data_upload, deep_learning, health, project
 from app.shared.logging_config import get_logger
 from app.socketio_instance import sio
 
@@ -48,6 +48,7 @@ app.add_middleware(RequestLoggingMiddleware)
 app.add_exception_handler(AppException, app_exception_handler)
 app.add_exception_handler(Exception, generic_exception_handler)
 
+app.include_router(health.router, tags=["health"])
 app.include_router(data_upload.router, prefix=settings.api_base)
 app.include_router(data_process.router, prefix=settings.api_base)
 app.include_router(deep_learning.router, prefix=settings.api_base)

--- a/tensormap-backend/app/routers/health.py
+++ b/tensormap-backend/app/routers/health.py
@@ -1,0 +1,25 @@
+"""Health check endpoints for Kubernetes and production monitoring."""
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import text
+from sqlmodel import Session
+
+from app.database import get_db
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+def health_check():
+    """Basic liveness probe."""
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+def readiness_check(db: Session = Depends(get_db)):
+    """Readiness probe - checks database connectivity."""
+    try:
+        db.exec(text("SELECT 1"))
+        return {"status": "ready", "database": "connected"}
+    except Exception:
+        return {"status": "not ready", "database": "disconnected"}


### PR DESCRIPTION
Add health check endpoints for Kubernetes liveness and readiness probes.

Changes:
- app/routers/health.py: New router with /health and /ready endpoints
- app/main.py: Register health router

- /health: Basic liveness probe
- /ready: Readiness probe with database connectivity check
