### PR TITLE
fix: use disk_name instead of file_name for file path resolution

### DIFF
--- a/tensormap-backend/app/services/code_generation.py
+++ b/tensormap-backend/app/services/code_generation.py
@@ -93,6 +93,4 @@ def _file_location(file_id, db: Session) -> str:
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if file is None:
         raise CodeGenerationError(f"Dataset file not found (id={file_id})")
-    if file.file_type == "zip":
-        return f"{settings.upload_folder}/{file.file_name}"
-    return f"{settings.upload_folder}/{file.file_name}.{file.file_type}"
+    return f"{settings.upload_folder}/{file.disk_name}"

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -33,7 +33,7 @@ def _paginated_resp(data: list, pagination: dict) -> tuple:
 def _get_file_path(file: DataFile) -> str:
     """Resolve the on-disk path for a DataFile record."""
     settings = get_settings()
-    return f"{settings.upload_folder}/{file.file_name}.{file.file_type}"
+    return f"{settings.upload_folder}/{file.disk_name}"
 
 
 def add_target_service(db: Session, file_id: uuid_pkg.UUID, target: str) -> tuple:

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -130,9 +130,7 @@ def _helper_generate_file_location(db: Session, file_id) -> str:
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if file is None:
         raise ModelRunError(f"Dataset file not found (id={file_id})")
-    if file.file_type == "zip":
-        return upload_folder + "/" + file.file_name
-    return upload_folder + "/" + file.file_name + "." + file.file_type
+    return upload_folder + "/" + file.disk_name
 
 
 def _helper_generate_json_model_file_location(model_name: str) -> str:

--- a/tensormap-backend/tests/test_column_stats.py
+++ b/tensormap-backend/tests/test_column_stats.py
@@ -23,6 +23,7 @@ def _fake_file(tmp_path, csv_content, file_name="test"):
     f = MagicMock()
     f.file_name = file_name
     f.file_type = "csv"
+    f.disk_name = f"{file_name}.csv"
     return f
 
 

--- a/tensormap-backend/tests/test_data_process_params.py
+++ b/tensormap-backend/tests/test_data_process_params.py
@@ -34,6 +34,7 @@ def test_get_file_data_unsupported_file_type(mock_db, mock_settings, file_type, 
     mock_file.id = uuid.uuid4()
     mock_file.file_name = "test"
     mock_file.file_type = file_type
+    mock_file.disk_name = f"test.{file_type}"
     mock_db.exec.return_value.first.return_value = mock_file
     with patch("builtins.open", side_effect=FileNotFoundError):
         body, status = get_file_data(mock_db, uuid.uuid4())
@@ -51,6 +52,7 @@ def test_get_file_data_csv_success(tmp_path, mock_db, mock_settings):
     mock_file.id = uuid.uuid4()
     mock_file.file_name = "test"
     mock_file.file_type = "csv"
+    mock_file.disk_name = "test.csv"
     mock_db.exec.return_value.first.return_value = mock_file
 
     body, status = get_file_data(mock_db, mock_file.id)

--- a/tensormap-backend/tests/test_data_process_service.py
+++ b/tensormap-backend/tests/test_data_process_service.py
@@ -43,6 +43,7 @@ def sample_file(file_id):
     f.id = file_id
     f.file_name = "iris"
     f.file_type = "csv"
+    f.disk_name = "iris.csv"
     f.row_count = None
     f.columns = None
     return f
@@ -295,6 +296,7 @@ class TestGetDataMetrics:
         reg_file.id = file_id
         reg_file.file_name = "housing"
         reg_file.file_type = "csv"
+        reg_file.disk_name = "housing.csv"
 
         mock_settings.return_value.upload_folder = str(regression_csv)
         mock_db.exec.return_value.first.return_value = reg_file
@@ -331,6 +333,7 @@ class TestGetDataMetrics:
         empty_file = MagicMock(spec=DataFile)
         empty_file.file_name = "empty"
         empty_file.file_type = "csv"
+        empty_file.disk_name = "empty.csv"
 
         mock_settings.return_value.upload_folder = str(tmp_path)
         mock_db.exec.return_value.first.return_value = empty_file
@@ -391,6 +394,7 @@ class TestGetFileData:
         empty_file = MagicMock(spec=DataFile)
         empty_file.file_name = "empty"
         empty_file.file_type = "csv"
+        empty_file.disk_name = "empty.csv"
         empty_file.row_count = None
 
         mock_settings.return_value.upload_folder = str(tmp_path)

--- a/tensormap-backend/tests/test_null_checks.py
+++ b/tensormap-backend/tests/test_null_checks.py
@@ -59,6 +59,7 @@ class TestHelperGenerateFileLocation:
         mock_file = MagicMock()
         mock_file.file_type = "csv"
         mock_file.file_name = "test_data"
+        mock_file.disk_name = "test_data.csv"
         mock_db.exec.return_value.first.return_value = mock_file
 
         with patch("app.services.model_run.get_settings") as mock_settings:
@@ -68,17 +69,18 @@ class TestHelperGenerateFileLocation:
         assert result == "/uploads/test_data.csv"
 
     def test_returns_path_for_zip_files(self, mock_db):
-        """Zip files don't append extension."""
+        """Zip files use disk_name."""
         mock_file = MagicMock()
         mock_file.file_type = "zip"
         mock_file.file_name = "images"
+        mock_file.disk_name = "images.zip"
         mock_db.exec.return_value.first.return_value = mock_file
 
         with patch("app.services.model_run.get_settings") as mock_settings:
             mock_settings.return_value.upload_folder = "/uploads"
             result = _helper_generate_file_location(mock_db, file_id=1)
 
-        assert result == "/uploads/images"
+        assert result == "/uploads/images.zip"
 
 
 # ---------------------------------------------------------------------------
@@ -102,6 +104,7 @@ class TestCodeGenFileLocation:
         mock_file = MagicMock()
         mock_file.file_type = "csv"
         mock_file.file_name = "test_data"
+        mock_file.disk_name = "test_data.csv"
         mock_db.exec.return_value.first.return_value = mock_file
 
         with patch("app.services.code_generation.get_settings") as mock_settings:


### PR DESCRIPTION
All three file-path helpers construct incorrect on-disk paths by joining file.file_name + file.file_type instead of using file.disk_name. The upload service stores files under a UUID-tagged disk_name (e.g. data_a1b2c3d4.csv), so every downstream operation -- preprocessing, code generation, model training -- silently fails to find the file.

Affected helpers:
- data_process.py:_get_file_path -- called by preprocess_data
- code_generation.py:_file_location -- embedded in generated training scripts
- model_run.py:_helper_generate_file_location -- called during model training

The existing delete_one_file_by_id_service (data_upload.py:152) already uses file.disk_name correctly -- these three were missed.