### PR TITLE
fix: validate disconnected nodes and exclude input nodes from outputs

### DIFF
--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -67,8 +67,20 @@ def model_generation(model_params: dict) -> dict:
             node = nodes_by_id[target_id]
             keras_tensors[target_id] = _build_layer(node, input_tensor)
 
+    # Identify input and output tensors
+    unvisited_non_input = {
+        nid for nid in nodes_by_id if nid not in visited and nodes_by_id[nid]["type"] != "custominput"
+    }
+    if unvisited_non_input:
+        raise ValueError(
+            f"Disconnected nodes detected: {unvisited_non_input}. "
+            "Please connect all layers before generating the model."
+        )
+
     inputs = [keras_tensors[n["id"]] for n in model_params["nodes"] if n["type"] == "custominput"]
-    output_ids = [n["id"] for n in model_params["nodes"] if n["id"] not in source_to_targets]
+    output_ids = [
+        n["id"] for n in model_params["nodes"] if n["id"] not in source_to_targets and n["type"] != "custominput"
+    ]
     outputs = [keras_tensors[oid] for oid in output_ids]
 
     model = tf.keras.Model(inputs=inputs, outputs=outputs)

--- a/tensormap-backend/tests/test_model_generation.py
+++ b/tensormap-backend/tests/test_model_generation.py
@@ -264,6 +264,19 @@ class TestModelGeneration:
         model = tf.keras.models.model_from_json(json.dumps(result))
         assert model.input_shape == (None, 28, 28, 1)
 
+    def test_disconnected_node_raises_value_error(self):
+        """A node not reachable from any input must raise ValueError."""
+        params = {
+            "nodes": [
+                _input_node("in", [10]),
+                _dense_node("out", 1),
+                _dense_node("isolated", 1),
+            ],
+            "edges": [_edge("in", "out")],
+        }
+        with pytest.raises(ValueError, match="Disconnected nodes detected"):
+            model_generation(params)
+
 
 # ===================================================================
 # Helper Builders for New Layer Types


### PR DESCRIPTION
## Problem
Closes #244
Supersedes #245

Two bugs in model_generation.py silently broke model generation:

- Disconnected nodes caused a KeyError crash — BFS never visits 
  unconnected layers but the code still tries to access them in 
  keras_tensors

- Input nodes were misidentified as outputs — custominput nodes 
  with no outgoing edges were included in output_ids, producing 
  malformed Keras models silently

## Fix
- Added validation after BFS loop that raises a clear ValueError 
  listing exactly which nodes are disconnected
- Fixed output_ids filter to exclude custominput nodes

## Testing
- Disconnected canvas nodes → clear error message shown ✅
- Connected canvas → model generates correctly ✅
- Iris sample project still works perfectly ✅

## Note
Fresh PR as requested by @ivantha from #245.
Rebased on latest main, single clean commit, all checks passing.