### PR TITLE
feat: add Delete option to node context menu

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -74,6 +74,8 @@ function Canvas() {
   });
   const [contextMenu, setContextMenu] = useState({ nodeId: null, x: 0, y: 0 });
   const [clearConfirmOpen, setClearConfirmOpen] = useState(false);
+  const [deleteConfirmOpen, setDeleteConfirmOpen] = useState(false);
+  const [nodeToDelete, setNodeToDelete] = useState(null);
   const defaultViewport = { x: 10, y: 15, zoom: 0.5 };
 
   const draftKey = `tensormap_draft_${projectId || "default"}`;
@@ -404,6 +406,22 @@ function Canvas() {
     closeContextMenu();
   }, [contextMenu.nodeId, setNodes, closeContextMenu, takeSnapshotAndUpdate]);
 
+  const deleteNode = useCallback(() => {
+    setNodeToDelete(contextMenu.nodeId);
+    setDeleteConfirmOpen(true);
+    closeContextMenu();
+  }, [contextMenu.nodeId, closeContextMenu]);
+
+  const confirmDeleteNode = useCallback(() => {
+    if (!nodeToDelete) return;
+    takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
+    setSelectedNodeId((prev) => (prev === nodeToDelete ? null : prev));
+    setNodes((nds) => nds.filter((n) => n.id !== nodeToDelete));
+    setEdges((eds) => eds.filter((e) => e.source !== nodeToDelete && e.target !== nodeToDelete));
+    setDeleteConfirmOpen(false);
+    setNodeToDelete(null);
+  }, [nodeToDelete, setNodes, setEdges, takeSnapshotAndUpdate]);
+
   const onNodeUpdate = useCallback(
     (nodeId, newParams) => {
       takeSnapshotAndUpdate(nodesRef.current, edgesRef.current);
@@ -542,6 +560,25 @@ function Canvas() {
         message={feedbackDialog.message}
         detail={feedbackDialog.detail}
       />
+      <Dialog open={deleteConfirmOpen} onOpenChange={setDeleteConfirmOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete node</DialogTitle>
+            <DialogDescription>
+              This will remove the node and all its connections. You can undo with{" "}
+              {isMac ? "⌘Z" : "Ctrl+Z"}.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDeleteConfirmOpen(false)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmDeleteNode}>
+              Delete
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
       <Dialog open={clearConfirmOpen} onOpenChange={setClearConfirmOpen}>
         <DialogContent>
           <DialogHeader>
@@ -639,6 +676,7 @@ function Canvas() {
               x={contextMenu.x}
               y={contextMenu.y}
               onDuplicate={duplicateNode}
+              onDelete={deleteNode}
               onClose={closeContextMenu}
             />
           )}

--- a/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.jsx
@@ -9,12 +9,11 @@ import PropTypes from "prop-types";
  * click outside the menu triggers onClose without needing document-level
  * event listeners (which would require explicit cleanup).
  */
-function ContextMenu({ x, y, onDuplicate, onClose }) {
+function ContextMenu({ x, y, onDuplicate, onDelete, onClose }) {
   return (
     <>
       {/* transparent overlay — catches clicks outside the menu */}
       <div className="fixed inset-0 z-40" onClick={onClose} />
-
       <div
         style={{ left: x, top: y }}
         className="fixed z-50 min-w-[140px] rounded-md border bg-white py-1 shadow-md"
@@ -25,6 +24,12 @@ function ContextMenu({ x, y, onDuplicate, onClose }) {
         >
           Duplicate
         </button>
+        <button
+          className="w-full px-3 py-1.5 text-left text-sm text-destructive hover:bg-red-50 hover:text-red-700"
+          onClick={onDelete}
+        >
+          Delete
+        </button>
       </div>
     </>
   );
@@ -34,6 +39,7 @@ ContextMenu.propTypes = {
   x: PropTypes.number.isRequired,
   y: PropTypes.number.isRequired,
   onDuplicate: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
   onClose: PropTypes.func.isRequired,
 };
 

--- a/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.test.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/ContextMenu.test.jsx
@@ -1,0 +1,47 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import ContextMenu from "./ContextMenu";
+
+const defaultProps = {
+  x: 100,
+  y: 200,
+  onDuplicate: vi.fn(),
+  onDelete: vi.fn(),
+  onClose: vi.fn(),
+};
+
+describe("ContextMenu", () => {
+  it("renders Duplicate and Delete buttons", () => {
+    render(<ContextMenu {...defaultProps} />);
+    expect(screen.getByText("Duplicate")).toBeDefined();
+    expect(screen.getByText("Delete")).toBeDefined();
+  });
+
+  it("calls onDuplicate when Duplicate is clicked", () => {
+    const onDuplicate = vi.fn();
+    render(<ContextMenu {...defaultProps} onDuplicate={onDuplicate} />);
+    fireEvent.click(screen.getByText("Duplicate"));
+    expect(onDuplicate).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onDelete when Delete is clicked", () => {
+    const onDelete = vi.fn();
+    render(<ContextMenu {...defaultProps} onDelete={onDelete} />);
+    fireEvent.click(screen.getByText("Delete"));
+    expect(onDelete).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onClose when overlay is clicked", () => {
+    const onClose = vi.fn();
+    render(<ContextMenu {...defaultProps} onClose={onClose} />);
+    const overlay = document.querySelector(".fixed.inset-0");
+    fireEvent.click(overlay);
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("Delete button has destructive styling", () => {
+    render(<ContextMenu {...defaultProps} />);
+    const deleteBtn = screen.getByText("Delete");
+    expect(deleteBtn.className).toContain("text-destructive");
+  });
+});


### PR DESCRIPTION
- Add Delete button to ContextMenu component (right-click on any node)
- Wire deleteNode handler in Canvas that removes node and its edges
- Snapshot taken before deletion so Ctrl+Z restores the node
- onDelete prop added to ContextMenu with PropTypes validation

## Description

Brief summary of the changes. Reference any related issues.

Fixes #206 

## Type of Change

- [ ] Bug fix
- [x] New feature
- [x] Breaking change
- [x] Documentation update

## How Has This Been Tested?

Describe the tests you ran to verify your changes.

- [x] Existing tests pass
- [ ] New tests added
- [x] Manual testing



## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
