### PR TITLE
ci: add backend unit tests to CI workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,11 +1,34 @@
-name: Integration Tests
+name: Tests
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
-  integration-test:
+  backend-unit-tests:
+    name: Backend Unit Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: tensormap-backend
+        run: uv sync --frozen --extra dev
+
+      - name: Run backend unit tests
+        working-directory: tensormap-backend
+        run: uv run pytest tests/ -v --tb=short
+
+  integration-tests:
+    name: Integration Tests
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -24,4 +47,4 @@ jobs:
 
       - name: Run integration tests
         working-directory: tensormap-backend
-        run: uv run pytest ../tests/integration/ -v
+        run: uv run pytest ../tests/integration/ -v --tb=short


### PR DESCRIPTION
## Summary

The CI `integration-tests.yml` workflow only ran integration tests, leaving the 162 backend unit tests in `tensormap-backend/tests/` completely untested in CI. This PR splits the single `integration-test` job into two parallel jobs:

- **`backend-unit-tests`**: Runs `pytest tests/` against the backend unit test suite
- **`integration-tests`**: Runs `pytest ../tests/integration/` against the full integration suite

## Changes

- Renamed workflow from `Integration Tests` to `Tests` for accuracy
- Added a dedicated `backend-unit-tests` job that runs `uv run pytest tests/ -v --tb=short`
- Both jobs run in parallel on PRs to `main` with separate checkout/setup for clean environments

## Validation

- All 162 backend unit tests pass locally (`162 passed in 2.54s`)
- No changes to application code — only CI workflow changes

## Risk

- Zero application code changes
- CI-only change that adds test coverage
- Both jobs run independently and in parallel

## Files Changed

- `.github/workflows/integration-tests.yml` — split into two parallel test jobs