### PR TITLE
fix: delete file from disk only after DB commit succeeds

### DIFF
--- a/tensormap-backend/app/services/data_upload.py
+++ b/tensormap-backend/app/services/data_upload.py
@@ -237,5 +237,6 @@ def delete_one_file_by_id_service(db: Session, file_id: uuid_pkg.UUID) -> tuple:
             shutil.rmtree(extract_path, ignore_errors=True)
     except OSError:
         logger.exception("Failed to remove disk file for id=%s", file_id)
+        return _resp(200, True, "File record deleted, but the physical file could not be removed from storage")
 
     return _resp(200, True, "File deleted successfully")

--- a/tensormap-backend/app/services/data_upload.py
+++ b/tensormap-backend/app/services/data_upload.py
@@ -12,7 +12,7 @@ from sqlmodel import Session, select
 from werkzeug.utils import secure_filename
 
 from app.config import get_settings
-from app.models import DataFile, ImageProperties
+from app.models import DataFile, ImageProperties, ModelBasic
 from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -209,20 +209,33 @@ def delete_one_file_by_id_service(db: Session, file_id: uuid_pkg.UUID) -> tuple:
 
         file_path = os.path.join(upload_folder, file.disk_name)
 
-        try:
-            os.remove(file_path)
-        except FileNotFoundError:
-            logger.warning("File already absent on disk: %s", file_path)
+        # Null out every ModelBasic that references this DataFile so FK
+        # constraints do not block the DB delete.
+        model_basics = db.exec(select(ModelBasic).where(ModelBasic.file_id == file_id)).all()
+        for mb in model_basics:
+            mb.file_id = None
+            db.add(mb)
 
-        # Remove extracted ZIP directory if it exists
+        db.delete(file)
+        db.commit()
+    except (SQLAlchemyError, OSError):
+        db.rollback()
+        logger.exception("Error deleting file")
+        return _resp(500, False, "An error occurred while deleting the file")
+
+    # Remove the file from disk only AFTER the DB commit succeeds, so a
+    # failed commit does not orphan the disk file with a surviving DB record.
+    # Disk failures after a successful commit are logged but do not revert the
+    # deletion — the record is already gone from the application's perspective.
+    try:
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(file_path)
+
         if file.file_type == "zip":
             extract_dir_name = file.disk_name.rsplit(".", 1)[0]
             extract_path = os.path.join(upload_folder, extract_dir_name)
             shutil.rmtree(extract_path, ignore_errors=True)
+    except OSError:
+        logger.exception("Failed to remove disk file for id=%s", file_id)
 
-        db.delete(file)
-        db.commit()
-        return _resp(200, True, "File deleted successfully")
-    except (SQLAlchemyError, OSError):
-        logger.exception("Error deleting file")
-        return _resp(500, False, "An error occurred while deleting the file")
+    return _resp(200, True, "File deleted successfully")

--- a/tensormap-backend/tests/test_data_upload_service.py
+++ b/tensormap-backend/tests/test_data_upload_service.py
@@ -1,0 +1,104 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+
+from app.models.data import DataFile
+from app.services.data_upload import delete_one_file_by_id_service
+
+
+@pytest.fixture()
+def file_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_file(file_id):
+    f = MagicMock(spec=DataFile)
+    f.id = file_id
+    f.disk_name = "some_file.csv"
+    f.file_type = "csv"
+    return f
+
+
+class TestDeleteOneFileById:
+    def test_returns_400_when_file_not_found(self, mock_db, file_id):
+        mock_db.exec.return_value.first.return_value = None
+        body, status = delete_one_file_by_id_service(mock_db, file_id)
+        assert status == 400
+        assert body["success"] is False
+
+    def test_happy_path_deletes_db_and_disk(self, mock_db, file_id, sample_file):
+        mock_db.exec.return_value.first.return_value = sample_file
+        mock_db.exec.return_value.all.return_value = []
+
+        with (
+            patch("app.services.data_upload.os.remove") as mock_remove,
+            patch("app.services.data_upload.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = "/tmp"
+            body, status = delete_one_file_by_id_service(mock_db, file_id)
+
+        assert status == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_file)
+        mock_db.commit.assert_called_once()
+        mock_remove.assert_called_once()
+
+    def test_disk_removed_after_db_commit(self, mock_db, file_id, sample_file):
+        mock_db.exec.return_value.first.return_value = sample_file
+        mock_db.exec.return_value.all.return_value = []
+
+        call_order = []
+        mock_db.commit.side_effect = lambda: call_order.append("commit")
+
+        with (
+            patch("app.services.data_upload.os.remove", side_effect=lambda p: call_order.append("remove")),
+            patch("app.services.data_upload.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = "/tmp"
+            delete_one_file_by_id_service(mock_db, file_id)
+
+        assert call_order == ["commit", "remove"], f"Expected commit before remove, got {call_order}"
+
+    def test_db_delete_failure_does_not_remove_disk(self, mock_db, file_id, sample_file):
+        """If db.commit() raises, the disk file must NOT be removed."""
+        mock_db.exec.return_value.first.return_value = sample_file
+        mock_db.exec.return_value.all.return_value = []
+        mock_db.commit.side_effect = SQLAlchemyError("DB commit failed")
+
+        removed = []
+
+        with (
+            patch("app.services.data_upload.os.remove", side_effect=lambda p: removed.append(p)),
+            patch("app.services.data_upload.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = "/tmp"
+            body, status = delete_one_file_by_id_service(mock_db, file_id)
+
+        assert status == 500
+        assert len(removed) == 0, f"os.remove was called despite commit failure: {removed}"
+
+    def test_nulls_all_model_basic_file_ids(self, mock_db, file_id, sample_file):
+        mb1, mb2 = MagicMock(), MagicMock()
+        mb1.file_id = file_id
+        mb2.file_id = file_id
+        mock_db.exec.return_value.first.return_value = sample_file
+        mock_db.exec.return_value.all.return_value = [mb1, mb2]
+
+        with (
+            patch("app.services.data_upload.os.remove"),
+            patch("app.services.data_upload.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = "/tmp"
+            delete_one_file_by_id_service(mock_db, file_id)
+
+        assert mb1.file_id is None
+        assert mb2.file_id is None
+        assert mock_db.add.call_count >= 2

--- a/tensormap-backend/tests/test_data_upload_service.py
+++ b/tensormap-backend/tests/test_data_upload_service.py
@@ -35,8 +35,10 @@ class TestDeleteOneFileById:
         assert body["success"] is False
 
     def test_happy_path_deletes_db_and_disk(self, mock_db, file_id, sample_file):
-        mock_db.exec.return_value.first.return_value = sample_file
-        mock_db.exec.return_value.all.return_value = []
+        r1, r2 = MagicMock(), MagicMock()
+        r1.first.return_value = sample_file
+        r2.all.return_value = []
+        mock_db.exec.side_effect = [r1, r2]
 
         with (
             patch("app.services.data_upload.os.remove") as mock_remove,
@@ -52,8 +54,10 @@ class TestDeleteOneFileById:
         mock_remove.assert_called_once()
 
     def test_disk_removed_after_db_commit(self, mock_db, file_id, sample_file):
-        mock_db.exec.return_value.first.return_value = sample_file
-        mock_db.exec.return_value.all.return_value = []
+        r1, r2 = MagicMock(), MagicMock()
+        r1.first.return_value = sample_file
+        r2.all.return_value = []
+        mock_db.exec.side_effect = [r1, r2]
 
         call_order = []
         mock_db.commit.side_effect = lambda: call_order.append("commit")
@@ -69,8 +73,10 @@ class TestDeleteOneFileById:
 
     def test_db_delete_failure_does_not_remove_disk(self, mock_db, file_id, sample_file):
         """If db.commit() raises, the disk file must NOT be removed."""
-        mock_db.exec.return_value.first.return_value = sample_file
-        mock_db.exec.return_value.all.return_value = []
+        r1, r2 = MagicMock(), MagicMock()
+        r1.first.return_value = sample_file
+        r2.all.return_value = []
+        mock_db.exec.side_effect = [r1, r2]
         mock_db.commit.side_effect = SQLAlchemyError("DB commit failed")
 
         removed = []
@@ -89,8 +95,10 @@ class TestDeleteOneFileById:
         mb1, mb2 = MagicMock(), MagicMock()
         mb1.file_id = file_id
         mb2.file_id = file_id
-        mock_db.exec.return_value.first.return_value = sample_file
-        mock_db.exec.return_value.all.return_value = [mb1, mb2]
+        r1, r2 = MagicMock(), MagicMock()
+        r1.first.return_value = sample_file
+        r2.all.return_value = [mb1, mb2]
+        mock_db.exec.side_effect = [r1, r2]
 
         with (
             patch("app.services.data_upload.os.remove"),


### PR DESCRIPTION
In delete_one_file_by_id_service, files were removed from disk before the DB transaction committed. If the commit failed (e.g. FK constraint), the data was permanently lost even though the DB record survived.