### PR TITLE
fix: replace server-local paths in generated training scripts with client-relative filenames

### DIFF
--- a/tensormap-backend/app/services/code_generation.py
+++ b/tensormap-backend/app/services/code_generation.py
@@ -1,7 +1,6 @@
 from jinja2 import Environment, FileSystemLoader
 from sqlmodel import Session, select
 
-from app.config import get_settings
 from app.models import DataFile, ImageProperties, ModelBasic
 from app.shared.constants import (
     BATCH_SIZE,
@@ -14,7 +13,6 @@ from app.shared.constants import (
     LABEL_MODE,
     LEARNING_MODEL,
     MODEL_EPOCHS,
-    MODEL_GENERATION_LOCATION,
     MODEL_GENERATION_TYPE,
     MODEL_JSON_FILE,
     MODEL_METRIC,
@@ -45,12 +43,12 @@ def generate_code(model_name: str, db: Session) -> str:
 
     data = {
         DATASET: {
-            FILE_NAME: _file_location(model_configs.file_id, db),
+            FILE_NAME: _file_location(file),
             FILE_TARGET: model_configs.target_field,
             MODEL_TRAINING_SPLIT: model_configs.training_split,
         },
         LEARNING_MODEL: {
-            MODEL_JSON_FILE: MODEL_GENERATION_LOCATION + model_name + MODEL_GENERATION_TYPE,
+            MODEL_JSON_FILE: model_name + MODEL_GENERATION_TYPE,
             MODEL_OPTIMIZER: model_configs.optimizer,
             MODEL_METRIC: model_configs.metric,
             MODEL_EPOCHS: model_configs.epochs,
@@ -87,12 +85,14 @@ def _map_template(problem_type_id: int) -> str:
     return options[problem_type_id]
 
 
-def _file_location(file_id, db: Session) -> str:
-    """Resolve the on-disk path for a file referenced by its DB ID."""
-    settings = get_settings()
-    file = db.exec(select(DataFile).where(DataFile.id == file_id)).first()
-    if file is None:
-        raise CodeGenerationError(f"Dataset file not found (id={file_id})")
+def _file_location(file: DataFile) -> str:
+    """Return the dataset path used in the generated training script.
+
+    Returns the original uploaded filename (or the ZIP extraction
+    directory name) so the script references a path the user recognises.
+    The user places the dataset beside the script; the server-local
+    storage path is not embedded in the generated code.
+    """
     if file.file_type == "zip":
-        return f"{settings.upload_folder}/{file.disk_name.rsplit('.', 1)[0]}"
-    return f"{settings.upload_folder}/{file.disk_name}"
+        return file.file_name.rsplit(".", 1)[0]
+    return file.file_name

--- a/tensormap-backend/tests/test_null_checks.py
+++ b/tensormap-backend/tests/test_null_checks.py
@@ -89,43 +89,27 @@ class TestHelperGenerateFileLocation:
 
 
 class TestCodeGenFileLocation:
-    def test_raises_error_when_file_not_found(self, mock_db):
-        """Missing DataFile raises CodeGenerationError with descriptive message."""
-        mock_db.exec.return_value.first.return_value = None
-
-        with pytest.raises(CodeGenerationError) as exc_info:
-            _file_location(file_id=999, db=mock_db)
-
-        assert "Dataset file not found" in str(exc_info.value)
-        assert "999" in str(exc_info.value)
-
-    def test_returns_path_when_file_exists(self, mock_db):
-        """Existing DataFile returns correct path."""
+    def test_returns_filename_for_csv(self):
+        """Existing CSV DataFile returns its original filename."""
         mock_file = MagicMock()
         mock_file.file_type = "csv"
-        mock_file.file_name = "test_data"
-        mock_file.disk_name = "test_data.csv"
-        mock_db.exec.return_value.first.return_value = mock_file
+        mock_file.file_name = "iris.csv"
+        mock_file.disk_name = "abc123.csv"
 
-        with patch("app.services.code_generation.get_settings") as mock_settings:
-            mock_settings.return_value.upload_folder = "/uploads"
-            result = _file_location(file_id=1, db=mock_db)
+        result = _file_location(mock_file)
 
-        assert result == "/uploads/test_data.csv"
+        assert result == "iris.csv"
 
-    def test_returns_zip_extraction_dir(self, mock_db):
-        """Zip files return extraction directory."""
+    def test_returns_dirname_for_zip(self):
+        """Zip file returns extraction directory name (filename without .zip)."""
         mock_file = MagicMock()
         mock_file.file_type = "zip"
-        mock_file.file_name = "images"
-        mock_file.disk_name = "images_def456.zip"
-        mock_db.exec.return_value.first.return_value = mock_file
+        mock_file.file_name = "images.zip"
+        mock_file.disk_name = "def456.zip"
 
-        with patch("app.services.code_generation.get_settings") as mock_settings:
-            mock_settings.return_value.upload_folder = "/uploads"
-            result = _file_location(file_id=1, db=mock_db)
+        result = _file_location(mock_file)
 
-        assert result == "/uploads/images_def456"
+        assert result == "images"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Downloaded training scripts contained hardcoded server-local paths (./data/uuid.csv, ./templates/json-model/model.json) that do not exist on the user's machine. Every generated script crashed on the first pd.read_csv() call.

Changed the file path to use the original uploaded filename (file.file_name) and the model JSON path to use just the model name, so both reference files the user can place alongside the script.