### PR TITLE
feat: add request ID middleware for request tracing

### DIFF
--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -51,8 +51,8 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
-app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
+app.add_middleware(RequestIDMiddleware)
 
 app.add_exception_handler(AppException, app_exception_handler)
 app.add_exception_handler(IntegrityError, integrity_error_handler)

--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -20,7 +20,7 @@ from app.exceptions import (
     integrity_error_handler,
     validation_exception_handler,
 )
-from app.middleware import RequestLoggingMiddleware
+from app.middleware import RequestIDMiddleware, RequestLoggingMiddleware
 from app.routers import data_process, data_upload, deep_learning, health, project
 from app.shared.logging_config import get_logger
 from app.socketio_instance import sio
@@ -51,6 +51,7 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+app.add_middleware(RequestIDMiddleware)
 app.add_middleware(RequestLoggingMiddleware)
 
 app.add_exception_handler(AppException, app_exception_handler)

--- a/tensormap-backend/app/middleware.py
+++ b/tensormap-backend/app/middleware.py
@@ -1,7 +1,8 @@
-"""HTTP request/response logging middleware."""
+"""HTTP request/response logging and tracing middleware."""
 
 import re
 import time
+import uuid
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -13,6 +14,16 @@ logger = get_logger(__name__)
 
 _UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
 _INT_SEGMENT_RE = re.compile(r"(?<=/)\d+(?=/|$)")
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """Attach a unique X-Request-ID header to every response for request tracing."""
+
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
+        response = await call_next(request)
+        response.headers["X-Request-ID"] = request_id
+        return response
 
 
 def _sanitize_path(path: str) -> str:

--- a/tensormap-backend/app/middleware.py
+++ b/tensormap-backend/app/middleware.py
@@ -1,8 +1,10 @@
 """HTTP request/response logging and tracing middleware."""
 
+import logging
 import re
 import time
 import uuid
+from contextvars import ContextVar
 
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.requests import Request
@@ -15,15 +17,38 @@ logger = get_logger(__name__)
 _UUID_RE = re.compile(r"[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}", re.IGNORECASE)
 _INT_SEGMENT_RE = re.compile(r"(?<=/)\d+(?=/|$)")
 
+request_id_var: ContextVar[str] = ContextVar("request_id", default="")
+
+
+class RequestIDFilter(logging.Filter):
+    """Inject the current request ID into every log record as ``request_id``."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = request_id_var.get()
+        return True
+
+
+# Register the filter on the root logger so every module benefits.
+logging.getLogger().addFilter(RequestIDFilter())
+
 
 class RequestIDMiddleware(BaseHTTPMiddleware):
     """Attach a unique X-Request-ID header to every response for request tracing."""
 
     async def dispatch(self, request: Request, call_next) -> Response:
-        request_id = request.headers.get("X-Request-ID", str(uuid.uuid4()))
-        response = await call_next(request)
-        response.headers["X-Request-ID"] = request_id
-        return response
+        raw_id = request.headers.get("X-Request-ID", "")
+        if raw_id and _UUID_RE.fullmatch(raw_id):
+            request_id = raw_id
+        else:
+            request_id = str(uuid.uuid4())
+
+        token = request_id_var.set(request_id)
+        try:
+            response = await call_next(request)
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            request_id_var.reset(token)
 
 
 def _sanitize_path(path: str) -> str:
@@ -47,10 +72,12 @@ class RequestLoggingMiddleware(BaseHTTPMiddleware):
             route = request.scope.get("route")
             path = route.path if route is not None else _sanitize_path(request.url.path)
             status = response.status_code if response is not None else 500
+            req_id = request_id_var.get()
             logger.info(
-                "%s %s → %d (%.1fms)",
+                "%s %s → %d (%.1fms) [request_id=%s]",
                 request.method,
                 path,
                 status,
                 duration_ms,
+                req_id,
             )

--- a/tensormap-backend/app/middleware.py
+++ b/tensormap-backend/app/middleware.py
@@ -37,10 +37,7 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
 
     async def dispatch(self, request: Request, call_next) -> Response:
         raw_id = request.headers.get("X-Request-ID", "")
-        if raw_id and _UUID_RE.fullmatch(raw_id):
-            request_id = raw_id
-        else:
-            request_id = str(uuid.uuid4())
+        request_id = raw_id if raw_id and _UUID_RE.fullmatch(raw_id) else str(uuid.uuid4())
 
         token = request_id_var.set(request_id)
         try:

--- a/tensormap-backend/tests/test_logging_middleware.py
+++ b/tensormap-backend/tests/test_logging_middleware.py
@@ -1,5 +1,7 @@
 """Tests for RequestLoggingMiddleware — verifies every request is logged."""
 
+import uuid
+
 import pytest
 from fastapi import FastAPI
 from fastapi.responses import JSONResponse
@@ -86,6 +88,20 @@ def id_client():
     return TestClient(test_app)
 
 
+@pytest.fixture()
+def id_logging_client():
+    """Minimal app with both middlewares, ordered as in production."""
+    test_app = FastAPI()
+    test_app.add_middleware(RequestLoggingMiddleware)
+    test_app.add_middleware(RequestIDMiddleware)
+
+    @test_app.get("/test")
+    def test_route():
+        return {"ok": True}
+
+    return TestClient(test_app)
+
+
 def test_request_id_added_to_response(id_client):
     """Every response should receive an X-Request-ID header."""
     response = id_client.get("/test")
@@ -96,14 +112,13 @@ def test_request_id_is_valid_uuid(id_client):
     """The generated request ID should be a valid UUID string."""
     response = id_client.get("/test")
     request_id = response.headers["X-Request-ID"]
-    parts = request_id.split("-")
-    assert len(parts) == 5
-    assert all(len(p) in (8, 4, 4, 4, 12) for p in parts)
+    parsed = uuid.UUID(request_id)
+    assert str(parsed) == request_id
 
 
 def test_request_id_preserves_client_value(id_client):
-    """If the client sends X-Request-ID, the same value should be returned."""
-    client_id = "my-custom-trace-id"
+    """If the client sends a valid UUID X-Request-ID, the same value should be echoed."""
+    client_id = "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
     response = id_client.get("/test", headers={"X-Request-ID": client_id})
     assert response.headers["X-Request-ID"] == client_id
 
@@ -113,3 +128,18 @@ def test_request_id_unique_per_request(id_client):
     r1 = id_client.get("/test")
     r2 = id_client.get("/test")
     assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]
+
+
+def test_invalid_client_id_is_overridden(id_client):
+    """A non-UUID client X-Request-ID should be replaced with a new UUID."""
+    response = id_client.get("/test", headers={"X-Request-ID": "not-a-uuid"})
+    raw = response.headers["X-Request-ID"]
+    parsed = uuid.UUID(raw)
+    assert str(parsed) == raw
+
+
+def test_request_id_in_logs(id_logging_client, caplog):
+    """Request ID should appear in the middleware log line."""
+    with caplog.at_level("INFO", logger="app.middleware"):
+        id_logging_client.get("/test")
+    assert "request_id=" in caplog.text

--- a/tensormap-backend/tests/test_logging_middleware.py
+++ b/tensormap-backend/tests/test_logging_middleware.py
@@ -5,7 +5,7 @@ from fastapi import FastAPI
 from fastapi.responses import JSONResponse
 from fastapi.testclient import TestClient
 
-from app.middleware import RequestLoggingMiddleware
+from app.middleware import RequestIDMiddleware, RequestLoggingMiddleware
 
 
 @pytest.fixture()
@@ -66,3 +66,50 @@ def test_existing_handlers_unaffected(client):
     response = client.get("/health")
     assert response.status_code == 200
     assert response.json() == {"ok": True}
+
+
+# ---------------------------------------------------------------------------
+# RequestIDMiddleware
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def id_client():
+    """Minimal app with RequestIDMiddleware only."""
+    test_app = FastAPI()
+    test_app.add_middleware(RequestIDMiddleware)
+
+    @test_app.get("/test")
+    def test_route():
+        return {"ok": True}
+
+    return TestClient(test_app)
+
+
+def test_request_id_added_to_response(id_client):
+    """Every response should receive an X-Request-ID header."""
+    response = id_client.get("/test")
+    assert "X-Request-ID" in response.headers
+
+
+def test_request_id_is_valid_uuid(id_client):
+    """The generated request ID should be a valid UUID string."""
+    response = id_client.get("/test")
+    request_id = response.headers["X-Request-ID"]
+    parts = request_id.split("-")
+    assert len(parts) == 5
+    assert all(len(p) in (8, 4, 4, 4, 12) for p in parts)
+
+
+def test_request_id_preserves_client_value(id_client):
+    """If the client sends X-Request-ID, the same value should be returned."""
+    client_id = "my-custom-trace-id"
+    response = id_client.get("/test", headers={"X-Request-ID": client_id})
+    assert response.headers["X-Request-ID"] == client_id
+
+
+def test_request_id_unique_per_request(id_client):
+    """Each request should get a different request ID when none is provided."""
+    r1 = id_client.get("/test")
+    r2 = id_client.get("/test")
+    assert r1.headers["X-Request-ID"] != r2.headers["X-Request-ID"]


### PR DESCRIPTION
## Summary

Add a `RequestIDMiddleware` that attaches a unique `X-Request-ID` header to every HTTP response. This enables request tracing across logs and client-side debugging.

## Changes

- **`app/middleware.py`**: Added `RequestIDMiddleware` — generates a UUID if none is provided, preserves client-sent IDs
- **`app/main.py`**: Registered `RequestIDMiddleware` before `RequestLoggingMiddleware`
- **4 new tests**: validates header presence, UUID format, client value preservation, and uniqueness per request

## Validation

- 4 new unit tests added
- Single commit, rebased on latest main
