### PR TITLE
fix: remove duplicate MaxPooling2D entry in sidebar

### DIFF
--- a/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
+++ b/tensormap-frontend/src/components/DragAndDropCanvas/Sidebar.jsx
@@ -53,14 +53,6 @@ function Sidebar() {
           MaxPooling2D
         </div>
         <div
-          className="cursor-grab rounded-md border border-l-4 border-l-node-conv bg-white px-3 py-2 text-xs font-medium"
-          onDragStart={(e) => onDragStart(e, "custommaxpool")}
-          draggable
-        >
-          MaxPooling2D
-        </div>
-
-        <div
           className="cursor-grab rounded-md border border-l-4 border-l-node-flatten bg-white px-3 py-2 text-xs font-medium"
           onDragStart={(e) => onDragStart(e, "customglobalavgpool")}
           draggable


### PR DESCRIPTION
Sidebar.jsx contains two adjacent div elements with identical onDragStart handlers for custommaxpool, causing MaxPooling2D to appear twice in the drag-and-drop palette. This removes the duplicate entry.