### PR TITLE
fix: resolve JSON serialization error for NaN values in dataset preview

### DIFF
--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -4,6 +4,7 @@ import shutil
 import uuid as uuid_pkg
 from collections.abc import Callable
 from typing import Any
+import json
 
 import numpy as np
 import pandas as pd
@@ -285,7 +286,9 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size:
         return _resp(500, False, f"Error reading CSV: {e}")
 
     # For empty or any dataframe slice, to_dict will convert to list of plain dict elements avoiding json strings
-    data_list = df_page.to_dict(orient="records")
+    df_page = df_page.where(pd.notnull(df_page), None)
+    json_str = df_page.to_json(orient="records")
+    data_list = json.loads(json_str)
 
     return _paginated_resp(
         data_list, {"page": page, "page_size": page_size, "total_rows": total_rows, "total_pages": total_pages}

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -1,10 +1,10 @@
 import contextlib
+import json
 import os
 import shutil
 import uuid as uuid_pkg
 from collections.abc import Callable
 from typing import Any
-import json
 
 import numpy as np
 import pandas as pd

--- a/tensormap-backend/app/services/data_process.py
+++ b/tensormap-backend/app/services/data_process.py
@@ -286,7 +286,6 @@ def get_file_data(db: Session, file_id: uuid_pkg.UUID, page: int = 1, page_size:
         return _resp(500, False, f"Error reading CSV: {e}")
 
     # For empty or any dataframe slice, to_dict will convert to list of plain dict elements avoiding json strings
-    df_page = df_page.where(pd.notnull(df_page), None)
     json_str = df_page.to_json(orient="records")
     data_list = json.loads(json_str)
 


### PR DESCRIPTION
## Description

Resolves an issue where the dataset preview fails to load (returning a 500 Internal Server Error) if the uploaded CSV contains empty or missing values.

Previously, Pandas would parse empty cells as `NaN`. When FastAPI attempted to serialize this data using `.to_dict()` and `JSONResponse`, it threw a `ValueError: Out of range float values are not JSON compliant: nan`. This PR fixes the issue by utilizing Pandas' native `.to_json()` method, which safely converts all `NaN` and `pd.NA` values to standard JSON `null` values before passing the data to the frontend.

Fixes #366 

## Type of Change

- [x] Bug fix

## How Has This Been Tested?

- Rebuilt the backend docker container with the new changes.
- Uploaded the `tensormap_stress_test` CSV dataset (which contains empty cells).
- Verified that the Dataset Preview page in the UI successfully loads the table without the "Failed to load dataset" error.
- Verified that the API correctly returns `null` for missing values, which the frontend renders correctly.

- [x] Existing tests pass
- [x] Manual testing

## Screenshot

<img width="1710" height="1112" alt="2026-06-21_11-55-07" src="https://github.com/user-attachments/assets/5a80a5f8-91e5-46ba-945f-00b770b79202" />


## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
