### PR TITLE
ci: add backend unit tests to Tests workflow

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,10 +1,31 @@
-name: Integration Tests
+name: Tests
 
 on:
   pull_request:
     branches: [main]
 
 jobs:
+  backend-unit-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: astral-sh/setup-uv@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install dependencies
+        working-directory: tensormap-backend
+        run: uv sync --frozen --extra dev
+
+      - name: Run backend unit tests
+        working-directory: tensormap-backend
+        run: uv run pytest tests/ -v --tb=short
+
   integration-test:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Summary

The CI pipeline runs integration tests via the existing `integration-test` job but never runs the 162 backend unit tests in `tensormap-backend/tests/`. This PR adds a parallel `backend-unit-tests` job.

## Changes

- Renamed workflow from `Integration Tests` to `Tests` to reflect broader scope
- Added `backend-unit-tests` job that runs `pytest tests/ -v --tb=short` via uv
- Both jobs run in parallel on PRs to `main`

## Validation

- All 162 backend unit tests pass locally on Python 3.12
- No changes to application code — CI workflow only
- Single commit, rebased on latest `main`

## Files Changed

- `.github/workflows/integration-tests.yml` — added parallel backend unit test job
