### PR TITLE
Feat: Implement DepthwiseConv2D Layer

### DIFF
--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -120,5 +120,15 @@ def _build_layer(node: dict, input_tensor):
             raise ValueError(f"Dropout rate must be in [0, 1), got {rate!r}.")
         return tf.keras.layers.Dropout(rate=rate, name=name)(input_tensor)
 
+    elif node_type == "customdepthwiseconv":
+        activation = params.get("activation", "none")
+        return tf.keras.layers.DepthwiseConv2D(
+            kernel_size=(int(params.get("kernelX", 3)), int(params.get("kernelY", 3))),
+            strides=(int(params.get("strideX", 1)), int(params.get("strideY", 1))),
+            padding=params.get("padding", "same"),
+            activation="linear" if activation == "none" else activation,
+            name=name,
+        )(input_tensor)
+
     else:
         raise ValueError(f"Unknown node type: {node_type}")

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Canvas.jsx
@@ -41,6 +41,7 @@ import { trainingHistory as trainingHistoryAtom } from "../../shared/atoms";
 import ContextMenu from "./ContextMenu";
 import useUndoRedo from "../../hooks/useUndoRedo";
 import GlobalAvgPoolNode from "./CustomNodes/GlobalAvgPoolNode/GlobalAvgPoolNode";
+import DepthwiseConvNode from "./CustomNodes/DepthwiseConvNode/DepthwiseConvNode";
 
 const isMac =
   typeof navigator !== "undefined"
@@ -57,6 +58,7 @@ const nodeTypes = {
   customdropout: DropoutNode,
   custommaxpool: MaxPoolingNode,
   customglobalavgpool: GlobalAvgPoolNode,
+  customdepthwiseconv: DepthwiseConvNode,
 };
 
 // Keys MUST match nodeTypes above. Add a description when adding a node type.
@@ -68,6 +70,7 @@ const nodeDescriptions = {
   customdropout: "Randomly drops a fraction of inputs during training to reduce overfitting.",
   custommaxpool: "Downsamples by taking the maximum value in each pooling window.",
   customglobalavgpool: "Averages each feature map down to a single value.",
+  customdepthwiseconv: "Applies a depthwise convolution filter.",
 };
 
 const getTooltipStyle = (x, y) => {
@@ -604,6 +607,14 @@ function Canvas() {
         customdropout: { rate: "" },
         custommaxpool: { pool_size: "", stride: "", padding: "valid" },
         customglobalavgpool: {},
+        customdepthwiseconv: {
+          kernelX: "",
+          kernelY: "",
+          strideX: "",
+          strideY: "",
+          padding: "same",
+          activation: "none",
+        },
       };
 
       const newNode = {

--- a/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DepthwiseConvNode/DepthwiseConvNode.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/CustomNodes/DepthwiseConvNode/DepthwiseConvNode.jsx
@@ -1,0 +1,38 @@
+import PropTypes from "prop-types";
+import { Handle, Position } from "reactflow";
+
+function DepthwiseConvNode({ data, id }) {
+  const { kernelX, kernelY, activation } = data.params;
+  return (
+    <div className="w-44 rounded-lg border bg-white shadow-sm">
+      <Handle type="target" position={Position.Left} isConnectable id={`${id}_in`} />
+      <div className="rounded-t-lg bg-node-depthwiseconv px-3 py-1.5 text-xs font-bold text-white">
+        DepthwiseConv2D
+      </div>
+      <div className="px-3 py-2 text-xs text-muted-foreground space-y-0.5">
+        {kernelX !== undefined && kernelX !== "" ? (
+          <div>
+            Kernel: {kernelX}×{kernelY}
+          </div>
+        ) : (
+          <div>Not configured</div>
+        )}
+        {activation && <div>Act: {activation}</div>}
+      </div>
+      <Handle type="source" position={Position.Right} isConnectable id={`${id}_out`} />
+    </div>
+  );
+}
+
+DepthwiseConvNode.propTypes = {
+  data: PropTypes.shape({
+    params: PropTypes.shape({
+      kernelX: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      kernelY: PropTypes.oneOfType([PropTypes.string, PropTypes.number]),
+      activation: PropTypes.string,
+    }).isRequired,
+  }).isRequired,
+  id: PropTypes.string.isRequired,
+};
+
+export default DepthwiseConvNode;

--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -351,6 +351,94 @@ function NodePropertiesPanel({
     );
   }
 
+  if (type === "customdepthwiseconv") {
+    return (
+      <Card className="h-fit">
+        <CardHeader>
+          <CardTitle className="text-sm">DepthwiseConv2D Layer</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-1">
+            <Label>Kernel X</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Kernel X"
+              value={params.kernelX ?? ""}
+              onChange={handleChange("kernelX")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Kernel Y</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Kernel Y"
+              value={params.kernelY ?? ""}
+              onChange={handleChange("kernelY")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Stride X</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Stride X"
+              value={params.strideX ?? ""}
+              onChange={handleChange("strideX")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Stride Y</Label>
+            <Input
+              type="number"
+              min="1"
+              placeholder="Stride Y"
+              value={params.strideY ?? ""}
+              onChange={handleChange("strideY")}
+            />
+          </div>
+          <div className="space-y-1">
+            <Label>Padding</Label>
+            <Select
+              value={params.padding ?? ""}
+              onValueChange={(v) => doUpdate("padding", v || null)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Padding" />
+              </SelectTrigger>
+              <SelectContent>
+                {convPaddings.map((p) => (
+                  <SelectItem key={p.value} value={p.value}>
+                    {p.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-1">
+            <Label>Activation</Label>
+            <Select
+              value={params.activation ?? ""}
+              onValueChange={(v) => doUpdate("activation", v || null)}
+            >
+              <SelectTrigger>
+                <SelectValue placeholder="Activation" />
+              </SelectTrigger>
+              <SelectContent>
+                {ACTIVATIONS.map((a) => (
+                  <SelectItem key={a.value} value={a.value}>
+                    {a.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return null;
 }
 

--- a/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
@@ -59,6 +59,13 @@ function Sidebar() {
         >
           GlobalAvgPool2D
         </div>
+        <div
+          className="cursor-grab rounded-md border border-l-4 border-l-node-depthwiseconv bg-white px-3 py-2 text-xs font-medium"
+          onDragStart={(e) => onDragStart(e, "customdepthwiseconv")}
+          draggable
+        >
+          DepthwiseConv2D
+        </div>
       </CardContent>
     </Card>
   );

--- a/tensormap-frontend/tailwind.config.js
+++ b/tensormap-frontend/tailwind.config.js
@@ -45,6 +45,7 @@ export default {
         "node-conv": { DEFAULT: "rgb(255, 128, 43)", header: "rgb(255, 128, 43)" },
         "node-dropout": { DEFAULT: "rgb(220, 80, 80)", header: "rgb(180, 50, 50)" },
         "node-maxpool": { DEFAULT: "rgb(34, 182, 176)", header: "rgb(20, 140, 135)" },
+        "node-depthwiseconv": { DEFAULT: "rgb(180, 100, 220)", header: "rgb(140, 80, 180)" },
       },
       borderRadius: {
         lg: "var(--radius)",


### PR DESCRIPTION
## Summary

This PR implements the DepthwiseConv2D layer as an isolated, rebase-fresh PR, superseding the DepthwiseConv2D part of #266.

### Changes
- Created `DepthwiseConvNode` component and added it to the sidebar/canvas.
- Configurable parameters: Kernel size (X,Y), Stride (X,Y), Padding, and Activation.
- Backend code generation in `model_generation.py` handles the new layer configuration.
