### PR TITLE
fix: clean up uploaded files and model JSONs on disk when deleting a project

### DIFF
--- a/tensormap-backend/app/services/project.py
+++ b/tensormap-backend/app/services/project.py
@@ -173,7 +173,11 @@ def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
         logger.exception("Error deleting project")
         return _resp(500, False, "An error occurred while deleting the project")
 
-    # Remove uploaded files from disk.
+    # Disk cleanup runs after the DB commit so that a failed commit never
+    # orphans disk records. The trade-off: if the process is interrupted
+    # between commit and cleanup, orphaned files remain with no DB record
+    # to retry from. This is acceptable because the files are scoped to a
+    # project that has been intentionally deleted.
     n_files = 0
     for file in data_files:
         file_path = os.path.realpath(os.path.join(upload_folder, file.disk_name))
@@ -182,6 +186,7 @@ def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
             continue
         with contextlib.suppress(FileNotFoundError):
             os.remove(file_path)
+            # Only files that were actually present and removed are counted.
             n_files += 1
 
         if file.file_type == "zip" and "." in file.disk_name:

--- a/tensormap-backend/app/services/project.py
+++ b/tensormap-backend/app/services/project.py
@@ -1,3 +1,6 @@
+import contextlib
+import os
+import shutil
 import uuid as uuid_pkg
 from datetime import UTC, datetime
 from typing import Any
@@ -6,10 +9,12 @@ from sqlalchemy import func
 from sqlalchemy.exc import SQLAlchemyError
 from sqlmodel import Session, select
 
+from app.config import get_settings
 from app.models.data import DataFile
 from app.models.ml import ModelBasic
 from app.models.project import Project
 from app.schemas.project import ProjectCreateRequest, ProjectUpdateRequest
+from app.shared.constants import MODEL_GENERATION_LOCATION, MODEL_GENERATION_TYPE
 from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -147,14 +152,48 @@ def update_project_service(db: Session, project_id: uuid_pkg.UUID, data: Project
 
 
 def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
-    """Delete a project and cascade-remove associated files and models."""
+    """Delete a project, cascade-remove associated DB records, and clean up disk files."""
     try:
         project = db.get(Project, project_id)
         if not project:
             return _resp(404, False, "Project not found")
 
+        settings = get_settings()
+        upload_folder = os.path.realpath(settings.upload_folder)
+        model_json_dir = os.path.realpath(MODEL_GENERATION_LOCATION)
+
+        # Collect disk paths *before* the DB cascade so we still have the records.
+        data_files = db.exec(select(DataFile).where(DataFile.project_id == project_id)).all()
+        models = db.exec(select(ModelBasic).where(ModelBasic.project_id == project_id)).all()
+
         db.delete(project)
         db.commit()
+
+        # Remove uploaded files from disk.
+        for file in data_files:
+            file_path = os.path.realpath(os.path.join(upload_folder, file.disk_name))
+            if not file_path.startswith(upload_folder + os.sep):
+                logger.warning("Path traversal blocked for disk_name=%s", file.disk_name)
+                continue
+            with contextlib.suppress(FileNotFoundError):
+                os.remove(file_path)
+
+            if file.file_type == "zip":
+                # The extraction directory is derived from the ZIP's disk_name by
+                # stripping the extension (e.g. data_abc123.zip -> data_abc123/).
+                # This mirrors the convention in add_file_service in data_upload.py.
+                extract_dir_name = file.disk_name.rsplit(".", 1)[0]
+                extract_path = os.path.realpath(os.path.join(upload_folder, extract_dir_name))
+                if extract_path.startswith(upload_folder + os.sep):
+                    shutil.rmtree(extract_path, ignore_errors=True)
+
+        # Remove generated model JSON files from disk.
+        for model in models:
+            if model.model_name:
+                json_path = os.path.realpath(os.path.join(model_json_dir, model.model_name + MODEL_GENERATION_TYPE))
+                if json_path.startswith(model_json_dir + os.sep):
+                    with contextlib.suppress(FileNotFoundError):
+                        os.remove(json_path)
     except SQLAlchemyError:
         db.rollback()
         logger.exception("Error deleting project")

--- a/tensormap-backend/app/services/project.py
+++ b/tensormap-backend/app/services/project.py
@@ -168,36 +168,40 @@ def delete_project_service(db: Session, project_id: uuid_pkg.UUID) -> tuple:
 
         db.delete(project)
         db.commit()
-
-        # Remove uploaded files from disk.
-        for file in data_files:
-            file_path = os.path.realpath(os.path.join(upload_folder, file.disk_name))
-            if not file_path.startswith(upload_folder + os.sep):
-                logger.warning("Path traversal blocked for disk_name=%s", file.disk_name)
-                continue
-            with contextlib.suppress(FileNotFoundError):
-                os.remove(file_path)
-
-            if file.file_type == "zip":
-                # The extraction directory is derived from the ZIP's disk_name by
-                # stripping the extension (e.g. data_abc123.zip -> data_abc123/).
-                # This mirrors the convention in add_file_service in data_upload.py.
-                extract_dir_name = file.disk_name.rsplit(".", 1)[0]
-                extract_path = os.path.realpath(os.path.join(upload_folder, extract_dir_name))
-                if extract_path.startswith(upload_folder + os.sep):
-                    shutil.rmtree(extract_path, ignore_errors=True)
-
-        # Remove generated model JSON files from disk.
-        for model in models:
-            if model.model_name:
-                json_path = os.path.realpath(os.path.join(model_json_dir, model.model_name + MODEL_GENERATION_TYPE))
-                if json_path.startswith(model_json_dir + os.sep):
-                    with contextlib.suppress(FileNotFoundError):
-                        os.remove(json_path)
     except SQLAlchemyError:
         db.rollback()
         logger.exception("Error deleting project")
         return _resp(500, False, "An error occurred while deleting the project")
 
-    logger.info("Project deleted: id=%s", project_id)
+    # Remove uploaded files from disk.
+    n_files = 0
+    for file in data_files:
+        file_path = os.path.realpath(os.path.join(upload_folder, file.disk_name))
+        if not file_path.startswith(upload_folder + os.sep):
+            logger.warning("Path traversal blocked for disk_name=%s", file.disk_name)
+            continue
+        with contextlib.suppress(FileNotFoundError):
+            os.remove(file_path)
+            n_files += 1
+
+        if file.file_type == "zip" and "." in file.disk_name:
+            # The extraction directory is derived from the ZIP's disk_name by
+            # stripping the extension (e.g. data_abc123.zip -> data_abc123/).
+            # This mirrors the convention in add_file_service in data_upload.py.
+            extract_dir_name = file.disk_name.rsplit(".", 1)[0]
+            extract_path = os.path.realpath(os.path.join(upload_folder, extract_dir_name))
+            if extract_path.startswith(upload_folder + os.sep):
+                shutil.rmtree(extract_path, ignore_errors=True)
+
+    # Remove generated model JSON files from disk.
+    n_models = 0
+    for model in models:
+        if model.model_name:
+            json_path = os.path.realpath(os.path.join(model_json_dir, model.model_name + MODEL_GENERATION_TYPE))
+            if json_path.startswith(model_json_dir + os.sep):
+                with contextlib.suppress(FileNotFoundError):
+                    os.remove(json_path)
+                    n_models += 1
+
+    logger.info("Project deleted: id=%s (%d data files, %d model files)", project_id, n_files, n_models)
     return _resp(200, True, "Project deleted successfully")

--- a/tensormap-backend/tests/test_project_service.py
+++ b/tensormap-backend/tests/test_project_service.py
@@ -111,6 +111,31 @@ class TestDeleteProjectService:
 
         mock_remove.assert_not_called()
 
+    def test_path_traversal_blocked_on_model_name(self, mock_db, project_id, sample_project, tmp_path):
+        malicious = MagicMock(spec=ModelBasic)
+        malicious.model_name = "../../etc/bad"
+
+        mock_db.get.return_value = sample_project
+        mock_db.exec.return_value.all.side_effect = [
+            [],
+            [malicious],
+        ]
+
+        targeted = tmp_path / "etc" / "bad.json"
+        targeted.parent.mkdir(parents=True)
+        targeted.write_text("{}")
+
+        with (
+            patch("app.services.project.get_settings") as mock_settings,
+            patch("app.services.project.MODEL_GENERATION_LOCATION", str(tmp_path)),
+            patch("app.services.project.MODEL_GENERATION_TYPE", ".json"),
+            patch("app.services.project.os.remove") as mock_remove,
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            delete_project_service(mock_db, project_id)
+
+        mock_remove.assert_not_called()
+
     def test_missing_files_dont_cause_error(self, mock_db, project_id, sample_project, sample_csv_file, tmp_path):
         mock_db.get.return_value = sample_project
         mock_db.exec.return_value.all.side_effect = [

--- a/tensormap-backend/tests/test_project_service.py
+++ b/tensormap-backend/tests/test_project_service.py
@@ -1,0 +1,150 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from app.models.data import DataFile
+from app.models.ml import ModelBasic
+from app.models.project import Project
+from app.services.project import delete_project_service
+
+
+@pytest.fixture()
+def project_id():
+    return uuid.uuid4()
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_project(project_id):
+    p = MagicMock(spec=Project)
+    p.id = project_id
+    p.name = "test-project"
+    return p
+
+
+@pytest.fixture()
+def sample_csv_file():
+    f = MagicMock(spec=DataFile)
+    f.disk_name = "data.csv"
+    f.file_type = "csv"
+    return f
+
+
+@pytest.fixture()
+def sample_zip_file():
+    f = MagicMock(spec=DataFile)
+    f.disk_name = "images.zip"
+    f.file_type = "zip"
+    return f
+
+
+@pytest.fixture()
+def sample_model():
+    m = MagicMock(spec=ModelBasic)
+    m.model_name = "my_model"
+    return m
+
+
+class TestDeleteProjectService:
+    def test_returns_404_when_not_found(self, mock_db, project_id):
+        mock_db.get.return_value = None
+        body, status = delete_project_service(mock_db, project_id)
+        assert status == 404
+        assert body["success"] is False
+
+    def test_deletes_db_and_removes_files(
+        self, mock_db, project_id, sample_project, sample_csv_file, sample_model, tmp_path
+    ):
+        mock_db.get.return_value = sample_project
+        mock_db.exec.return_value.all.side_effect = [
+            [sample_csv_file],
+            [sample_model],
+        ]
+
+        csv_path = tmp_path / "data.csv"
+        csv_path.write_text("col1,col2\n1,2")
+
+        json_path = tmp_path / "my_model.json"
+        json_path.write_text("{}")
+
+        with (
+            patch("app.services.project.get_settings") as mock_settings,
+            patch("app.services.project.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.project.MODEL_GENERATION_TYPE", ".json"),
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            body, status = delete_project_service(mock_db, project_id)
+
+        assert status == 200
+        assert body["success"] is True
+        mock_db.delete.assert_called_once_with(sample_project)
+        mock_db.commit.assert_called_once()
+        assert not csv_path.exists()
+        assert not json_path.exists()
+
+    def test_path_traversal_blocked_on_disk_name(self, mock_db, project_id, sample_project, tmp_path):
+        malicious = MagicMock(spec=DataFile)
+        malicious.disk_name = "../../etc/passwd"
+        malicious.file_type = "csv"
+
+        mock_db.get.return_value = sample_project
+        mock_db.exec.return_value.all.side_effect = [
+            [malicious],
+            [],
+        ]
+
+        targeted = tmp_path / "etc" / "passwd"
+        targeted.parent.mkdir(parents=True)
+        targeted.write_text("root:x:0:0:")
+
+        with (
+            patch("app.services.project.get_settings") as mock_settings,
+            patch("app.services.project.os.remove") as mock_remove,
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            delete_project_service(mock_db, project_id)
+
+        mock_remove.assert_not_called()
+
+    def test_missing_files_dont_cause_error(self, mock_db, project_id, sample_project, sample_csv_file, tmp_path):
+        mock_db.get.return_value = sample_project
+        mock_db.exec.return_value.all.side_effect = [
+            [sample_csv_file],
+            [],
+        ]
+
+        with (
+            patch("app.services.project.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            body, status = delete_project_service(mock_db, project_id)
+
+        assert status == 200
+        assert body["success"] is True
+
+    def test_removes_zip_extraction_dir(self, mock_db, project_id, sample_project, sample_zip_file, tmp_path):
+        mock_db.get.return_value = sample_project
+        mock_db.exec.return_value.all.side_effect = [
+            [sample_zip_file],
+            [],
+        ]
+
+        zip_path = tmp_path / "images.zip"
+        zip_path.write_text("not a real zip")
+        extract_dir = tmp_path / "images"
+        extract_dir.mkdir()
+        (extract_dir / "file.txt").write_text("data")
+
+        with (
+            patch("app.services.project.get_settings") as mock_settings,
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            body, status = delete_project_service(mock_db, project_id)
+
+        assert status == 200
+        assert not extract_dir.exists()

--- a/tensormap-backend/tests/test_project_service.py
+++ b/tensormap-backend/tests/test_project_service.py
@@ -74,7 +74,7 @@ class TestDeleteProjectService:
 
         with (
             patch("app.services.project.get_settings") as mock_settings,
-            patch("app.services.project.MODEL_GENERATION_LOCATION", str(tmp_path) + "/"),
+            patch("app.services.project.MODEL_GENERATION_LOCATION", str(tmp_path)),
             patch("app.services.project.MODEL_GENERATION_TYPE", ".json"),
         ):
             mock_settings.return_value.upload_folder = str(tmp_path)


### PR DESCRIPTION
delete_project_service cascade-deletes DB records but leaves uploaded CSV/ZIP files, extracted ZIP directories, and generated model JSON files on disk. This change collects the disk paths before the DB cascade, deletes the DB records, then removes the orphaned files.