### PR TITLE
Full-stack model export service - SavedModel, TFLite, and ONNX support

### DIFF
--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -10,6 +10,7 @@ from app.database import get_db
 from app.schemas.deep_learning import ModelNameRequest, ModelSaveRequest, ModelValidateRequest, TrainingConfigRequest
 from app.services.deep_learning import (
     delete_model_service,
+    export_model_service,
     get_available_model_list,
     get_code_service,
     get_model_graph_service,
@@ -110,4 +111,17 @@ def get_model_list(
 ):
     """Return a paginated list of saved model names, optionally filtered by project."""
     body, status_code = get_available_model_list(db, project_id=project_id, offset=offset, limit=limit)
+    return JSONResponse(status_code=status_code, content=body)
+
+
+@router.get("/model/export/{model_name}")
+def export_model(
+    model_name: str,
+    format: str = Query("savedmodel", regex="^(savedmodel|tflite|onnx)$"),
+    project_id: uuid_pkg.UUID | None = Query(None),
+    db: Session = Depends(get_db),
+):
+    """Export a trained model in the specified format."""
+    logger.debug("Exporting model %s as %s", model_name, format)
+    body, status_code = export_model_service(db, model_name=model_name, export_format=format, project_id=project_id)
     return JSONResponse(status_code=status_code, content=body)

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -486,3 +486,99 @@ def delete_model_service(db: Session, model_id: int) -> tuple:
 
     logger.info("Model '%s' (id=%s) deleted successfully", model_name, model_id)
     return _resp(200, True, f"Model '{model_name}' deleted successfully")
+
+
+def export_model_service(
+    db: Session, model_name: str, export_format: str = "savedmodel", project_id: uuid_pkg.UUID | None = None
+) -> tuple:
+    """Export a trained model in the specified format.
+
+    Args:
+        db: Database session.
+        model_name: Name of the model to export.
+        export_format: One of 'savedmodel' or 'tflite'.
+        project_id: Optional project ID for scoping.
+
+    Returns:
+        Tuple of (response_body, status_code).
+    """
+    from sqlmodel import select
+
+    stmt = select(ModelBasic).where(ModelBasic.model_name == model_name)
+    if project_id is not None:
+        stmt = stmt.where(ModelBasic.project_id == project_id)
+    model = db.exec(stmt).first()
+
+    if not model:
+        return {"success": False, "message": f"Model '{model_name}' not found", "data": None}, 404
+
+    model_path = os.path.join(MODEL_GENERATION_LOCATION, model_name + MODEL_GENERATION_TYPE)
+    if not os.path.exists(model_path):
+        return {"success": False, "message": "Model file not found on disk", "data": None}, 404
+
+    try:
+        loaded_model = tf.keras.models.load_model(model_path)
+    except Exception as e:
+        logger.error("Failed to load model from %s: %s", model_path, e)
+        return {"success": False, "message": f"Could not load model: {e}", "data": None}, 400
+
+    export_dir = os.path.join(MODEL_GENERATION_LOCATION, f"{model_name}_export", export_format)
+    os.makedirs(export_dir, exist_ok=True)
+
+    try:
+        if export_format == "savedmodel":
+            saved_path = os.path.join(export_dir, model_name)
+            loaded_model.save(saved_path)
+            return (
+                {
+                    "success": True,
+                    "message": f"Model exported to {saved_path}",
+                    "data": {"path": saved_path, "format": "savedmodel"},
+                },
+                200,
+            )
+
+        elif export_format == "tflite":
+            converter = tf.lite.TFLiteConverter.from_keras_model(loaded_model)
+            converter.optimizations = [tf.lite.Optimize.DEFAULT]
+            tflite_model = converter.convert()
+            tflite_path = os.path.join(export_dir, f"{model_name}.tflite")
+            with open(tflite_path, "wb") as f:
+                f.write(tflite_model)
+            return {
+                "success": True,
+                "message": f"Model exported to {tflite_path}",
+                "data": {"path": tflite_path, "format": "tflite"},
+            }, 200
+
+        elif export_format == "onnx":
+            try:
+                import tf2onnx
+            except ImportError:
+                return {
+                    "success": False,
+                    "message": "ONNX not available - install tf2onnx: pip install tf2onnx",
+                    "data": None,
+                }, 501
+
+            onnx_path = os.path.join(export_dir, f"{model_name}.onnx")
+            try:
+                tf2onnx.convert.from_keras(loaded_model, output_path=onnx_path)
+            except Exception as e:
+                return {
+                    "success": False,
+                    "message": f"ONNX conversion failed: {e}",
+                    "data": None,
+                }, 400
+
+            return {
+                "success": True,
+                "message": f"Model exported to {onnx_path}",
+                "data": {"path": onnx_path, "format": "onnx"},
+            }, 200
+
+        return {"success": False, "message": f"Unsupported format: {export_format}", "data": None}, 400
+
+    except Exception as e:
+        logger.error("Export failed for %s: %s", model_name, e)
+        return {"success": False, "message": f"Export failed: {e}", "data": None}, 500

--- a/tensormap-backend/tests/test_model_export.py
+++ b/tensormap-backend/tests/test_model_export.py
@@ -1,0 +1,96 @@
+"""Unit tests for the deep_learning service — export_model_service.
+
+Tests verify export_model_service returns correct responses for different scenarios.
+"""
+
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.ml import ModelBasic
+
+sys.modules.setdefault("tensorflow", MagicMock())
+sys.modules.setdefault("flatten_json", MagicMock())
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_model():
+    m = MagicMock(spec=ModelBasic)
+    m.id = 1
+    m.model_name = "test_model"
+    m.project_id = None
+    return m
+
+
+class TestExportModelService:
+    """Tests for export_model_service."""
+
+    @pytest.mark.parametrize("export_format,expected_format", [
+        ("savedmodel", "savedmodel"),
+        ("tflite", "tflite"),
+        ("onnx", "onnx"),
+    ])
+    def test_supported_formats(self, mock_db, sample_model, export_format, expected_format):
+        """All supported formats are accepted in the regex."""
+        from app.services.deep_learning import export_model_service
+
+        mock_db.exec.return_value.first.return_value = sample_model
+        mock_model = MagicMock(save=MagicMock())
+
+        with (
+            patch("app.services.deep_learning.os.path.exists", return_value=True),
+            patch("tensorflow.keras.models.load_model", return_value=mock_model),
+            patch("app.services.deep_learning.os.path.join", return_value="/export/test_model"),
+            patch("app.services.deep_learning.os.makedirs"),
+            patch("builtins.open", MagicMock()),
+        ):
+            body, status = export_model_service(mock_db, "test_model", export_format)
+
+        assert status == 200
+        assert body["success"] is True
+        assert body["data"]["format"] == expected_format
+
+    def test_model_not_found_returns_404(self, mock_db):
+        """Returns 404 when model doesn't exist."""
+        from app.services.deep_learning import export_model_service
+
+        mock_db.exec.return_value.first.return_value = None
+
+        body, status = export_model_service(mock_db, "nonexistent", "savedmodel")
+
+        assert status == 404
+        assert body["success"] is False
+
+    def test_unsupported_format_returns_400(self, mock_db, sample_model):
+        """Returns 400 for unsupported format."""
+        from app.services.deep_learning import export_model_service
+
+        mock_db.exec.return_value.first.return_value = sample_model
+        mock_model = MagicMock()
+
+        with (
+            patch("app.services.deep_learning.os.path.exists", return_value=True),
+            patch("tensorflow.keras.models.load_model", return_value=mock_model),
+        ):
+            body, status = export_model_service(mock_db, "test_model", "invalid")
+
+        assert status == 400
+        assert "Unsupported format" in body["message"]
+
+    def test_missing_file_returns_404(self, mock_db, sample_model):
+        """Returns 404 when model file is missing from disk."""
+        from app.services.deep_learning import export_model_service
+
+        mock_db.exec.return_value.first.return_value = sample_model
+
+        with patch("app.services.deep_learning.os.path.exists", return_value=False):
+            body, status = export_model_service(mock_db, "test_model", "savedmodel")
+
+        assert status == 404
+        assert "not found on disk" in body["message"]

--- a/tensormap-frontend/src/constants/Urls.js
+++ b/tensormap-frontend/src/constants/Urls.js
@@ -25,3 +25,4 @@ export const BACKEND_UPDATE_TRAINING_CONFIG = "/model/training-config";
 export const BACKEND_DELETE_MODEL = "/model";
 export const BACKEND_PROJECT = "/project";
 export const BACKEND_GET_COLUMN_STATS = "/data/process/stats/";
+export const BACKEND_MODEL_EXPORT = "/model/export";

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -33,6 +33,7 @@ import {
   getAllModels,
   updateTrainingConfig,
   deleteModel,
+  exportModel,
 } from "../../services/ModelServices";
 import { getAllFiles } from "../../services/FileServices";
 import { models as modelListAtom } from "../../shared/atoms";
@@ -401,6 +402,18 @@ export default function Training() {
     }
   };
 
+  const handleExport = async (format) => {
+    if (!selectedModel) return;
+    setIsLoading(true);
+    try {
+      await exportModel(selectedModel, format, projectId);
+    } catch (error) {
+      setResultValues([error.response?.data?.message ?? "Export failed"]);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
   const handleRun = () => {
     if (!selectedModel) return;
 
@@ -550,6 +563,27 @@ export default function Training() {
               variant="outline"
             >
               Download Code
+            </Button>
+            <Button
+              onClick={() => handleExport("savedmodel")}
+              disabled={!selectedModel || !configSaved || isLoading}
+              variant="outline"
+            >
+              Export (SavedModel)
+            </Button>
+            <Button
+              onClick={() => handleExport("tflite")}
+              disabled={!selectedModel || !configSaved || isLoading}
+              variant="outline"
+            >
+              Export (TFLite)
+            </Button>
+            <Button
+              onClick={() => handleExport("onnx")}
+              disabled={!selectedModel || !configSaved || isLoading}
+              variant="outline"
+            >
+              Export (ONNX)
             </Button>
             <Button
               onClick={handleRun}

--- a/tensormap-frontend/src/services/ModelServices.js
+++ b/tensormap-frontend/src/services/ModelServices.js
@@ -170,3 +170,41 @@ export const runModel = async (modelName, projectId) => {
       throw err;
     });
 };
+
+/**
+ * Export a trained model in the specified format.
+ *
+ * @param {string} model_name - Name of the model to export
+ * @param {string} format - Export format: 'savedmodel', 'tflite', or 'onnx'
+ * @param {string} [projectId] - Optional project ID
+ * @returns {Promise<void>}
+ */
+export const exportModel = async (model_name, format, projectId) => {
+  const params = new URLSearchParams({ format });
+  if (projectId) params.append("project_id", projectId);
+
+  return axios
+    .get(`${urls.BACKEND_MODEL_EXPORT}/${model_name}?${params}`, { responseType: "blob" })
+    .then((resp) => {
+      if (resp.status === 200) {
+        let extension = format;
+        if (format === "savedmodel") extension = "tar.gz";
+
+        const link = document.createElement("a");
+        link.href = window.URL.createObjectURL(new Blob([resp.data]));
+        link.download = `${model_name}.${extension}`;
+        document.body.appendChild(link);
+        link.click();
+        setTimeout(() => {
+          window.URL.revokeObjectURL(link.href);
+          document.body.removeChild(link);
+        }, 200);
+      } else {
+        throw new Error("Export failed");
+      }
+    })
+    .catch((err) => {
+      logger.error(err);
+      throw err;
+    });
+};


### PR DESCRIPTION
## Summary

Add the ability to export trained TensorFlow models in three popular formats:

- **SavedModel** - TensorFlow's native format for deployment and serving
- **TFLite** - TensorFlow Lite for mobile/edge deployment  
- **ONNX** - Open Neural Network Exchange for cross-platform interoperability

## Backend Changes

- New endpoint: 
- New service function:  handling all three formats
- Graceful error handling for missing tf2onnx package (returns 501 if not installed)
- Validation for model existence and file on disk

## Frontend Changes  

- Added three export buttons in Training page:
  - Export (SavedModel)
  - Export (TFLite)
  - Export (ONNX)
- New service function:  in ModelServices.js
- Uses blob download for file export

## Testing

- Added unit tests for export_model_service:
  - Test model not found (404)
  - Test file not on disk (404)  
  - Test unsupported format (400)
  - Test all three formats succeed

---

This addresses the model export feature from the GSoC blueprints - enables users to export trained models for deployment to various platforms.