### PR TITLE
fix: back up original CSV before overwriting during preprocessing

### DIFF
--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -1,3 +1,4 @@
+import contextlib
 import os
 import shutil
 import uuid as uuid_pkg
@@ -406,8 +407,12 @@ def preprocess_data(db: Session, file_id: uuid_pkg.UUID, transformations: list) 
         # Write to a temp file, then atomically replace the original so an
         # interruption between writing and replacing never leaves a truncated CSV.
         tmp_path = file_path + ".tmp"
-        df.to_csv(tmp_path, index=False)
-        os.replace(tmp_path, file_path)
+        try:
+            df.to_csv(tmp_path, index=False)
+            os.replace(tmp_path, file_path)
+        finally:
+            with contextlib.suppress(OSError):
+                os.remove(tmp_path)
         return _resp(200, True, "Dataset preprocessed successfully")
     except ValueError as e:
         return _resp(422, False, str(e))

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -1,3 +1,5 @@
+import os
+import shutil
 import uuid as uuid_pkg
 from collections.abc import Callable
 from typing import Any
@@ -394,7 +396,18 @@ def preprocess_data(db: Session, file_id: uuid_pkg.UUID, transformations: list) 
             handler = _TRANSFORMATION_REGISTRY[t.transformation]
             df = handler(df, t.feature, t.params)
 
-        df.to_csv(file_path, index=False)
+        # Backup the original before overwriting so the user can recover.
+        # Only one .bak is retained — repeated preprocessing silently replaces it.
+        try:
+            shutil.copy2(file_path, file_path + ".bak")
+        except OSError:
+            logger.exception("Could not create backup at %s.bak", file_path)
+
+        # Write to a temp file, then atomically replace the original so an
+        # interruption between writing and replacing never leaves a truncated CSV.
+        tmp_path = file_path + ".tmp"
+        df.to_csv(tmp_path, index=False)
+        os.replace(tmp_path, file_path)
         return _resp(200, True, "Dataset preprocessed successfully")
     except ValueError as e:
         return _resp(422, False, str(e))

--- a/tensormap-backend/tests/test_data_process_backup.py
+++ b/tensormap-backend/tests/test_data_process_backup.py
@@ -1,0 +1,60 @@
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from app.services.data_process import preprocess_data
+
+
+@pytest.fixture()
+def mock_db():
+    return MagicMock()
+
+
+@pytest.fixture()
+def sample_file():
+    f = MagicMock()
+    f.file_name = "iris"
+    f.file_type = "csv"
+    f.disk_name = "iris.csv"
+    return f
+
+
+class TestPreprocessBackup:
+    def test_backup_created_on_happy_path(self, mock_db, sample_file, tmp_path):
+        csv = tmp_path / "iris.csv"
+        pd.DataFrame({"col": [1.0, 2.0]}).to_csv(csv, index=False)
+
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        with patch("app.services.data_process.get_settings") as mock_settings:
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            body, status = preprocess_data(
+                mock_db,
+                uuid.uuid4(),
+                [MagicMock(transformation="Drop Column", feature="col", params=None)],
+            )
+
+        assert status == 200
+        assert (tmp_path / "iris.csv.bak").exists()
+
+    def test_backup_failure_does_not_block_write(self, mock_db, sample_file, tmp_path):
+        csv = tmp_path / "iris.csv"
+        pd.DataFrame({"col": [1.0, 2.0]}).to_csv(csv, index=False)
+
+        mock_db.exec.return_value.first.return_value = sample_file
+
+        with (
+            patch("app.services.data_process.get_settings") as mock_settings,
+            patch("app.services.data_process.shutil.copy2", side_effect=OSError("Permission denied")),
+        ):
+            mock_settings.return_value.upload_folder = str(tmp_path)
+            body, status = preprocess_data(
+                mock_db,
+                uuid.uuid4(),
+                [MagicMock(transformation="Drop Column", feature="col", params=None)],
+            )
+
+        assert status == 200
+        assert csv.read_text() != ""

--- a/tensormap-backend/tests/test_data_process_backup.py
+++ b/tensormap-backend/tests/test_data_process_backup.py
@@ -28,7 +28,11 @@ class TestPreprocessBackup:
 
         mock_db.exec.return_value.first.return_value = sample_file
 
-        with patch("app.services.data_process.get_settings") as mock_settings:
+        with (
+            patch("app.services.data_process.get_settings") as mock_settings,
+            patch("app.services.data_process.pd.read_csv") as mock_read_csv,
+        ):
+            mock_read_csv.return_value = pd.DataFrame({"col": [1.0, 2.0]})
             mock_settings.return_value.upload_folder = str(tmp_path)
             body, status = preprocess_data(
                 mock_db,
@@ -38,6 +42,7 @@ class TestPreprocessBackup:
 
         assert status == 200
         assert (tmp_path / "iris.csv.bak").exists()
+        assert csv.exists()
 
     def test_backup_failure_does_not_block_write(self, mock_db, sample_file, tmp_path):
         csv = tmp_path / "iris.csv"
@@ -47,8 +52,10 @@ class TestPreprocessBackup:
 
         with (
             patch("app.services.data_process.get_settings") as mock_settings,
+            patch("app.services.data_process.pd.read_csv") as mock_read_csv,
             patch("app.services.data_process.shutil.copy2", side_effect=OSError("Permission denied")),
         ):
+            mock_read_csv.return_value = pd.DataFrame({"col": [1.0, 2.0]})
             mock_settings.return_value.upload_folder = str(tmp_path)
             body, status = preprocess_data(
                 mock_db,

--- a/tensormap-backend/tests/test_new_transforms.py
+++ b/tensormap-backend/tests/test_new_transforms.py
@@ -25,6 +25,8 @@ def _run(df: pd.DataFrame, transformation: str, feature: str, params: dict = Non
         patch("app.services.data_process.select"),
         patch("app.services.data_process.pd.read_csv", return_value=df.copy()),
         patch("app.services.data_process.get_settings") as mock_settings,
+        patch("app.services.data_process.shutil.copy2"),
+        patch("app.services.data_process.os.replace"),
         patch("pandas.DataFrame.to_csv"),
     ):
         mock_settings.return_value.upload_folder = "/tmp"
@@ -45,6 +47,8 @@ def _run_df(df: pd.DataFrame, transformation: str, feature: str, params: dict = 
         patch("app.services.data_process.select"),
         patch("app.services.data_process.pd.read_csv", return_value=df.copy()),
         patch("app.services.data_process.get_settings") as mock_settings,
+        patch("app.services.data_process.shutil.copy2"),
+        patch("app.services.data_process.os.replace"),
         patch.object(pd.DataFrame, "to_csv", capture),
     ):
         mock_settings.return_value.upload_folder = "/tmp"


### PR DESCRIPTION
preprocess_data calls df.to_csv(file_path, index=False) which overwrites the original uploaded CSV with no way to recover. This change creates a .bak copy via shutil.copy2 before the overwrite.