### PR TITLE
feat(frontend): add route error boundaries and retry UX for lazy-loaded pages

### DIFF
--- a/tensormap-frontend/src/App.jsx
+++ b/tensormap-frontend/src/App.jsx
@@ -1,5 +1,6 @@
 import { Suspense, lazy } from "react";
 import { BrowserRouter, Route, Routes, Navigate } from "react-router-dom";
+import { ErrorBoundary, ErrorFallback, PageLoader } from "./components/ErrorBoundary/ErrorBoundary";
 import AppTopBar from "./components/AppTopBar";
 import WorkspaceLayout from "./components/Workspace/WorkspaceLayout";
 
@@ -12,42 +13,80 @@ const Training = lazy(() => import("./containers/Training/Training"));
 /**
  * Root application component that defines all client-side routes.
  *
- * Uses lazy-loaded page components with a Suspense fallback. Routes are
- * organised into a projects listing and a per-project workspace layout
- * with nested dataset, process, model, and training pages.
+ * Uses lazy-loaded page components with Suspense and error boundaries.
+ * Routes are organised into a projects listing and a per-project workspace
+ * layout with nested dataset, process, model, and training pages.
  */
 function App() {
   return (
     <BrowserRouter>
       <AppTopBar />
-      <Suspense
-        fallback={<div className="flex h-screen items-center justify-center">Loading...</div>}
-      >
-        <Routes>
-          {/* Projects landing page */}
-          <Route path="/projects" element={<ProjectsPage />} />
+      <ErrorBoundary>
+        <Suspense fallback={<PageLoader />}>
+          <Routes>
+            {/* Projects landing page */}
+            <Route
+              path="/projects"
+              element={
+                <ErrorBoundary>
+                  <ProjectsPage />
+                </ErrorBoundary>
+              }
+            />
 
-          {/* Workspace with sidebar */}
-          <Route path="/workspace/:projectId" element={<WorkspaceLayout />}>
-            <Route index element={<Navigate to="dataset" replace />} />
-            <Route path="dataset" element={<DataUpload />} />
-            <Route path="datasets" element={<Navigate to="../dataset" replace />} />
-            <Route path="process" element={<DataProcess />} />
-            <Route path="models" element={<DeepLearning />} />
-            <Route path="training" element={<Training />} />
-          </Route>
+            {/* Workspace with sidebar */}
+            <Route path="/workspace/:projectId" element={<WorkspaceLayout />}>
+              <Route index element={<Navigate to="dataset" replace />} />
+              <Route
+                path="dataset"
+                element={
+                  <ErrorBoundary>
+                    <DataUpload />
+                  </ErrorBoundary>
+                }
+              />
+              <Route path="datasets" element={<Navigate to="../dataset" replace />} />
+              <Route
+                path="process"
+                element={
+                  <ErrorBoundary>
+                    <DataProcess />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="models"
+                element={
+                  <ErrorBoundary>
+                    <DeepLearning />
+                  </ErrorBoundary>
+                }
+              />
+              <Route
+                path="training"
+                element={
+                  <ErrorBoundary>
+                    <Training />
+                  </ErrorBoundary>
+                }
+              />
+            </Route>
 
-          {/* Legacy redirects */}
-          <Route path="/" element={<Navigate to="/projects" replace />} />
-          <Route path="/home" element={<Navigate to="/projects" replace />} />
-          <Route path="/data-upload" element={<Navigate to="/projects" replace />} />
-          <Route path="/data-process" element={<Navigate to="/projects" replace />} />
-          <Route path="/deep-learning" element={<Navigate to="/projects" replace />} />
+            {/* Legacy redirects */}
+            <Route path="/" element={<Navigate to="/projects" replace />} />
+            <Route path="/home" element={<Navigate to="/projects" replace />} />
+            <Route path="/data-upload" element={<Navigate to="/projects" replace />} />
+            <Route path="/data-process" element={<Navigate to="/projects" replace />} />
+            <Route path="/deep-learning" element={<Navigate to="/projects" replace />} />
 
-          {/* Catch-all */}
-          <Route path="*" element={<Navigate to="/projects" replace />} />
-        </Routes>
-      </Suspense>
+            {/* Catch-all */}
+            <Route
+              path="*"
+              element={<ErrorFallback error={{ message: "Page not found" }} onGoHome={() => {}} />}
+            />
+          </Routes>
+        </Suspense>
+      </ErrorBoundary>
     </BrowserRouter>
   );
 }

--- a/tensormap-frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
+++ b/tensormap-frontend/src/components/ErrorBoundary/ErrorBoundary.jsx
@@ -1,0 +1,85 @@
+import { Component } from "react";
+import { useNavigate } from "react-router-dom";
+
+/**
+ * Error boundary component that catches JavaScript errors in its children.
+ * Provides a recovery UI with retry and navigation options.
+ */
+export class ErrorBoundary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error) {
+    return { hasError: true, error };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    console.error("Route error:", error, errorInfo);
+  }
+
+  handleRetry = () => {
+    this.setState({ hasError: false, error: null });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback error={this.state.error} onRetry={this.handleRetry} />;
+    }
+
+    return this.props.children;
+  }
+}
+
+/**
+ * Standalone error fallback UI with retry and navigation.
+ * Can be used without the class component for simpler cases.
+ */
+export function ErrorFallback({ error, onRetry }) {
+  const navigate = useNavigate();
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[400px] p-8">
+      <div className="text-center max-w-md">
+        <div className="mb-4">
+          <span className="text-6xl">⚠️</span>
+        </div>
+        <h2 className="text-xl font-semibold text-gray-900 mb-2">Something went wrong</h2>
+        <p className="text-gray-600 mb-6">
+          {error?.message || "Failed to load this page. Please try again."}
+        </p>
+        <div className="flex flex-col sm:flex-row gap-3 justify-center">
+          {onRetry && (
+            <button
+              onClick={onRetry}
+              className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              Try Again
+            </button>
+          )}
+          <button
+            onClick={() => navigate("/projects")}
+            className="px-4 py-2 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 transition-colors"
+          >
+            Back to Projects
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Loading spinner component to replace text fallback.
+ */
+export function PageLoader() {
+  return (
+    <div className="flex items-center justify-center h-screen">
+      <div className="flex flex-col items-center gap-4">
+        <div className="w-10 h-10 border-4 border-blue-600 border-t-transparent rounded-full animate-spin" />
+        <span className="text-gray-600">Loading page...</span>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
Add route-level error boundaries and improved loading UX for lazy-loaded pages.

Changes:
- Add ErrorBoundary component to catch runtime errors in routes
- Add ErrorFallback with retry button and back-to-projects navigation
- Add PageLoader component with spinner to replace bare text loading
- Wrap each lazy-loaded route (ProjectsPage, DataUpload, DataProcess, DeepLearning, Training) with its own error boundary
- Global error boundary wraps the entire app for unhandled errors

This improves resilience when route chunks fail to load or pages throw during render.
