### PR TITLE
ci: add frontend unit tests workflow

### DIFF
--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22
+          node-version: "22.12"
           cache: npm
           cache-dependency-path: tensormap-frontend/package-lock.json
 
@@ -24,4 +24,4 @@ jobs:
 
       - name: Run tests
         working-directory: tensormap-frontend
-        run: npm run test:ci
+        run: npm test

--- a/.github/workflows/frontend-tests.yml
+++ b/.github/workflows/frontend-tests.yml
@@ -1,0 +1,27 @@
+name: Frontend Tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  frontend-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: tensormap-frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: tensormap-frontend
+        run: npm ci
+
+      - name: Run tests
+        working-directory: tensormap-frontend
+        run: npm run test:ci

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -37,7 +37,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || '' }}
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: "22.12"
           cache: npm
           cache-dependency-path: tensormap-frontend/package-lock.json
       - run: npm ci

--- a/tensormap-frontend/package.json
+++ b/tensormap-frontend/package.json
@@ -31,8 +31,7 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext js,jsx --fix",
     "prettier": "prettier . --write",
-    "test": "vitest run",
-    "test:ci": "vitest run --reporter=default"
+    "test": "vitest run"
   },
   "engines": {
     "node": ">=22.12.0",

--- a/tensormap-frontend/package.json
+++ b/tensormap-frontend/package.json
@@ -31,7 +31,8 @@
     "lint": "eslint . --ext js,jsx --report-unused-disable-directives --max-warnings 0",
     "lint:fix": "eslint . --ext js,jsx --fix",
     "prettier": "prettier . --write",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:ci": "vitest run --reporter=default"
   },
   "engines": {
     "node": ">=22.12.0",


### PR DESCRIPTION
## Summary

The 45 frontend unit tests across 9 test files in `tensormap-frontend/src/` were never executed in CI. This PR adds a dedicated workflow that runs vitest on every PR to `main`.

## Changes

- Added `.github/workflows/frontend-tests.yml` — runs `npm run test:ci` on PRs to `main`
- Added `test:ci` script to `package.json` (`vitest run --reporter=default`) for CI-optimized output

## Validation

- All 45 frontend unit tests pass locally (9 test files)
- No changes to application code

## Files Changed

- `tensormap-frontend/package.json` — added `test:ci` script
- `.github/workflows/frontend-tests.yml` — new frontend test workflow
