### PR TITLE
fix: use curried doUpdate for Dropout and MaxPooling param handlers

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/NodePropertiesPanel.jsx
@@ -296,8 +296,8 @@ function NodePropertiesPanel({
               min="0"
               max="1"
               step="0.1"
-              value={params.rate}
-              onChange={(e) => updateParam("rate", e.target.value)}
+              value={params.rate ?? ""}
+              onChange={handleChange("rate")}
             />
           </div>
         </CardContent>
@@ -317,8 +317,8 @@ function NodePropertiesPanel({
               type="number"
               min="1"
               placeholder="Pool size"
-              value={params.pool_size}
-              onChange={(e) => updateParam("pool_size", Number(e.target.value))}
+              value={params.pool_size ?? ""}
+              onChange={handleChange("pool_size")}
             />
           </div>
           <div className="space-y-1">
@@ -327,13 +327,13 @@ function NodePropertiesPanel({
               type="number"
               min="1"
               placeholder="Stride"
-              value={params.stride}
-              onChange={(e) => updateParam("stride", Number(e.target.value))}
+              value={params.stride ?? ""}
+              onChange={handleChange("stride")}
             />
           </div>
           <div className="space-y-1">
             <Label>Padding</Label>
-            <Select value={params.padding} onValueChange={(v) => updateParam("padding", v)}>
+            <Select value={params.padding ?? ""} onValueChange={(v) => doUpdate("padding", v)}>
               <SelectTrigger>
                 <SelectValue placeholder="Padding" />
               </SelectTrigger>


### PR DESCRIPTION
updateParam is a curried function (params, onNodeUpdate, id) => (name, value) => void. It is correctly unwrapped on line 90 as const doUpdate = updateParam(params, onNodeUpdate, id). However, the Dropout and MaxPooling sections call the outer function directly instead of the returned inner handler, so the parameter update is silently discarded.

Broken:
onChange={(e) => updateParam("rate", e.target.value)}
(calls 3-arg curry with 2 args, returned fn is never invoked)

Fixed:
onChange={handleChange("rate")}
(uses the same handleNumberChange helper as Dense/Conv/Input)

Also applies ?? "" null-coalescing on all value bindings to prevent uncontrolled-to-controlled React warnings.