### PR TITLE
Add /model/check-name and /model/count endpoints

### DIFF
--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -9,6 +9,7 @@ from contextlib import asynccontextmanager
 import socketio
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse
 
 from app.config import get_settings
 from app.exceptions import AppException, app_exception_handler, generic_exception_handler
@@ -52,6 +53,31 @@ app.include_router(data_upload.router, prefix=settings.api_base)
 app.include_router(data_process.router, prefix=settings.api_base)
 app.include_router(deep_learning.router, prefix=settings.api_base)
 app.include_router(project.router, prefix=settings.api_base)
+
+
+@app.get("/health")
+def health_check():
+    """Basic health check - app is running."""
+    return {"status": "ok", "service": "tensormap"}
+
+
+@app.get("/ready")
+def readiness_check():
+    """Readiness check - verify DB is accessible."""
+    from sqlmodel import text
+
+    from app.database import get_db
+
+    try:
+        with next(get_db()) as db:
+            db.execute(text("SELECT 1")).first()
+        return {"status": "ready", "database": "connected"}
+    except Exception as e:
+        return JSONResponse(
+            status_code=503,
+            content={"status": "not ready", "database": "disconnected", "error": str(e)},
+        )
+
 
 # Wrap FastAPI with SocketIO so socket.io requests are handled,
 # and everything else passes through to FastAPI.

--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -9,9 +9,11 @@ from sqlmodel import Session
 from app.database import get_db
 from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
 from app.services.deep_learning import (
+    check_model_name_service,
     delete_model_service,
     get_available_model_list,
     get_code_service,
+    get_model_count_service,
     get_model_graph_service,
     model_save_service,
     model_validate_service,
@@ -110,4 +112,27 @@ def get_model_list(
 ):
     """Return a paginated list of saved model names, optionally filtered by project."""
     body, status_code = get_available_model_list(db, project_id=project_id, offset=offset, limit=limit)
+    return JSONResponse(status_code=status_code, content=body)
+
+
+@router.get("/model/check-name")
+def check_model_name(
+    model_name: str,
+    project_id: uuid_pkg.UUID | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Check if a model name is available before trying to save."""
+    logger.debug("Checking model name: %s", model_name)
+    body, status_code = check_model_name_service(db, model_name=model_name, project_id=project_id)
+    return JSONResponse(status_code=status_code, content=body)
+
+
+@router.get("/model/count")
+def get_model_count(
+    project_id: uuid_pkg.UUID | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Get the total count of saved models."""
+    logger.debug("Getting model count for project_id=%s", project_id)
+    body, status_code = get_model_count_service(db, project_id=project_id)
     return JSONResponse(status_code=status_code, content=body)

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -464,6 +464,28 @@ def get_available_model_list(
     return body, 200
 
 
+def check_model_name_service(db: Session, model_name: str, project_id: uuid_pkg.UUID | None = None) -> tuple:
+    """Check if a model name is available or already taken."""
+    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
+    if project_id is not None:
+        stmt = stmt.where(ModelBasic.project_id == project_id)
+    existing = db.exec(stmt).first()
+
+    if existing:
+        return {"success": False, "message": "Model name already in use", "data": {"available": False}}, 200
+    return {"success": True, "message": "Model name is available", "data": {"available": True}}, 200
+
+
+def get_model_count_service(db: Session, project_id: uuid_pkg.UUID | None = None) -> tuple:
+    """Get model count, optionally scoped to a project."""
+    stmt = select(func.count(ModelBasic.id))
+    if project_id is not None:
+        stmt = stmt.where(ModelBasic.project_id == project_id)
+
+    total = db.exec(stmt).one()
+    return {"success": True, "message": "Model count retrieved", "data": {"count": total}}, 200
+
+
 def delete_model_service(db: Session, model_id: int) -> tuple:
     """Delete a model and its associated ModelConfigs (cascade), and remove the JSON file."""
     model = db.get(ModelBasic, model_id)


### PR DESCRIPTION
New backend endpoints for better model management.

## What this adds
- **GET /api/v1/model/check-name?model_name=xyz** — Check if a model name is available before saving (returns {available: true/false})
- **GET /api/v1/model/count** — Get total count of models (optionally scoped by project_id)

## Why useful
- Frontend can prevent duplicate model names with a quick check before trying to save
- Dashboard badges and counts can be shown without loading full model list
- Simple improvement that doesn't exist in the API today