### PR TITLE
fix: allow ZIP uploads for image datasets

### DIFF
--- a/tensormap-backend/app/routers/data_upload.py
+++ b/tensormap-backend/app/routers/data_upload.py
@@ -57,7 +57,7 @@ def upload_file(
             status_code=400,
             content={
                 "success": False,
-                "message": "Only CSV files are supported.",
+                "message": "Only CSV and ZIP files are supported.",
                 "data": None,
             },
         )

--- a/tensormap-backend/app/routers/data_upload.py
+++ b/tensormap-backend/app/routers/data_upload.py
@@ -15,7 +15,7 @@ from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
 router = APIRouter(tags=["data-upload"])
-ALLOWED_EXTENSIONS = {"csv"}
+ALLOWED_EXTENSIONS = {"csv", "zip"}
 
 
 class _UploadFileWrapper:

--- a/tensormap-backend/app/services/code_generation.py
+++ b/tensormap-backend/app/services/code_generation.py
@@ -93,4 +93,6 @@ def _file_location(file_id, db: Session) -> str:
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if file is None:
         raise CodeGenerationError(f"Dataset file not found (id={file_id})")
+    if file.file_type == "zip":
+        return f"{settings.upload_folder}/{file.disk_name.rsplit('.', 1)[0]}"
     return f"{settings.upload_folder}/{file.disk_name}"

--- a/tensormap-backend/app/services/data_upload.py
+++ b/tensormap-backend/app/services/data_upload.py
@@ -1,6 +1,8 @@
 import contextlib
 import os
+import shutil
 import uuid as uuid_pkg
+import zipfile
 from typing import Any
 
 import pandas as pd
@@ -10,7 +12,7 @@ from sqlmodel import Session, select
 from werkzeug.utils import secure_filename
 
 from app.config import get_settings
-from app.models import DataFile
+from app.models import DataFile, ImageProperties
 from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -54,6 +56,61 @@ def add_file_service(db: Session, file_wrapper: Any, project_id: uuid_pkg.UUID |
     file_type_db = original_ext
     logger.info("Saving file: %s (disk name: %s)", file_name_db, safe_filename)
 
+    file_id = uuid_pkg.uuid4()
+
+    # Extract ZIP archives for image datasets
+    if file_type_db == "zip":
+        extract_dir_name = safe_filename.rsplit(".", 1)[0]
+        extract_path = os.path.join(upload_folder, extract_dir_name)
+        os.makedirs(extract_path, exist_ok=True)
+
+        max_extracted = 2 * 1024 * 1024 * 1024  # 2 GB decompression-bomb limit
+        total_extracted = 0
+
+        with zipfile.ZipFile(file_path, "r") as zf:
+            for member in zf.namelist():
+                member_path = os.path.realpath(os.path.join(extract_path, member))
+                if not member_path.startswith(os.path.realpath(extract_path) + os.sep):
+                    zf.close()
+                    os.remove(file_path)
+                    shutil.rmtree(extract_path, ignore_errors=True)
+                    return _resp(400, False, "Invalid ZIP: path traversal detected")
+
+                total_extracted += zf.getinfo(member).file_size
+                if total_extracted > max_extracted:
+                    zf.close()
+                    os.remove(file_path)
+                    shutil.rmtree(extract_path, ignore_errors=True)
+                    return _resp(413, False, "ZIP too large after extraction. Maximum extracted size is 2 GB.")
+
+            zf.extractall(extract_path)
+
+        logger.info("Extracted ZIP to %s", extract_path)
+
+        record = DataFile(
+            id=file_id,
+            file_name=file_name_db,
+            file_type=file_type_db,
+            disk_name=safe_filename,
+            project_id=project_id,
+            columns=None,
+            row_count=None,
+        )
+        db.add(record)
+        db.flush()
+
+        db.add(
+            ImageProperties(
+                id=file_id,
+                image_size=224,
+                batch_size=32,
+                color_mode="rgb",
+                label_mode="int",
+            )
+        )
+        db.commit()
+        return _resp(201, True, "File saved successfully")
+
     # Cache column names and row count at upload time (CSV only)
     columns_list: list[str] | None = None
     row_count: int | None = None
@@ -66,6 +123,7 @@ def add_file_service(db: Session, file_wrapper: Any, project_id: uuid_pkg.UUID |
             logger.warning("Could not extract columns/row_count from %s", file_path)
 
     record = DataFile(
+        id=file_id,
         file_name=file_name_db,
         file_type=file_type_db,
         disk_name=safe_filename,
@@ -155,6 +213,13 @@ def delete_one_file_by_id_service(db: Session, file_id: uuid_pkg.UUID) -> tuple:
             os.remove(file_path)
         except FileNotFoundError:
             logger.warning("File already absent on disk: %s", file_path)
+
+        # Remove extracted ZIP directory if it exists
+        if file.file_type == "zip":
+            extract_dir_name = file.disk_name.rsplit(".", 1)[0]
+            extract_path = os.path.join(upload_folder, extract_dir_name)
+            shutil.rmtree(extract_path, ignore_errors=True)
+
         db.delete(file)
         db.commit()
         return _resp(200, True, "File deleted successfully")

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -130,6 +130,8 @@ def _helper_generate_file_location(db: Session, file_id) -> str:
     file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
     if file is None:
         raise ModelRunError(f"Dataset file not found (id={file_id})")
+    if file.file_type == "zip":
+        return upload_folder + "/" + file.disk_name.rsplit(".", 1)[0]
     return upload_folder + "/" + file.disk_name
 
 

--- a/tensormap-backend/tests/test_null_checks.py
+++ b/tensormap-backend/tests/test_null_checks.py
@@ -69,18 +69,18 @@ class TestHelperGenerateFileLocation:
         assert result == "/uploads/test_data.csv"
 
     def test_returns_path_for_zip_files(self, mock_db):
-        """Zip files use disk_name."""
+        """Zip files return the extraction directory (disk_name without .zip)."""
         mock_file = MagicMock()
         mock_file.file_type = "zip"
         mock_file.file_name = "images"
-        mock_file.disk_name = "images.zip"
+        mock_file.disk_name = "images_abc123.zip"
         mock_db.exec.return_value.first.return_value = mock_file
 
         with patch("app.services.model_run.get_settings") as mock_settings:
             mock_settings.return_value.upload_folder = "/uploads"
             result = _helper_generate_file_location(mock_db, file_id=1)
 
-        assert result == "/uploads/images.zip"
+        assert result == "/uploads/images_abc123"
 
 
 # ---------------------------------------------------------------------------
@@ -112,6 +112,20 @@ class TestCodeGenFileLocation:
             result = _file_location(file_id=1, db=mock_db)
 
         assert result == "/uploads/test_data.csv"
+
+    def test_returns_zip_extraction_dir(self, mock_db):
+        """Zip files return extraction directory."""
+        mock_file = MagicMock()
+        mock_file.file_type = "zip"
+        mock_file.file_name = "images"
+        mock_file.disk_name = "images_def456.zip"
+        mock_db.exec.return_value.first.return_value = mock_file
+
+        with patch("app.services.code_generation.get_settings") as mock_settings:
+            mock_settings.return_value.upload_folder = "/uploads"
+            result = _file_location(file_id=1, db=mock_db)
+
+        assert result == "/uploads/images_def456"
 
 
 # ---------------------------------------------------------------------------

--- a/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
+++ b/tensormap-frontend/src/containers/DataUpload/DataUpload.jsx
@@ -135,7 +135,7 @@ function DataUpload() {
       <input
         ref={fileInputRef}
         type="file"
-        accept=".csv"
+        accept=".csv,.zip"
         className="hidden"
         onChange={onFileChange}
       />


### PR DESCRIPTION
Unblock ZIP image dataset uploads and make the image-classification pipeline functional end to end.

Changes:

1. Router (data_upload.py): ALLOWED_EXTENSIONS now accepts both csv and zip.
2. Frontend (DataUpload.jsx): File picker accept attribute now permits .csv and .zip.
3. Upload service (data_upload.py):
   - On ZIP save, extracts the archive to {upload_folder}/{disk_name_no_ext}/ with zip-slip protection (path traversal check on every member) and a 2 GB decompression-bomb limit.
   - Creates an ImageProperties record (image_size=224, batch_size=32, color_mode=rgb, label_mode=int) linked to the same file_id so training and code-generation paths do not raise ModelRunError("Image properties not found").
   - Delete service now cleans up the extraction directory via shutil.rmtree.
4. Path resolvers:
   - model_run.py:_helper_generate_file_location returns the extraction directory for ZIP files (disk_name without .zip extension) and uses disk_name for all other files.
   - code_generation.py:_file_location follows the same logic.
5. Tests: Updated test_null_checks.py to assert extraction directory paths and added a ZIP path test for the code_generation resolver.