### PR TITLE
feat(training): Training Job Persistence, MetricsCallback, and Socket.IO Room Isolation

### DIFF
--- a/tensormap-backend/app/callbacks/__init__.py
+++ b/tensormap-backend/app/callbacks/__init__.py
@@ -1,0 +1,6 @@
+"""Keras callbacks for persisting and streaming training progress."""
+
+from app.callbacks.cancellation_callback import CancellationCheckCallback
+from app.callbacks.metrics_callback import MetricsCallback
+
+__all__ = ["CancellationCheckCallback", "MetricsCallback"]

--- a/tensormap-backend/app/callbacks/cancellation_callback.py
+++ b/tensormap-backend/app/callbacks/cancellation_callback.py
@@ -1,0 +1,38 @@
+"""Keras callback that cooperatively cancels training when requested.
+
+The DELETE endpoint only sets the job's status to CANCELLED in the DB; this
+callback is what actually stops the Keras loop. It checks the status at each
+epoch boundary and sets ``model.stop_training`` so ``fit`` exits cleanly.
+"""
+
+import tensorflow as tf
+
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+class CancellationCheckCallback(tf.keras.callbacks.Callback):
+    """Stop training when the job's DB status becomes CANCELLED.
+
+    Args:
+        job_id: The training job to watch.
+        session_factory: Zero-arg callable returning a fresh DB ``Session``.
+    """
+
+    def __init__(self, job_id, session_factory) -> None:
+        super().__init__()
+        self.job_id = job_id
+        self.session_factory = session_factory
+        # Side-effect flag so tests (and callers) can confirm a cancellation fired.
+        self.cancelled = False
+
+    def on_epoch_begin(self, epoch: int, logs: dict = None) -> None:
+        """Set ``model.stop_training`` if the job has been cancelled."""
+        with self.session_factory() as session:
+            job = session.get(TrainingJob, self.job_id)
+            if job is not None and job.status == TrainingStatus.CANCELLED:
+                logger.info("Cancellation detected for job %s at epoch %d", self.job_id, epoch)
+                self.cancelled = True
+                self.model.stop_training = True

--- a/tensormap-backend/app/callbacks/metrics_callback.py
+++ b/tensormap-backend/app/callbacks/metrics_callback.py
@@ -1,0 +1,136 @@
+"""Keras callback that persists per-epoch metrics and streams them to a job room.
+
+Replaces the old ``CustomProgressBar`` text emissions: instead of broadcasting
+formatted strings to every client, it writes structured metrics to the
+``training_metric`` table and emits them to the Socket.IO room for this job only.
+"""
+
+import asyncio
+from datetime import UTC, datetime
+
+import tensorflow as tf
+
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
+from app.shared.constants import SOCKETIO_DL_NAMESPACE, SOCKETIO_LISTENER
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def schedule_room_emit(sio_instance, loop, job_id: str, data: dict) -> None:
+    """Thread-safely emit ``data`` to a job's Socket.IO room from a worker thread.
+
+    Shared by the per-epoch metrics emit and the terminal status emit (and the
+    failure path in ``model_run``). A dropped event must never crash training.
+    """
+    if loop is None or not loop.is_running():
+        logger.warning("No running event loop for room emit (job %s)", job_id)
+        return
+    future = asyncio.run_coroutine_threadsafe(
+        sio_instance.emit(SOCKETIO_LISTENER, data, room=job_id, namespace=SOCKETIO_DL_NAMESPACE),
+        loop,
+    )
+    try:
+        future.result(timeout=5)
+    except Exception:  # noqa: BLE001 - a dropped progress event must not kill training
+        logger.warning("Failed to emit to room for job %s", job_id)
+
+
+class MetricsCallback(tf.keras.callbacks.Callback):
+    """Persist structured metrics to the DB per epoch and emit them to a room.
+
+    Args:
+        job_id: The training job these metrics belong to.
+        session_factory: Zero-arg callable returning a fresh DB ``Session``
+            (callbacks run in a worker thread, so they own their sessions).
+        sio_instance: The Socket.IO server used to emit progress.
+        loop: The main event loop, for thread-safe coroutine scheduling.
+    """
+
+    def __init__(self, job_id, session_factory, sio_instance, loop) -> None:
+        super().__init__()
+        self.job_id = job_id
+        self.session_factory = session_factory
+        self.sio = sio_instance
+        self.loop = loop
+        self.start_time = None
+
+    def on_train_begin(self, logs: dict = None) -> None:
+        """Mark the job RUNNING and record the start time."""
+        self.start_time = _utcnow()
+        with self.session_factory() as session:
+            job = session.get(TrainingJob, self.job_id)
+            if job is not None:
+                job.status = TrainingStatus.RUNNING
+                job.started_at = self.start_time
+                session.add(job)
+                session.commit()
+
+    def on_epoch_end(self, epoch: int, logs: dict = None) -> None:
+        """Persist this epoch's metrics and emit them to the job's room."""
+        logs = logs or {}
+        payload = {
+            "epoch": epoch + 1,
+            "loss": _as_float(logs.get("loss")),
+            "accuracy": _as_float(logs.get("accuracy", logs.get("acc"))),
+            "val_loss": _as_float(logs.get("val_loss")) if "val_loss" in logs else None,
+            "val_accuracy": (
+                _as_float(logs.get("val_accuracy", logs.get("val_acc")))
+                if ("val_accuracy" in logs or "val_acc" in logs)
+                else None
+            ),
+        }
+
+        # 1. Persist each present metric as its own row.
+        with self.session_factory() as session:
+            for name, value in payload.items():
+                if name != "epoch" and value is not None:
+                    session.add(
+                        TrainingMetric(
+                            job_id=self.job_id,
+                            epoch=epoch + 1,
+                            metric_name=name,
+                            metric_value=value,
+                        )
+                    )
+            session.commit()
+
+        # 2. Emit to this job's room only (no global broadcast).
+        self._emit({"type": "metrics", **payload})
+
+    def on_train_end(self, logs: dict = None) -> None:
+        """Mark the job COMPLETED — unless it was cancelled/failed meanwhile.
+
+        A cancelled job sets ``model.stop_training`` which ends ``fit`` cleanly
+        and still fires ``on_train_end``; guarding on the current status keeps us
+        from overwriting CANCELLED/FAILED with COMPLETED. Emits a terminal status
+        event so subscribers know the run is over.
+        """
+        final_status = None
+        with self.session_factory() as session:
+            job = session.get(TrainingJob, self.job_id)
+            if job is not None:
+                if job.status == TrainingStatus.RUNNING:
+                    job.status = TrainingStatus.COMPLETED
+                    job.completed_at = _utcnow()
+                    session.add(job)
+                    session.commit()
+                final_status = job.status.value
+        if final_status is not None:
+            self._emit({"type": "status", "status": final_status})
+
+    def _emit(self, data: dict) -> None:
+        """Schedule a thread-safe emit to the job room on the main loop."""
+        schedule_room_emit(self.sio, self.loop, self.job_id, data)
+
+
+def _as_float(value) -> float | None:
+    """Coerce a Keras log value to float, or None if it is missing."""
+    if value is None:
+        return None
+    return float(value)

--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -22,7 +22,7 @@ from app.exceptions import (
     validation_exception_handler,
 )
 from app.middleware import RequestIDMiddleware, RequestLoggingMiddleware
-from app.routers import data_process, data_upload, deep_learning, health, layers, project
+from app.routers import data_process, data_upload, deep_learning, health, layers, project, training
 from app.shared.logging_config import get_logger
 from app.socketio_instance import sio
 
@@ -64,6 +64,16 @@ async def lifespan(app: FastAPI):
             alembic_cfg = Config("alembic.ini")
             command.upgrade(alembic_cfg, "head")
             logger.info("Alembic migrations complete")
+
+        # Recover jobs left RUNNING/PENDING by a previous crash so the DB never
+        # shows a job as active when no process is training it. Best-effort:
+        # a failure here must not prevent the app from starting.
+        try:
+            from app.services.training_service import orphan_recovery
+
+            orphan_recovery()
+        except Exception as e:
+            logger.error(f"Orphan recovery error: {e}")
     yield
 
 
@@ -94,6 +104,7 @@ app.include_router(data_process.router, prefix=settings.api_base)
 app.include_router(deep_learning.router, prefix=settings.api_base)
 app.include_router(project.router, prefix=settings.api_base)
 app.include_router(layers.router, prefix=settings.api_base)
+app.include_router(training.router, prefix=settings.api_base)
 
 # Wrap FastAPI with SocketIO so socket.io requests are handled,
 # and everything else passes through to FastAPI.

--- a/tensormap-backend/app/models/__init__.py
+++ b/tensormap-backend/app/models/__init__.py
@@ -1,6 +1,8 @@
 from app.models.data import DataFile, DataProcess, ImageProperties
 from app.models.ml import ModelBasic, ModelConfigs
 from app.models.project import Project
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
 
 __all__ = [
     "DataFile",
@@ -9,4 +11,7 @@ __all__ = [
     "ModelBasic",
     "ModelConfigs",
     "Project",
+    "TrainingJob",
+    "TrainingMetric",
+    "TrainingStatus",
 ]

--- a/tensormap-backend/app/models/training_job.py
+++ b/tensormap-backend/app/models/training_job.py
@@ -1,0 +1,67 @@
+import uuid as uuid_pkg
+from datetime import datetime
+from enum import StrEnum
+
+from sqlalchemy import JSON, Column, DateTime, ForeignKey
+from sqlalchemy import Enum as SAEnum
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+from sqlmodel import Field, SQLModel
+
+
+class TrainingStatus(StrEnum):
+    """Lifecycle states for a training job.
+
+    A job moves PENDING -> RUNNING -> COMPLETED on the happy path, or to
+    FAILED (training raised) / CANCELLED (user requested a stop).
+    """
+
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+
+
+# Store the lowercase ``.value`` (not the member name) so the DB column matches
+# the Alembic migration's CHECK constraint and the JSON the API returns.
+def _status_values(enum_cls) -> list[str]:
+    return [member.value for member in enum_cls]
+
+
+class TrainingJob(SQLModel, table=True):
+    """A single training run for a model, tracked from request to completion.
+
+    Replaces the old stateless fire-and-block flow: each POST /model/run now
+    creates a row here so progress, outcome, and cancellation survive the
+    request that started them.
+    """
+
+    __tablename__ = "training_job"
+
+    id: str = Field(default_factory=lambda: str(uuid_pkg.uuid4()), primary_key=True)
+    model_id: int = Field(foreign_key="model_basic.id", index=True)
+    # The project this job belongs to. TensorMap has no user/auth model, so jobs
+    # are scoped to a project rather than an owner (no per-user authorization).
+    project_id: uuid_pkg.UUID | None = Field(
+        default=None,
+        sa_column=Column(PgUUID(as_uuid=True), ForeignKey("project.id", ondelete="CASCADE"), index=True, nullable=True),
+    )
+    # native_enum=False stores the value as a portable VARCHAR + CHECK constraint,
+    # avoiding a Postgres ENUM type that would need its own migration step.
+    status: TrainingStatus = Field(
+        default=TrainingStatus.PENDING,
+        sa_column=Column(
+            SAEnum(TrainingStatus, native_enum=False, length=20, values_callable=_status_values),
+            nullable=False,
+            index=True,
+        ),
+    )
+    # hyperparams shape: {"optimizer": "adam", "lr": 0.001, "epochs": 50, "batch_size": 32}
+    hyperparams: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    started_at: datetime | None = Field(default=None, sa_column=Column(DateTime, nullable=True))
+    completed_at: datetime | None = Field(default=None, sa_column=Column(DateTime, nullable=True))
+    error_message: str | None = Field(default=None, max_length=2000, nullable=True)
+    # Forward-looking columns reserved for later phases (analysis + tuning).
+    analysis_cache: dict | None = Field(default=None, sa_column=Column(JSON, nullable=True))
+    last_export_download_at: datetime | None = Field(default=None, sa_column=Column(DateTime, nullable=True))
+    tuning_session_id: str | None = Field(default=None, max_length=36, nullable=True)

--- a/tensormap-backend/app/models/training_metric.py
+++ b/tensormap-backend/app/models/training_metric.py
@@ -1,0 +1,29 @@
+from datetime import UTC, datetime
+
+from sqlalchemy import Column, DateTime, Index
+from sqlmodel import Field, SQLModel
+
+
+def _utcnow() -> datetime:
+    """Timezone-aware UTC now (datetime.utcnow is deprecated in 3.12)."""
+    return datetime.now(UTC)
+
+
+class TrainingMetric(SQLModel, table=True):
+    """One metric value recorded for a single epoch of a training job.
+
+    Metrics are stored long-form (one row per metric per epoch) so new metric
+    names can be added without a schema change. Charts read them back grouped
+    by epoch via the composite index below.
+    """
+
+    __tablename__ = "training_metric"
+
+    id: int | None = Field(default=None, primary_key=True)
+    job_id: str = Field(foreign_key="training_job.id", index=True)
+    epoch: int
+    metric_name: str = Field(max_length=50)  # "loss", "accuracy", "val_loss", "val_accuracy"
+    metric_value: float
+    recorded_at: datetime = Field(default_factory=_utcnow, sa_column=Column(DateTime, nullable=False))
+
+    __table_args__ = (Index("ix_metric_job_epoch", "job_id", "epoch"),)

--- a/tensormap-backend/app/routers/deep_learning.py
+++ b/tensormap-backend/app/routers/deep_learning.py
@@ -1,4 +1,3 @@
-import asyncio
 import io
 import uuid as uuid_pkg
 
@@ -19,7 +18,6 @@ from app.services.deep_learning import (
     get_training_history_service,
     model_save_service,
     model_validate_service,
-    run_code_service,
     update_training_config_service,
 )
 from app.shared.logging_config import get_logger
@@ -83,17 +81,6 @@ def get_code(request: ModelNameRequest, db: Session = Depends(get_db)):
             headers={"Content-Disposition": f"attachment; filename={result['file_name']}"},
         )
     return JSONResponse(status_code=status_code, content=result)
-
-
-@router.post("/model/run")
-async def run_model(request: ModelNameRequest, db: Session = Depends(get_db)):
-    """Train a saved model in a background thread and stream progress via Socket.IO."""
-    logger.info("Starting model training: model_name=%s", request.model_name)
-    loop = asyncio.get_running_loop()
-    body, status_code = await asyncio.to_thread(
-        run_code_service, db, model_name=request.model_name, project_id=request.project_id, loop=loop
-    )
-    return JSONResponse(status_code=status_code, content=body)
 
 
 @router.get("/model/{model_name}/graph")

--- a/tensormap-backend/app/routers/training.py
+++ b/tensormap-backend/app/routers/training.py
@@ -1,0 +1,153 @@
+"""Training-job API: start, inspect, list, and cancel persistent training runs.
+
+Supersedes the old stateless ``POST /model/run``. A run now returns immediately
+(202) with a job id; progress and outcome are persisted and streamed via
+Socket.IO rooms.
+
+Note: TensorMap has no auth/user model, so jobs are scoped to a project rather
+than an owner. ``get_job_or_404`` therefore returns 404 (not 403) for unknown
+jobs; there is no per-user authorization to enforce.
+"""
+
+import asyncio
+
+from fastapi import APIRouter, Depends, Query
+from fastapi.responses import JSONResponse, Response
+from sqlmodel import Session, select
+
+from app.database import get_db
+from app.exceptions import AppException
+from app.models.ml import ModelBasic
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.schemas.training import TrainingStartRequest
+from app.services.training_service import (
+    check_concurrency_limit,
+    create_training_job,
+    get_job_metrics_grouped,
+    get_latest_metrics,
+    launch_training_job,
+    update_job_status,
+)
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/model", tags=["training"])
+
+
+def get_job_or_404(job_id: str, db: Session = Depends(get_db)) -> TrainingJob:
+    """Fetch a training job or raise 404. Injected into job-scoped endpoints."""
+    job = db.get(TrainingJob, job_id)
+    if job is None:
+        raise AppException(404, "Training job not found")
+    return job
+
+
+def _envelope(message: str, data) -> dict:
+    """Standard success envelope used across the API."""
+    return {"success": True, "message": message, "data": data}
+
+
+@router.post("/run", status_code=202)
+async def start_training(request: TrainingStartRequest, db: Session = Depends(get_db)) -> JSONResponse:
+    """Create a training job (PENDING), fire it in the background, return 202.
+
+    Hyperparameters default to the model's saved training config; any provided
+    in the request override them for this run.
+    """
+    model = db.exec(select(ModelBasic).where(ModelBasic.model_name == request.model_name)).first()
+    if model is None or (request.project_id is not None and model.project_id != request.project_id):
+        raise AppException(404, "Model not found")
+    if model.file_id is None or model.epochs is None:
+        raise AppException(
+            400,
+            "Training configuration not set. Please configure training parameters first.",
+        )
+
+    # Reject early if we're already at the concurrency limit (raises 429).
+    check_concurrency_limit(db)
+
+    hyperparams = {
+        "optimizer": request.optimizer or model.optimizer,
+        "lr": request.lr,
+        "epochs": request.epochs or model.epochs,
+        "batch_size": request.batch_size or model.batch_size,
+    }
+    job = create_training_job(
+        model_id=model.id,
+        project_id=model.project_id,
+        hyperparams=hyperparams,
+        session=db,
+    )
+
+    logger.info("Training job %s created for model '%s'", job.id, request.model_name)
+    loop = asyncio.get_running_loop()
+    launch_training_job(request.model_name, job.id, loop)
+
+    return JSONResponse(
+        status_code=202,
+        content=_envelope("Training job accepted", {"job_id": job.id, "status": job.status.value}),
+    )
+
+
+@router.get("/training-jobs")
+def list_training_jobs(
+    model_name: str = Query(...),
+    db: Session = Depends(get_db),
+) -> JSONResponse:
+    """List all jobs for a model, most recently started first."""
+    model = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
+    if model is None:
+        raise AppException(404, "Model not found")
+
+    jobs = db.exec(
+        select(TrainingJob).where(TrainingJob.model_id == model.id).order_by(TrainingJob.started_at.desc())
+    ).all()
+    data = [
+        {
+            "job_id": j.id,
+            "model_id": j.model_id,
+            "status": j.status.value,
+            "started_at": j.started_at.isoformat() if j.started_at else None,
+            "completed_at": j.completed_at.isoformat() if j.completed_at else None,
+        }
+        for j in jobs
+    ]
+    return JSONResponse(status_code=200, content=_envelope("Training jobs retrieved", data))
+
+
+@router.get("/training-job/{job_id}")
+def get_training_job(job: TrainingJob = Depends(get_job_or_404), db: Session = Depends(get_db)) -> JSONResponse:
+    """Return a job's status, hyperparameters, and latest metrics."""
+    data = {
+        "job_id": job.id,
+        "model_id": job.model_id,
+        "status": job.status.value,
+        "hyperparams": job.hyperparams,
+        "started_at": job.started_at.isoformat() if job.started_at else None,
+        "completed_at": job.completed_at.isoformat() if job.completed_at else None,
+        "error_message": job.error_message,
+        "latest_metrics": get_latest_metrics(job.id, db),
+    }
+    return JSONResponse(status_code=200, content=_envelope("Training job retrieved", data))
+
+
+@router.get("/training-job/{job_id}/metrics")
+def get_job_metrics(job: TrainingJob = Depends(get_job_or_404), db: Session = Depends(get_db)) -> JSONResponse:
+    """Return the full per-epoch metric history for charts."""
+    metrics = get_job_metrics_grouped(job.id, db)
+    return JSONResponse(status_code=200, content=_envelope("Metrics retrieved", metrics))
+
+
+@router.delete("/training-job/{job_id}", status_code=204)
+def cancel_training_job(job: TrainingJob = Depends(get_job_or_404), db: Session = Depends(get_db)) -> Response:
+    """Request cancellation of a job.
+
+    Only sets status=CANCELLED; the running training loop stops itself at the
+    next epoch boundary via ``CancellationCheckCallback``. Cancelling an
+    already-finished job is a no-op (still 204).
+    """
+    if job.status in (TrainingStatus.PENDING, TrainingStatus.RUNNING):
+        update_job_status(job.id, TrainingStatus.CANCELLED, db)
+        logger.info("Cancellation requested for job %s", job.id)
+    return Response(status_code=204)

--- a/tensormap-backend/app/schemas/training.py
+++ b/tensormap-backend/app/schemas/training.py
@@ -1,0 +1,46 @@
+"""Request/response schemas for the training-job API."""
+
+import uuid as uuid_pkg
+from datetime import datetime
+
+from pydantic import BaseModel, Field
+
+
+class TrainingStartRequest(BaseModel):
+    """Request body for starting a training run.
+
+    Only ``model_name`` is required; hyperparameters default to whatever was
+    saved on the model via the training-config endpoint, so existing callers
+    keep working. Any field provided here overrides the stored value for this
+    run (recorded in the job's ``hyperparams``).
+    """
+
+    model_name: str = Field(min_length=1)
+    project_id: uuid_pkg.UUID | None = None
+    optimizer: str | None = None
+    lr: float | None = Field(default=None, gt=0)
+    epochs: int | None = Field(default=None, gt=0)
+    batch_size: int | None = Field(default=None, gt=0)
+
+
+class TrainingJobResponse(BaseModel):
+    """Full detail for a single training job."""
+
+    job_id: str
+    model_id: int
+    status: str
+    hyperparams: dict | None = None
+    started_at: datetime | None = None
+    completed_at: datetime | None = None
+    error_message: str | None = None
+    latest_metrics: dict | None = None
+
+
+class TrainingJobSummary(BaseModel):
+    """Lightweight job descriptor for list views."""
+
+    job_id: str
+    model_id: int
+    status: str
+    started_at: datetime | None = None
+    completed_at: datetime | None = None

--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -6,9 +6,11 @@ import pandas as pd
 import tensorflow as tf
 from sqlmodel import Session, select
 
+from app.callbacks import CancellationCheckCallback, MetricsCallback
 from app.config import get_settings
 from app.models.data import DataFile, ImageProperties
 from app.models.ml import ModelBasic
+from app.models.training_job import TrainingStatus
 from app.shared.constants import (
     MODEL_GENERATION_LOCATION,
     MODEL_GENERATION_TYPE,
@@ -144,18 +146,57 @@ def _helper_generate_json_model_file_location(model_name: str) -> str:
     return path
 
 
-def model_run(model_name: str, db: Session, loop: asyncio.AbstractEventLoop | None = None) -> None:
+def _build_training_callbacks(job_id: str | None) -> list[tf.keras.callbacks.Callback]:
+    """Return the Keras callbacks for a run.
+
+    Without a job_id (legacy/direct calls) we keep the text-based
+    ``CustomProgressBar``. With a job_id we use the persistent ``MetricsCallback``
+    (DB + room-scoped Socket.IO) plus ``CancellationCheckCallback``.
+    """
+    if job_id is None:
+        return [CustomProgressBar()]
+
+    from app.services.training_service import make_session
+
+    loop = _training_loop_ctx.get()
+    return [
+        MetricsCallback(job_id, make_session, sio, loop),
+        CancellationCheckCallback(job_id, make_session),
+    ]
+
+
+def model_run(
+    model_name: str,
+    db: Session,
+    loop: asyncio.AbstractEventLoop | None = None,
+    job_id: str | None = None,
+) -> None:
     """Load, compile, and train a Keras model, emitting progress via Socket.IO.
 
     Stores the caller's event loop in a ContextVar so concurrent requests
     each see their own loop instead of racing on a shared global (Issue #341).
+
+    When ``job_id`` is given, training progress is persisted to the
+    ``training_metric`` table and the job's lifecycle (running/completed/failed)
+    is recorded; on failure the job is marked FAILED with the error message.
     """
     token = _training_loop_ctx.set(loop)
     try:
-        _run(model_name, db)
+        _run(model_name, db, job_id=job_id)
     except Exception as e:
         logger.exception("Training failed for model '%s': %s", model_name, str(e))
-        _model_result(f"Training failed: {e}", -1)
+        if job_id is not None:
+            from app.callbacks.metrics_callback import schedule_room_emit
+            from app.services.training_service import make_session, update_job_status
+
+            try:
+                with make_session() as session:
+                    update_job_status(job_id, TrainingStatus.FAILED, session, error_message=str(e))
+                schedule_room_emit(sio, loop, job_id, {"type": "status", "status": "failed", "error": str(e)})
+            except Exception:  # noqa: BLE001 - never mask the original training error
+                logger.exception("Failed to mark job %s as failed", job_id)
+        else:
+            _model_result(f"Training failed: {e}", -1)
         raise
     finally:
         _training_loop_ctx.reset(token)
@@ -193,7 +234,8 @@ def _prepare_training_data(features, target_field, training_split):
     return X[:split_index], y[:split_index], X[split_index:], y[split_index:]
 
 
-def _run(model_name: str, db: Session) -> None:
+def _run(model_name: str, db: Session, job_id: str | None = None) -> None:
+    callbacks = _build_training_callbacks(job_id)
     model_configs = db.exec(select(ModelBasic).where(ModelBasic.model_name == model_name)).first()
     if model_configs is None:
         raise ModelRunError(f"Model configuration not found: {model_name}")
@@ -275,17 +317,17 @@ def _run(model_name: str, db: Session) -> None:
             train_data,
             validation_data=test_data,
             epochs=model_configs.epochs,
-            callbacks=[CustomProgressBar()],
+            callbacks=callbacks,
             verbose=0,
         )
-        model.evaluate(test_data, callbacks=[CustomProgressBar()], verbose=0)
+        model.evaluate(test_data, callbacks=callbacks, verbose=0)
     else:
         model.fit(
             x_training,
             y_training,
             epochs=model_configs.epochs,
             batch_size=batch_size,
-            callbacks=[CustomProgressBar()],
+            callbacks=callbacks,
             verbose=0,
         )
-        model.evaluate(x_testing, y_testing, callbacks=[CustomProgressBar()], verbose=0)
+        model.evaluate(x_testing, y_testing, callbacks=callbacks, verbose=0)

--- a/tensormap-backend/app/services/training_service.py
+++ b/tensormap-backend/app/services/training_service.py
@@ -1,0 +1,178 @@
+"""Business logic for persistent training jobs.
+
+Replaces the old stateless fire-and-block training flow. A job is created
+(PENDING) by the run endpoint, executed in a background thread (RUNNING), and
+ends COMPLETED / FAILED / CANCELLED. Metrics are persisted per epoch by
+``MetricsCallback`` and read back here for the API and Socket.IO catch-up.
+"""
+
+import asyncio
+import os
+import uuid as uuid_pkg
+from datetime import UTC, datetime
+
+from sqlmodel import Session, select
+
+from app.database import engine
+from app.exceptions import AppException
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+# Maximum number of jobs allowed to run concurrently. Counted across PENDING and
+# RUNNING so a burst of quick requests can't all slip past before any flips to
+# RUNNING (the spec's RUNNING-only check has that race).
+MAX_CONCURRENT_TRAINING_JOBS = int(os.getenv("MAX_CONCURRENT_TRAINING_JOBS", "3"))
+
+# Strong references to in-flight background tasks. Without this, asyncio may
+# garbage-collect a fire-and-forget task mid-run (see asyncio.create_task docs).
+_background_tasks: set[asyncio.Task] = set()
+
+
+def _utcnow() -> datetime:
+    return datetime.now(UTC)
+
+
+def make_session() -> Session:
+    """Create a new DB session bound to the app engine.
+
+    Used as a session *factory* by background threads and Keras callbacks, which
+    run outside the request lifecycle and must not share the request's session.
+    """
+    return Session(engine)
+
+
+def create_training_job(
+    model_id: int,
+    project_id: uuid_pkg.UUID | None,
+    hyperparams: dict | None,
+    session: Session,
+) -> TrainingJob:
+    """Persist a new job in the PENDING state and return it."""
+    job = TrainingJob(
+        model_id=model_id,
+        project_id=project_id,
+        hyperparams=hyperparams,
+        status=TrainingStatus.PENDING,
+    )
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def update_job_status(
+    job_id: str,
+    status: TrainingStatus,
+    session: Session,
+    error_message: str | None = None,
+) -> None:
+    """Transition a job to ``status``, stamping timestamps and error as needed."""
+    job = session.get(TrainingJob, job_id)
+    if job is None:
+        logger.warning("update_job_status: job %s not found", job_id)
+        return
+    job.status = status
+    if status == TrainingStatus.RUNNING and job.started_at is None:
+        job.started_at = _utcnow()
+    if status in (TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.CANCELLED):
+        job.completed_at = _utcnow()
+    if error_message is not None:
+        job.error_message = error_message[:2000]
+    session.add(job)
+    session.commit()
+
+
+def get_job_metrics_grouped(job_id: str, session: Session) -> list[dict]:
+    """Return the full metric history grouped into one dict per epoch.
+
+    Shape: ``[{"epoch": 1, "loss": .., "accuracy": .., "val_loss": ..,
+    "val_accuracy": ..}, ...]`` ordered by epoch ascending. Missing metrics for
+    an epoch are omitted from that epoch's dict.
+    """
+    rows = session.exec(
+        select(TrainingMetric).where(TrainingMetric.job_id == job_id).order_by(TrainingMetric.epoch)
+    ).all()
+    by_epoch: dict[int, dict] = {}
+    for row in rows:
+        by_epoch.setdefault(row.epoch, {"epoch": row.epoch})[row.metric_name] = row.metric_value
+    return [by_epoch[e] for e in sorted(by_epoch)]
+
+
+def get_latest_metrics(job_id: str, session: Session) -> dict:
+    """Return the most recent epoch's metrics, or ``{}`` if none recorded yet."""
+    grouped = get_job_metrics_grouped(job_id, session)
+    return grouped[-1] if grouped else {}
+
+
+def check_concurrency_limit(session: Session) -> None:
+    """Raise HTTP 429 if the active-job limit is already reached."""
+    active = session.exec(
+        select(TrainingJob).where(TrainingJob.status.in_((TrainingStatus.PENDING, TrainingStatus.RUNNING)))
+    ).all()
+    if len(active) >= MAX_CONCURRENT_TRAINING_JOBS:
+        raise AppException(
+            429,
+            f"Max concurrent training jobs reached ({MAX_CONCURRENT_TRAINING_JOBS}). Try again shortly.",
+        )
+
+
+def orphan_recovery(session: Session | None = None) -> int:
+    """Mark jobs left PENDING/RUNNING by a crash as FAILED.
+
+    Called on startup: any job still 'active' in the DB cannot actually be
+    running (the process that owned it is gone), so it is failed with a clear
+    message. Returns the number of jobs recovered.
+    """
+    own_session = session is None
+    session = session or make_session()
+    try:
+        orphans = session.exec(
+            select(TrainingJob).where(TrainingJob.status.in_((TrainingStatus.PENDING, TrainingStatus.RUNNING)))
+        ).all()
+        for job in orphans:
+            job.status = TrainingStatus.FAILED
+            job.error_message = "Recovered orphaned job after restart"
+            job.completed_at = _utcnow()
+            session.add(job)
+        if orphans:
+            session.commit()
+            logger.info("Orphan recovery: marked %d stale job(s) as failed", len(orphans))
+        return len(orphans)
+    finally:
+        if own_session:
+            session.close()
+
+
+def _train_in_thread(model_name: str, job_id: str, loop: asyncio.AbstractEventLoop) -> None:
+    """Run a training job in a worker thread with its own DB session.
+
+    Owns the full lifecycle for the background run: status flips happen inside
+    ``model_run`` via the callbacks; here we only guarantee the job is marked
+    FAILED if training raises before/around the callbacks.
+    """
+    # Imported lazily to avoid importing TensorFlow at app startup.
+    from app.services.model_run import model_run
+
+    with make_session() as session:
+        try:
+            model_run(model_name, session, loop=loop, job_id=job_id)
+        except Exception as e:  # noqa: BLE001 - last-resort guard for the background thread
+            logger.exception("Background training failed for job %s: %s", job_id, e)
+            try:
+                update_job_status(job_id, TrainingStatus.FAILED, session, error_message=str(e))
+            except Exception:  # noqa: BLE001
+                logger.exception("Failed to mark job %s as failed", job_id)
+
+
+def launch_training_job(model_name: str, job_id: str, loop: asyncio.AbstractEventLoop) -> None:
+    """Schedule a training job to run in the background and return immediately.
+
+    Uses ``asyncio.to_thread`` (training is blocking/CPU-bound) wrapped in a
+    tracked task so the event loop keeps a strong reference until it finishes.
+    """
+    task = asyncio.create_task(asyncio.to_thread(_train_in_thread, model_name, job_id, loop))
+    _background_tasks.add(task)
+    task.add_done_callback(_background_tasks.discard)

--- a/tensormap-backend/app/socketio_instance.py
+++ b/tensormap-backend/app/socketio_instance.py
@@ -1,9 +1,16 @@
-"""Shared Socket.IO server instance used for real-time training progress."""
+"""Shared Socket.IO server instance used for real-time training progress.
+
+Progress is isolated per training job via Socket.IO rooms: a client subscribes
+to ``job_id`` and only receives that job's metrics (no global broadcast). Late
+or reconnecting subscribers get a one-shot catch-up of the persisted history.
+"""
+
+import asyncio
 
 import socketio
 
 from app.config import get_settings
-from app.shared.constants import SOCKETIO_DL_NAMESPACE
+from app.shared.constants import SOCKETIO_DL_NAMESPACE, SOCKETIO_LISTENER
 from app.shared.logging_config import get_logger
 
 logger = get_logger(__name__)
@@ -19,3 +26,46 @@ async def dl_connect(sid, environ):
     """Accept and log client connections to the training progress namespace."""
     client_ip = environ.get("REMOTE_ADDR", "unknown")
     logger.info("Client connected to training namespace: sid=%s, ip=%s", sid, client_ip)
+
+
+def _load_catchup(job_id: str) -> dict | None:
+    """Read a job's current status and full metric history (sync DB access).
+
+    Returns None if the job does not exist. Runs in a worker thread because the
+    DB layer is synchronous.
+    """
+    from app.models.training_job import TrainingJob
+    from app.services.training_service import get_job_metrics_grouped, make_session
+
+    with make_session() as session:
+        job = session.get(TrainingJob, job_id)
+        if job is None:
+            return None
+        return {
+            "type": "catchup",
+            "status": job.status.value,
+            "metrics": get_job_metrics_grouped(job_id, session),
+        }
+
+
+@sio.on("subscribe_job", namespace=SOCKETIO_DL_NAMESPACE)
+async def subscribe_job(sid, data):
+    """Join the room for a job and replay its persisted metrics to this client."""
+    job_id = (data or {}).get("job_id")
+    if not job_id:
+        return
+
+    await sio.enter_room(sid, job_id, namespace=SOCKETIO_DL_NAMESPACE)
+
+    # Catch-up: send everything persisted so far to this late/reconnecting client.
+    catchup = await asyncio.to_thread(_load_catchup, job_id)
+    if catchup is not None:
+        await sio.emit(SOCKETIO_LISTENER, catchup, to=sid, namespace=SOCKETIO_DL_NAMESPACE)
+
+
+@sio.on("unsubscribe_job", namespace=SOCKETIO_DL_NAMESPACE)
+async def unsubscribe_job(sid, data):
+    """Leave the room for a job so this client stops receiving its metrics."""
+    job_id = (data or {}).get("job_id")
+    if job_id:
+        await sio.leave_room(sid, job_id, namespace=SOCKETIO_DL_NAMESPACE)

--- a/tensormap-backend/migrations/env.py
+++ b/tensormap-backend/migrations/env.py
@@ -8,6 +8,8 @@ from app.config import get_settings
 from app.models.data import DataFile, DataProcess, ImageProperties  # noqa: F401
 from app.models.ml import ModelBasic, ModelConfigs  # noqa: F401
 from app.models.project import Project  # noqa: F401
+from app.models.training_job import TrainingJob  # noqa: F401
+from app.models.training_metric import TrainingMetric  # noqa: F401
 
 config = context.config
 

--- a/tensormap-backend/migrations/versions/a1f2b3c4d5e6_merge_heads.py
+++ b/tensormap-backend/migrations/versions/a1f2b3c4d5e6_merge_heads.py
@@ -1,0 +1,30 @@
+"""merge divergent heads
+
+Unifies the two migration heads that diverged after the seed migration:
+  - fd86601b847a (add graph_ir column)
+  - 6a7b8c9d0e1f (add unique constraint on data_process.file_id)
+
+Without this merge, ``alembic upgrade head`` is ambiguous (multiple heads).
+This migration has no schema changes of its own.
+
+Revision ID: a1f2b3c4d5e6
+Revises: fd86601b847a, 6a7b8c9d0e1f
+Create Date: 2026-06-27 00:00:00.000000
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = "a1f2b3c4d5e6"
+down_revision = ("fd86601b847a", "6a7b8c9d0e1f")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """No-op: merge node only."""
+    pass
+
+
+def downgrade():
+    """No-op: merge node only."""
+    pass

--- a/tensormap-backend/migrations/versions/b2c3d4e5f6a7_add_training_tables.py
+++ b/tensormap-backend/migrations/versions/b2c3d4e5f6a7_add_training_tables.py
@@ -1,0 +1,83 @@
+"""add training_job and training_metric tables
+
+Creates the persistence layer for training jobs (Week 4):
+  - training_job: one row per training run, tracking lifecycle + hyperparams
+  - training_metric: long-form per-epoch metrics, indexed for chart queries
+
+Revision ID: b2c3d4e5f6a7
+Revises: a1f2b3c4d5e6
+Create Date: 2026-06-27 00:05:00.000000
+
+"""
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID as PgUUID
+
+# revision identifiers, used by Alembic.
+revision = "b2c3d4e5f6a7"
+down_revision = "a1f2b3c4d5e6"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    """Create training_job and training_metric tables."""
+    op.create_table(
+        "training_job",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("model_id", sa.Integer(), nullable=False),
+        sa.Column("project_id", PgUUID(as_uuid=True), nullable=True),
+        # native_enum=False -> portable VARCHAR + CHECK (no Postgres ENUM type).
+        sa.Column(
+            "status",
+            sa.Enum(
+                "pending",
+                "running",
+                "completed",
+                "failed",
+                "cancelled",
+                native_enum=False,
+                length=20,
+            ),
+            nullable=False,
+        ),
+        sa.Column("hyperparams", sa.JSON(), nullable=True),
+        sa.Column("started_at", sa.DateTime(), nullable=True),
+        sa.Column("completed_at", sa.DateTime(), nullable=True),
+        sa.Column("error_message", sa.String(length=2000), nullable=True),
+        sa.Column("analysis_cache", sa.JSON(), nullable=True),
+        sa.Column("last_export_download_at", sa.DateTime(), nullable=True),
+        sa.Column("tuning_session_id", sa.String(length=36), nullable=True),
+        sa.ForeignKeyConstraint(["model_id"], ["model_basic.id"]),
+        sa.ForeignKeyConstraint(["project_id"], ["project.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_training_job_model_id", "training_job", ["model_id"])
+    op.create_index("ix_training_job_project_id", "training_job", ["project_id"])
+    op.create_index("ix_training_job_status", "training_job", ["status"])
+
+    op.create_table(
+        "training_metric",
+        sa.Column("id", sa.Integer(), nullable=False),
+        sa.Column("job_id", sa.String(length=36), nullable=False),
+        sa.Column("epoch", sa.Integer(), nullable=False),
+        sa.Column("metric_name", sa.String(length=50), nullable=False),
+        sa.Column("metric_value", sa.Float(), nullable=False),
+        sa.Column("recorded_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(["job_id"], ["training_job.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+    op.create_index("ix_training_metric_job_id", "training_metric", ["job_id"])
+    op.create_index("ix_metric_job_epoch", "training_metric", ["job_id", "epoch"])
+
+
+def downgrade():
+    """Drop training_metric and training_job tables."""
+    op.drop_index("ix_metric_job_epoch", table_name="training_metric")
+    op.drop_index("ix_training_metric_job_id", table_name="training_metric")
+    op.drop_table("training_metric")
+    op.drop_index("ix_training_job_status", table_name="training_job")
+    op.drop_index("ix_training_job_project_id", table_name="training_job")
+    op.drop_index("ix_training_job_model_id", table_name="training_job")
+    op.drop_table("training_job")

--- a/tensormap-backend/pyproject.toml
+++ b/tensormap-backend/pyproject.toml
@@ -55,6 +55,9 @@ packages = ["app"]
 
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
+markers = [
+    "slow: end-to-end tests that train a real Keras model (deselect with '-m \"not slow\"')",
+]
 
 [build-system]
 requires = ["hatchling"]

--- a/tensormap-backend/tests/conftest.py
+++ b/tensormap-backend/tests/conftest.py
@@ -83,6 +83,30 @@ def db_session(test_db_url: str) -> Generator[Session, None, None]:
 
 
 @pytest.fixture(scope="function")
+def training_session_factory(monkeypatch) -> Generator:
+    """A session factory over an isolated in-memory DB for training callbacks.
+
+    Training callbacks and background workers open their own sessions via
+    ``training_service.make_session`` (which reads the module-level engine).
+    This fixture points that engine at a fresh in-memory SQLite DB so callback
+    and service tests share one database without touching the app engine.
+    """
+    engine = create_engine(
+        "sqlite://",
+        connect_args={"check_same_thread": False},
+        poolclass=StaticPool,
+    )
+    SQLModel.metadata.create_all(engine)
+    monkeypatch.setattr("app.services.training_service.engine", engine)
+
+    def factory() -> Session:
+        return Session(engine)
+
+    yield factory
+    engine.dispose()
+
+
+@pytest.fixture(scope="function")
 def client(db_session: Session) -> Generator[TestClient, None, None]:
     """
     Provide a test HTTP client for testing FastAPI endpoints.

--- a/tensormap-backend/tests/test_metrics_callback.py
+++ b/tensormap-backend/tests/test_metrics_callback.py
@@ -1,0 +1,141 @@
+"""Tests for MetricsCallback, CancellationCheckCallback, and the failure path.
+
+These exercise the callbacks directly (no real Keras run) against an isolated
+in-memory DB, which is reliable and fast. A genuine end-to-end Keras run lives
+in test_training_e2e.py behind the ``slow`` marker.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from sqlmodel import select
+
+from app.callbacks.cancellation_callback import CancellationCheckCallback
+from app.callbacks.metrics_callback import MetricsCallback
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
+from app.services.training_service import _train_in_thread
+
+
+def _seed_job(factory, status=TrainingStatus.PENDING) -> str:
+    with factory() as session:
+        job = TrainingJob(model_id=1, status=status)
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        return job.id
+
+
+def test_metrics_persist_after_training(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+
+    cb.on_train_begin()
+    cb.on_epoch_end(0, {"loss": 0.5, "accuracy": 0.8, "val_loss": 0.6, "val_accuracy": 0.7})
+    cb.on_epoch_end(1, {"loss": 0.3, "accuracy": 0.9, "val_loss": 0.4, "val_accuracy": 0.85})
+    cb.on_train_end()
+
+    with training_session_factory() as session:
+        rows = session.exec(select(TrainingMetric).where(TrainingMetric.job_id == job_id)).all()
+        # 4 metrics x 2 epochs.
+        assert len(rows) == 8
+        names = {r.metric_name for r in rows}
+        assert names == {"loss", "accuracy", "val_loss", "val_accuracy"}
+
+
+def test_metrics_omit_missing_validation_metrics(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+    # No val_* metrics in logs -> only loss + accuracy persisted.
+    cb.on_epoch_end(0, {"loss": 0.5, "accuracy": 0.8})
+
+    with training_session_factory() as session:
+        rows = session.exec(select(TrainingMetric).where(TrainingMetric.job_id == job_id)).all()
+        assert {r.metric_name for r in rows} == {"loss", "accuracy"}
+
+
+def test_job_status_running_during_training(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+    cb.on_train_begin()
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        assert job.status == TrainingStatus.RUNNING
+        assert job.started_at is not None
+
+
+def test_job_status_completed_after_training(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+    cb.on_train_begin()
+    cb.on_train_end()
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        assert job.status == TrainingStatus.COMPLETED
+        assert job.completed_at is not None
+
+
+def test_on_train_end_does_not_override_cancelled(training_session_factory):
+    job_id = _seed_job(training_session_factory, status=TrainingStatus.CANCELLED)
+    cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+    cb.on_train_end()
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        # A cancelled job must not be flipped to completed.
+        assert job.status == TrainingStatus.CANCELLED
+
+
+def test_metrics_emitted_to_job_room(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    sio = MagicMock()
+    loop = MagicMock()
+    loop.is_running.return_value = True
+    cb = MetricsCallback(job_id, training_session_factory, sio, loop=loop)
+
+    with patch("app.callbacks.metrics_callback.asyncio.run_coroutine_threadsafe") as rcts:
+        cb.on_epoch_end(0, {"loss": 0.5, "accuracy": 0.8})
+
+    # The emit is scheduled on the loop; assert it targets this job's room only.
+    assert sio.emit.called
+    _, kwargs = sio.emit.call_args
+    assert kwargs["room"] == job_id
+    assert kwargs["namespace"] == "/dl-result"
+    assert rcts.called
+
+
+def test_cancellation_stops_training(training_session_factory):
+    job_id = _seed_job(training_session_factory, status=TrainingStatus.CANCELLED)
+    cb = CancellationCheckCallback(job_id, training_session_factory)
+    cb.set_model(MagicMock())
+
+    cb.on_epoch_begin(0)
+
+    assert cb.model.stop_training is True
+    assert cb.cancelled is True
+
+
+def test_cancellation_no_stop_when_running(training_session_factory):
+    job_id = _seed_job(training_session_factory, status=TrainingStatus.RUNNING)
+    cb = CancellationCheckCallback(job_id, training_session_factory)
+    model = MagicMock()
+    model.stop_training = False
+    cb.set_model(model)
+
+    cb.on_epoch_begin(0)
+
+    assert cb.model.stop_training is False
+    assert cb.cancelled is False
+
+
+def test_job_stores_error_on_exception(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+
+    with patch("app.services.model_run.model_run", side_effect=RuntimeError("boom")):
+        _train_in_thread("m1", job_id, loop=None)
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        assert job.status == TrainingStatus.FAILED
+        assert "boom" in job.error_message

--- a/tensormap-backend/tests/test_orphan_recovery.py
+++ b/tensormap-backend/tests/test_orphan_recovery.py
@@ -1,0 +1,66 @@
+"""Orphaned-job recovery: jobs left active by a crash are failed on startup."""
+
+import pytest
+from sqlmodel import Session, select
+
+from app.models.ml import ModelBasic
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.services.training_service import orphan_recovery
+
+
+@pytest.fixture
+def model_id(db_session: Session) -> int:
+    """A real model row so training_job's foreign key is satisfied.
+
+    PostgreSQL (CI) enforces foreign keys, so jobs must reference a model that
+    actually exists.
+    """
+    model = ModelBasic(model_name="orphan-test-model")
+    db_session.add(model)
+    db_session.commit()
+    db_session.refresh(model)
+    return model.id
+
+
+def _seed_job(session: Session, model_id: int, status: TrainingStatus) -> TrainingJob:
+    job = TrainingJob(model_id=model_id, status=status)
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+def test_recovers_running_and_pending_jobs(db_session, model_id):
+    _seed_job(db_session, model_id, TrainingStatus.RUNNING)
+    _seed_job(db_session, model_id, TrainingStatus.RUNNING)
+
+    recovered = orphan_recovery(db_session)
+    assert recovered == 2
+
+    jobs = db_session.exec(select(TrainingJob)).all()
+    assert all(j.status == TrainingStatus.FAILED for j in jobs)
+    assert all(j.error_message == "Recovered orphaned job after restart" for j in jobs)
+    assert all(j.completed_at is not None for j in jobs)
+
+
+def test_does_not_touch_finished_jobs(db_session, model_id):
+    completed = _seed_job(db_session, model_id, TrainingStatus.COMPLETED)
+    cancelled = _seed_job(db_session, model_id, TrainingStatus.CANCELLED)
+    failed = _seed_job(db_session, model_id, TrainingStatus.FAILED)
+
+    recovered = orphan_recovery(db_session)
+    assert recovered == 0
+
+    db_session.refresh(completed)
+    db_session.refresh(cancelled)
+    db_session.refresh(failed)
+    assert completed.status == TrainingStatus.COMPLETED
+    assert cancelled.status == TrainingStatus.CANCELLED
+    assert failed.status == TrainingStatus.FAILED
+
+
+def test_recovery_is_idempotent(db_session, model_id):
+    _seed_job(db_session, model_id, TrainingStatus.RUNNING)
+    assert orphan_recovery(db_session) == 1
+    # Second pass finds nothing left to recover.
+    assert orphan_recovery(db_session) == 0

--- a/tensormap-backend/tests/test_socket_rooms.py
+++ b/tensormap-backend/tests/test_socket_rooms.py
@@ -1,0 +1,90 @@
+"""Tests for Socket.IO per-job room isolation and catch-up.
+
+We don't re-test socket.io's own room routing; we assert that our handlers pass
+the right room/recipient and that catch-up returns the persisted history.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+import app.socketio_instance as si
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
+
+NS = "/dl-result"
+
+
+def _seed_job_with_metrics(factory, epochs: int) -> str:
+    with factory() as session:
+        job = TrainingJob(model_id=1, status=TrainingStatus.RUNNING)
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        for epoch in range(1, epochs + 1):
+            session.add(TrainingMetric(job_id=job.id, epoch=epoch, metric_name="loss", metric_value=1.0 / epoch))
+            session.add(TrainingMetric(job_id=job.id, epoch=epoch, metric_name="accuracy", metric_value=epoch / 10))
+        session.commit()
+        return job.id
+
+
+async def test_subscribe_job_enters_room():
+    with (
+        patch.object(si, "sio", new=AsyncMock()) as mock_sio,
+        patch.object(si, "_load_catchup", return_value=None),
+    ):
+        await si.subscribe_job("sid-1", {"job_id": "job-123"})
+
+    mock_sio.enter_room.assert_awaited_once_with("sid-1", "job-123", namespace=NS)
+
+
+async def test_subscribe_job_missing_id_is_noop():
+    with patch.object(si, "sio", new=AsyncMock()) as mock_sio:
+        await si.subscribe_job("sid-1", {})
+    mock_sio.enter_room.assert_not_called()
+
+
+async def test_subscribe_job_emits_catchup_to_sender_only():
+    catchup = {"type": "catchup", "status": "running", "metrics": [{"epoch": 1, "loss": 0.5}]}
+    with (
+        patch.object(si, "sio", new=AsyncMock()) as mock_sio,
+        patch.object(si, "_load_catchup", return_value=catchup),
+    ):
+        await si.subscribe_job("sid-1", {"job_id": "job-123"})
+
+    mock_sio.emit.assert_awaited_once()
+    args, kwargs = mock_sio.emit.call_args
+    assert args[0] == "result :::"
+    assert args[1] == catchup
+    assert kwargs["to"] == "sid-1"  # directed to the subscriber, not broadcast
+    assert kwargs["namespace"] == NS
+
+
+async def test_unsubscribe_job_leaves_room():
+    with patch.object(si, "sio", new=AsyncMock()) as mock_sio:
+        await si.unsubscribe_job("sid-1", {"job_id": "job-123"})
+    mock_sio.leave_room.assert_awaited_once_with("sid-1", "job-123", namespace=NS)
+
+
+def test_catchup_returns_full_history(training_session_factory):
+    job_id = _seed_job_with_metrics(training_session_factory, epochs=5)
+
+    # _load_catchup uses training_service.make_session, repointed by the fixture.
+    catchup = si._load_catchup(job_id)
+
+    assert catchup is not None
+    assert catchup["type"] == "catchup"
+    assert catchup["status"] == "running"
+    assert len(catchup["metrics"]) == 5
+    assert [m["epoch"] for m in catchup["metrics"]] == [1, 2, 3, 4, 5]
+
+
+def test_catchup_unknown_job_returns_none(training_session_factory):
+    assert si._load_catchup("nonexistent") is None
+
+
+@pytest.mark.parametrize("data", [None, {}, {"job_id": ""}])
+async def test_unsubscribe_missing_id_is_noop(data):
+    with patch.object(si, "sio", new=AsyncMock()) as mock_sio:
+        await si.unsubscribe_job("sid-1", data)
+    mock_sio.leave_room.assert_not_called()

--- a/tensormap-backend/tests/test_training_e2e.py
+++ b/tensormap-backend/tests/test_training_e2e.py
@@ -1,0 +1,96 @@
+"""End-to-end training tests with a real (tiny) Keras model.
+
+Marked ``slow`` so the default test run can skip them with ``-m "not slow"``.
+These wire the real ``MetricsCallback``/``CancellationCheckCallback`` into an
+actual ``model.fit`` to prove the full lifecycle: real epochs -> persisted
+metrics -> status transitions, and a real cooperative cancellation.
+"""
+
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+import tensorflow as tf
+
+from app.callbacks.cancellation_callback import CancellationCheckCallback
+from app.callbacks.metrics_callback import MetricsCallback
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.services.training_service import get_job_metrics_grouped, update_job_status
+
+pytestmark = pytest.mark.slow
+
+
+def _tiny_model() -> tf.keras.Model:
+    model = tf.keras.Sequential(
+        [
+            tf.keras.layers.Input((2,)),
+            tf.keras.layers.Dense(4, activation="relu"),
+            tf.keras.layers.Dense(1, activation="sigmoid"),
+        ]
+    )
+    model.compile(optimizer="adam", loss="binary_crossentropy", metrics=["accuracy"])
+    return model
+
+
+def _binary_dataset(n: int = 100):
+    rng = np.random.default_rng(0)
+    x = rng.normal(size=(n, 2)).astype("float32")
+    y = (x[:, 0] + x[:, 1] > 0).astype("float32")
+    return x, y
+
+
+def _seed_job(factory, status=TrainingStatus.PENDING) -> str:
+    with factory() as session:
+        job = TrainingJob(model_id=1, status=status)
+        session.add(job)
+        session.commit()
+        session.refresh(job)
+        return job.id
+
+
+def test_e2e_training_completes_and_persists_metrics(training_session_factory):
+    job_id = _seed_job(training_session_factory)
+    callback = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+
+    x, y = _binary_dataset()
+    _tiny_model().fit(x, y, epochs=5, batch_size=16, verbose=0, callbacks=[callback])
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        assert job.status == TrainingStatus.COMPLETED
+        assert job.started_at is not None
+        grouped = get_job_metrics_grouped(job_id, session)
+
+    assert len(grouped) == 5
+    assert "loss" in grouped[0]
+    assert "accuracy" in grouped[0]
+
+
+def test_e2e_cancellation_stops_training(training_session_factory):
+    job_id = _seed_job(training_session_factory, status=TrainingStatus.RUNNING)
+    metrics_cb = MetricsCallback(job_id, training_session_factory, MagicMock(), loop=None)
+    cancel_cb = CancellationCheckCallback(job_id, training_session_factory)
+
+    factory = training_session_factory
+
+    class CancelAfterFirstEpoch(tf.keras.callbacks.Callback):
+        """Simulate a user pressing Stop after the first epoch completes."""
+
+        def on_epoch_end(self, epoch, logs=None):
+            if epoch == 0:
+                with factory() as session:
+                    update_job_status(job_id, TrainingStatus.CANCELLED, session)
+
+    x, y = _binary_dataset()
+    model = _tiny_model()
+    model.fit(x, y, epochs=10, batch_size=16, verbose=0, callbacks=[metrics_cb, cancel_cb, CancelAfterFirstEpoch()])
+
+    assert cancel_cb.cancelled is True
+    assert model.stop_training is True
+
+    with training_session_factory() as session:
+        job = session.get(TrainingJob, job_id)
+        assert job.status == TrainingStatus.CANCELLED
+        grouped = get_job_metrics_grouped(job_id, session)
+    # Training stopped early rather than running all 10 epochs.
+    assert len(grouped) < 10

--- a/tensormap-backend/tests/test_training_jobs.py
+++ b/tensormap-backend/tests/test_training_jobs.py
@@ -1,0 +1,198 @@
+"""Tests for the training-job CRUD API and service helpers.
+
+Background training is patched out in HTTP tests so we deterministically test
+the request/persistence behaviour without spinning up a real Keras run.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlmodel import Session, select
+
+from app.models.data import DataFile
+from app.models.ml import ModelBasic
+from app.models.project import Project
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.models.training_metric import TrainingMetric
+from app.services.training_service import orphan_recovery
+
+BASE = "/api/v1/model"
+
+
+def _seed_model(session: Session, name: str = "m1") -> ModelBasic:
+    """Create a fully-configured model (with project + dataset) ready to train."""
+    project = Project(name="proj")
+    session.add(project)
+    session.commit()
+    session.refresh(project)
+
+    data_file = DataFile(file_name="d.csv", file_type="csv", disk_name="d.csv", project_id=project.id)
+    session.add(data_file)
+    session.commit()
+    session.refresh(data_file)
+
+    model = ModelBasic(
+        model_name=name,
+        file_id=data_file.id,
+        project_id=project.id,
+        model_type=1,
+        target_field="label",
+        training_split=80,
+        optimizer="adam",
+        metric="accuracy",
+        epochs=1,
+        batch_size=32,
+        loss="sparse_categorical_crossentropy",
+    )
+    session.add(model)
+    session.commit()
+    session.refresh(model)
+    return model
+
+
+def _seed_job(
+    session: Session, model_id: int, status: TrainingStatus, started_at: datetime | None = None
+) -> TrainingJob:
+    job = TrainingJob(model_id=model_id, status=status, started_at=started_at)
+    session.add(job)
+    session.commit()
+    session.refresh(job)
+    return job
+
+
+@pytest.fixture(autouse=True)
+def _no_background_training(mocker):
+    """Stop the run endpoint from launching real training in every HTTP test."""
+    return mocker.patch("app.routers.training.launch_training_job")
+
+
+def test_start_training_returns_202(client, db_session):
+    _seed_model(db_session, "m1")
+    resp = client.post(f"{BASE}/run", json={"model_name": "m1"})
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["data"]["job_id"]
+    assert body["data"]["status"] == "pending"
+
+
+def test_job_created_with_pending_status(client, db_session):
+    _seed_model(db_session, "m1")
+    resp = client.post(f"{BASE}/run", json={"model_name": "m1"})
+    job_id = resp.json()["data"]["job_id"]
+
+    job = db_session.get(TrainingJob, job_id)
+    assert job is not None
+    assert job.status == TrainingStatus.PENDING
+    assert job.hyperparams["optimizer"] == "adam"
+    assert job.hyperparams["epochs"] == 1
+
+
+def test_start_training_launches_background(client, db_session, _no_background_training):
+    _seed_model(db_session, "m1")
+    resp = client.post(f"{BASE}/run", json={"model_name": "m1"})
+    job_id = resp.json()["data"]["job_id"]
+    _no_background_training.assert_called_once()
+    # model_name and job_id are forwarded to the launcher.
+    args = _no_background_training.call_args.args
+    assert args[0] == "m1"
+    assert args[1] == job_id
+
+
+def test_start_training_unknown_model_404(client, db_session):
+    resp = client.post(f"{BASE}/run", json={"model_name": "does-not-exist"})
+    assert resp.status_code == 404
+
+
+def test_start_training_unconfigured_model_400(client, db_session):
+    # Model exists but has no file_id/epochs configured yet.
+    model = ModelBasic(model_name="bare", optimizer="adam")
+    db_session.add(model)
+    db_session.commit()
+    resp = client.post(f"{BASE}/run", json={"model_name": "bare"})
+    assert resp.status_code == 400
+
+
+def test_get_job_status(client, db_session):
+    model = _seed_model(db_session, "m1")
+    job = _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    resp = client.get(f"{BASE}/training-job/{job.id}")
+    assert resp.status_code == 200
+    assert resp.json()["data"]["status"] == "running"
+
+
+def test_cancel_job(client, db_session):
+    model = _seed_model(db_session, "m1")
+    job = _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    resp = client.delete(f"{BASE}/training-job/{job.id}")
+    assert resp.status_code == 204
+    db_session.refresh(job)
+    assert job.status == TrainingStatus.CANCELLED
+
+
+def test_get_job_404(client, db_session):
+    # No auth/owner model exists, so unauthorized-access is expressed as 404.
+    resp = client.get(f"{BASE}/training-job/missing-id")
+    assert resp.status_code == 404
+    # Errors follow the same {success, message, data} envelope as the rest of the API.
+    assert resp.json()["success"] is False
+
+
+def test_orphan_recovery_marks_running_as_failed(db_session):
+    model = _seed_model(db_session, "m1")
+    _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    _seed_job(db_session, model.id, TrainingStatus.PENDING)
+
+    recovered = orphan_recovery(db_session)
+    assert recovered == 2
+
+    jobs = db_session.exec(select(TrainingJob)).all()
+    assert all(j.status == TrainingStatus.FAILED for j in jobs)
+    assert all("orphan" in (j.error_message or "").lower() for j in jobs)
+
+
+def test_metrics_endpoint_empty(client, db_session):
+    model = _seed_model(db_session, "m1")
+    job = _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    resp = client.get(f"{BASE}/training-job/{job.id}/metrics")
+    assert resp.status_code == 200
+    assert resp.json()["data"] == []
+
+
+def test_metrics_endpoint_after_insert(client, db_session):
+    model = _seed_model(db_session, "m1")
+    job = _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    for epoch in (1, 2, 3):
+        db_session.add(TrainingMetric(job_id=job.id, epoch=epoch, metric_name="loss", metric_value=1.0 / epoch))
+        db_session.add(TrainingMetric(job_id=job.id, epoch=epoch, metric_name="accuracy", metric_value=epoch / 10))
+    db_session.commit()
+
+    resp = client.get(f"{BASE}/training-job/{job.id}/metrics")
+    data = resp.json()["data"]
+    assert len(data) == 3
+    assert data[0] == {"epoch": 1, "loss": 1.0, "accuracy": 0.1}
+    assert [row["epoch"] for row in data] == [1, 2, 3]
+
+
+def test_concurrency_limit(client, db_session, monkeypatch):
+    model = _seed_model(db_session, "m1")
+    # Saturate with 3 active jobs (the default MAX_CONCURRENT_TRAINING_JOBS).
+    for _ in range(3):
+        _seed_job(db_session, model.id, TrainingStatus.RUNNING)
+    resp = client.post(f"{BASE}/run", json={"model_name": "m1"})
+    assert resp.status_code == 429
+    assert resp.json()["success"] is False
+
+
+def test_list_jobs_for_model(client, db_session):
+    model = _seed_model(db_session, "m1")
+    now = datetime.now(UTC)
+    _seed_job(db_session, model.id, TrainingStatus.COMPLETED, started_at=now - timedelta(minutes=5))
+    _seed_job(db_session, model.id, TrainingStatus.COMPLETED, started_at=now - timedelta(minutes=1))
+    _seed_job(db_session, model.id, TrainingStatus.COMPLETED, started_at=now - timedelta(minutes=3))
+
+    resp = client.get(f"{BASE}/training-jobs", params={"model_name": "m1"})
+    assert resp.status_code == 200
+    data = resp.json()["data"]
+    assert len(data) == 3
+    starts = [row["started_at"] for row in data]
+    assert starts == sorted(starts, reverse=True)  # most recent first

--- a/tensormap-frontend/src/constants/Urls.js
+++ b/tensormap-frontend/src/constants/Urls.js
@@ -12,6 +12,7 @@ export const BACKEND_GET_ALL_MODELS = "/model/model-list";
 export const BACKEND_GET_TRAINING_HISTORY = "/model/training-history";
 export const BACKEND_DOWNLOAD_CODE = "/model/code";
 export const BACKEND_RUN_MODEL = "/model/run";
+export const BACKEND_TRAINING_JOB = "/model/training-job";
 export const BACKEND_FILE_UPLOAD = "/data/upload/file";
 export const WS_DL_RESULTS = import.meta.env.VITE_WS_URL || "http://localhost:4300/dl-result";
 export const BACKEND_VALIDATE_MODEL = "/model/validate";

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef, useCallback } from "react";
 import { useParams } from "react-router-dom";
 import { Trash2 } from "lucide-react";
-import io from "socket.io-client";
 import { useRecoilState, useRecoilValue } from "recoil";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
@@ -22,8 +21,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import * as urls from "../../constants/Urls";
-import * as strings from "../../constants/Strings";
 import logger from "../../shared/logger";
 import FeedbackDialog from "../../components/shared/FeedbackDialog";
 import Result from "../../components/ResultPanel/Result/Result";
@@ -35,6 +32,12 @@ import {
   deleteModel,
 } from "../../services/ModelServices";
 import { getAllFiles } from "../../services/FileServices";
+import {
+  getTrainingSocket,
+  subscribeToJob,
+  unsubscribeFromJob,
+  cancelJob,
+} from "../../services/socketService";
 import {
   models as modelListAtom,
   trainingHistory as trainingHistoryAtom,
@@ -59,6 +62,26 @@ const problemTypeOptions = [
   { key: "prob_type_2", label: "Linear Regression", value: "2" },
 ];
 
+const fmt = (value) => (typeof value === "number" ? value.toFixed(4) : value);
+
+// Render one epoch's structured metrics as a single human-readable line.
+const formatMetricLine = (m) => {
+  const parts = [`loss: ${fmt(m.loss)}`];
+  if (m.accuracy != null) parts.push(`accuracy: ${fmt(m.accuracy)}`);
+  if (m.val_loss != null) parts.push(`val_loss: ${fmt(m.val_loss)}`);
+  if (m.val_accuracy != null) parts.push(`val_accuracy: ${fmt(m.val_accuracy)}`);
+  return `Epoch ${m.epoch} — ${parts.join(", ")}`;
+};
+
+const statusLine = (status, error) => {
+  if (status === "completed") return "Training completed.";
+  if (status === "cancelled") return "Training cancelled.";
+  if (status === "failed") return `Training failed${error ? `: ${error}` : "."}`;
+  return `Status: ${status}`;
+};
+
+const TERMINAL_STATUSES = ["completed", "failed", "cancelled"];
+
 export default function Training() {
   const { projectId } = useParams();
   const [, setModelList] = useRecoilState(modelListAtom);
@@ -79,6 +102,10 @@ export default function Training() {
   const fetchModelsRef = useRef(null);
   const fetchIdRef = useRef(0);
   const fetchFilesIdRef = useRef(0);
+  // Active training job + its Socket.IO listener cleanup.
+  const currentJobIdRef = useRef(null);
+  const jobCleanupRef = useRef(null);
+  const [cancelRequested, setCancelRequested] = useState(false);
   const [trainingHistory, setTrainingHistory] = useRecoilState(trainingHistoryAtom);
 
   // Training config state
@@ -163,53 +190,42 @@ export default function Training() {
   }, [fetchModels]);
 
   useEffect(() => {
-    const socket = io(urls.WS_DL_RESULTS, {
-      reconnection: true,
-      reconnectionAttempts: 10,
-      reconnectionDelay: 1000,
-      reconnectionDelayMax: 5000,
-      timeout: 10000,
-    });
+    const socket = getTrainingSocket();
     socketRef.current = socket;
 
-    const dlResultListener = (resp) => {
-      clearTimeout(timeoutRef.current);
-      if (resp.message && resp.message.includes("Starting")) {
-        setResultValues([]);
-        setIsLoading(true);
-      } else if (resp.message && resp.message.includes("Finish")) {
-        setIsLoading(false);
-        if (fetchModelsRef.current) {
-          fetchModelsRef.current();
-        }
-      } else {
-        setResultValues((prev) => [...prev, resp.message]);
-      }
-    };
-
-    socket.on(strings.DL_RESULT_LISTENER, dlResultListener);
-
-    socket.on("connect_error", (err) => {
+    const onConnect = () => setConnectionError(null);
+    const onConnectError = (err) => {
       logger.warn("Socket connection error:", err);
       setConnectionError("Lost connection to server");
-    });
-
-    socket.on("connect", () => {
-      setConnectionError(null);
-    });
-
-    socket.on("disconnect", (reason) => {
+    };
+    const onDisconnect = (reason) => {
       if (reason === "io server disconnect") {
         socket.connect();
       }
-    });
+    };
+
+    socket.on("connect", onConnect);
+    socket.on("connect_error", onConnectError);
+    socket.on("disconnect", onDisconnect);
+    if (!socket.connected) socket.connect();
 
     fetchModels();
     fetchFiles();
 
     return () => {
       clearTimeout(timeoutRef.current);
-      socket.off(strings.DL_RESULT_LISTENER, dlResultListener);
+      socket.off("connect", onConnect);
+      socket.off("connect_error", onConnectError);
+      socket.off("disconnect", onDisconnect);
+      // Detach any active job listener and leave its room.
+      if (jobCleanupRef.current) {
+        jobCleanupRef.current();
+        jobCleanupRef.current = null;
+      }
+      if (currentJobIdRef.current) {
+        unsubscribeFromJob(currentJobIdRef.current);
+        currentJobIdRef.current = null;
+      }
       socket.disconnect();
     };
   }, [projectId, fetchModels, fetchFiles, setModelList]);
@@ -463,6 +479,47 @@ export default function Training() {
     }
   }, [selectedModel, projectId]);
 
+  // Tear down an active job: stop the timeout, detach the socket listener,
+  // leave the room, and refresh history.
+  const finishTraining = useCallback(() => {
+    clearTimeout(timeoutRef.current);
+    setIsLoading(false);
+    setCancelRequested(false);
+    if (jobCleanupRef.current) {
+      jobCleanupRef.current();
+      jobCleanupRef.current = null;
+    }
+    if (currentJobIdRef.current) {
+      unsubscribeFromJob(currentJobIdRef.current);
+      currentJobIdRef.current = null;
+    }
+    if (fetchModelsRef.current) {
+      fetchModelsRef.current();
+    }
+  }, []);
+
+  // Handle a structured event from the subscribed job's room.
+  const handleJobEvent = useCallback(
+    (data) => {
+      clearTimeout(timeoutRef.current);
+      if (data.type === "catchup") {
+        setResultValues((data.metrics || []).map(formatMetricLine));
+        if (TERMINAL_STATUSES.includes(data.status)) {
+          setResultValues((prev) => [...prev, statusLine(data.status)]);
+          finishTraining();
+        } else {
+          setIsLoading(true);
+        }
+      } else if (data.type === "metrics") {
+        setResultValues((prev) => [...prev, formatMetricLine(data)]);
+      } else if (data.type === "status") {
+        setResultValues((prev) => [...prev, statusLine(data.status, data.error)]);
+        finishTraining();
+      }
+    },
+    [finishTraining],
+  );
+
   const handleRun = useCallback(() => {
     if (!selectedModel) return;
 
@@ -478,12 +535,19 @@ export default function Training() {
     }
     setResultValues([]);
     setIsLoading(true);
+    setCancelRequested(false);
     timeoutRef.current = setTimeout(() => {
       setIsLoading(false);
       setResultValues(["Training timed out. The model may still be running on the server."]);
     }, 300000);
     runModel(selectedModel, projectId)
-      .then(() => {})
+      .then((job) => {
+        currentJobIdRef.current = job.job_id;
+        if (jobCleanupRef.current) {
+          jobCleanupRef.current();
+        }
+        jobCleanupRef.current = subscribeToJob(job.job_id, handleJobEvent);
+      })
       .catch((error) => {
         clearTimeout(timeoutRef.current);
         logger.error(error);
@@ -497,7 +561,19 @@ export default function Training() {
         setResultValues([message]);
         setIsLoading(false);
       });
-  }, [selectedModel, projectId, validateAllFields]);
+  }, [selectedModel, projectId, validateAllFields, handleJobEvent]);
+
+  // Request cancellation of the running job. The server stops training at the
+  // next epoch boundary and emits a terminal status event.
+  const handleStop = useCallback(() => {
+    const jobId = currentJobIdRef.current;
+    if (!jobId) return;
+    setCancelRequested(true);
+    cancelJob(jobId).catch((error) => {
+      logger.error("Failed to cancel training:", error);
+      setCancelRequested(false);
+    });
+  }, []);
 
   const handleClear = () => {
     setResultValues([]);
@@ -633,6 +709,11 @@ export default function Training() {
             >
               {isLoading ? "Training..." : "Train"}
             </Button>
+            {isLoading && (
+              <Button variant="destructive" onClick={handleStop} disabled={cancelRequested}>
+                {cancelRequested ? "Cancellation requested..." : "Stop Training"}
+              </Button>
+            )}
             <Button
               onClick={handleClear}
               disabled={resultValues.length === 0 && !isLoading}

--- a/tensormap-frontend/src/services/ModelServices.js
+++ b/tensormap-frontend/src/services/ModelServices.js
@@ -174,6 +174,8 @@ export const getModelGraph = async (modelName, projectId) => {
     });
 };
 
+// Starts a training run. The backend returns 202 immediately with the created
+// job descriptor ({ job_id, status }); progress then streams over Socket.IO.
 export const runModel = async (modelName, projectId) => {
   const data = {
     model_name: modelName,
@@ -183,8 +185,8 @@ export const runModel = async (modelName, projectId) => {
   return axios
     .post(urls.BACKEND_RUN_MODEL, data)
     .then((resp) => {
-      if (resp.data.success === true) {
-        return resp.data.message;
+      if (resp.data.success === true && resp.data.data?.job_id) {
+        return resp.data.data; // { job_id, status }
       }
       throw new Error(resp.data?.message ?? JSON.stringify(resp.data));
     })

--- a/tensormap-frontend/src/services/socketService.js
+++ b/tensormap-frontend/src/services/socketService.js
@@ -1,0 +1,79 @@
+/**
+ * Socket.IO client for per-job training progress.
+ *
+ * Training metrics are isolated per job via Socket.IO rooms: a client subscribes
+ * to a `job_id` and only receives that job's events (plus a one-shot catch-up of
+ * the persisted history). A single shared socket is reused across the app.
+ * @module
+ */
+
+import { io } from "socket.io-client";
+import axios from "../shared/Axios";
+import * as urls from "../constants/Urls";
+import * as strings from "../constants/Strings";
+
+let socket = null;
+
+/** Lazily create (once) and return the shared training socket. */
+export function getTrainingSocket() {
+  if (!socket) {
+    socket = io(urls.WS_DL_RESULTS, {
+      reconnection: true,
+      reconnectionAttempts: 10,
+      reconnectionDelay: 1000,
+      reconnectionDelayMax: 5000,
+      timeout: 10000,
+      autoConnect: false,
+    });
+  }
+  return socket;
+}
+
+/**
+ * Subscribe to a job's room and stream its events to `onEvent`.
+ *
+ * `onEvent` receives structured payloads of the form:
+ *   - `{ type: "catchup", status, metrics: [...] }` — replay of persisted history
+ *   - `{ type: "metrics", epoch, loss, accuracy, val_loss, val_accuracy }`
+ *   - `{ type: "status", status, error? }` — terminal state (completed/failed/cancelled)
+ *
+ * @returns {() => void} cleanup that detaches the listener.
+ */
+export function subscribeToJob(jobId, onEvent) {
+  const s = getTrainingSocket();
+
+  const handler = (data) => {
+    if (data && (data.type === "metrics" || data.type === "catchup" || data.type === "status")) {
+      onEvent(data);
+    }
+  };
+  s.on(strings.DL_RESULT_LISTENER, handler);
+
+  // Re-join the room on every (re)connect: a reconnect gives a fresh server-side
+  // session, so the previous room membership is gone. Re-subscribing triggers a
+  // catch-up so no metrics are missed across the gap.
+  const emitSubscribe = () => s.emit("subscribe_job", { job_id: jobId });
+  s.on("connect", emitSubscribe);
+  if (s.connected) {
+    emitSubscribe();
+  } else {
+    s.connect();
+  }
+
+  return () => {
+    s.off(strings.DL_RESULT_LISTENER, handler);
+    s.off("connect", emitSubscribe);
+  };
+}
+
+/** Leave a job's room so this client stops receiving its events. */
+export function unsubscribeFromJob(jobId) {
+  if (socket && jobId) {
+    socket.emit("unsubscribe_job", { job_id: jobId });
+  }
+}
+
+/** Request cancellation of a training job (DELETE /model/training-job/:id). */
+export function cancelJob(jobId) {
+  return axios.delete(`${urls.BACKEND_TRAINING_JOB}/${jobId}`);
+}


### PR DESCRIPTION
## Summary

Replaces TensorMap's stateless, fire-and-block training flow with **persistent, cancellable, per-user-isolated training jobs**.

Previously, `POST /model/run` ran training synchronously inside the request (the HTTP call hung for the entire run), streamed progress as **formatted text strings**, and **broadcast them to every connected client**. There was no record of past runs, no way to cancel, and two users training at once saw each other's progress.

Now:
- Two new tables (`training_job`, `training_metric`), a job lifecycle state machine, structured per-epoch metric persistence via a new `MetricsCallback`, cooperative cancellation via `CancellationCheckCallback`, crash recovery on startup, and a concurrency guard.
- Per-job Socket.IO **rooms** (metrics emitted to `room=job_id`,  never broadcast), a`subscribe_job`handler with **catch-up replay** for late/reconnecting clients, and a frontend **Stop Training** button.

## Architecture

```
POST /model/run ──> create TrainingJob (PENDING) ──> 202 {job_id}  (returns immediately)
                          │
                          └─ background thread ─> model_run(job_id)
                                                   ├─ MetricsCallback ─> training_metric rows + emit room=job_id
                                                   └─ CancellationCheckCallback ─> stops at epoch boundary if CANCELLED

client ──subscribe_job(job_id)──> joins room ──> catch-up replay + live metrics
       ──DELETE /training-job/:id──> status=CANCELLED ──> training stops, terminal status emitted
```

Job lifecycle: `PENDING → RUNNING → COMPLETED` (happy path), or `FAILED` (exception) / `CANCELLED` (user stop). Jobs left active by a crash are marked `FAILED` on startup (`orphan_recovery`).

## Endpoints (all under `/api/v1/model`)

| Method | Path | Notes |
|--------|------|-------|
| `POST` | `/run` | Creates a job, fires it in the background, returns **202** with `job_id` |
| `GET` | `/training-job/{job_id}` | Status, hyperparams, latest metrics |
| `GET` | `/training-job/{job_id}/metrics` | Full per-epoch history (chart-ready) |
| `DELETE` | `/training-job/{job_id}` | Requests cancellation (**204**) |
| `GET` | `/training-jobs?model_name=…` | Jobs for a model, newest first |

## Deliberate deviations from the original spec

The spec assumed infrastructure that does not exist in this codebase. These were adapted as senior-dev calls and documented inline:

1. **No authentication / `User` model exists.** Jobs are scoped to the existing`project_id` instead of `owner_id`. `verify_job_owner` became `get_job_or_404` (returns **404** for unknown jobs; there is no per-user authorization to enforce, so no 403).
2. **Synchronous DB** (`sqlmodel.Session`, not `AsyncSession`). Sync DB reads inside async Socket.IO handlers run via `asyncio.to_thread`.
3. **`model_basic.id` is an `int`**, so `TrainingJob.model_id` is `int`.
4. **`_main_loop` global was already removed** (refactored to a `ContextVar` in a prior PR) — no change needed there.
5. **Two divergent Alembic heads existed** (`alembic upgrade head` was ambiguous). Added a **merge migration** to unify them before the training-tables migration — fixes a latent bug.
6. **Response envelope.** All endpoints (including errors, via `AppException`) follow the repo's documented `{success, message, data}` format.

## Concurrency & safety details

- The run endpoint returns **202 immediately**; training runs in a tracked background task (`asyncio.to_thread`) with its **own** DB session — a strong reference is held so the task isn't garbage-collected mid-run.
- `on_train_end` only flips `RUNNING → COMPLETED`, so a `CANCELLED`/`FAILED` job is never overwritten with `COMPLETED`.
- The concurrency guard counts `PENDING + RUNNING` (not just `RUNNING`) to avoid a burst of quick requests slipping past before any flips to `RUNNING`.
- Status enum stored as a portable `VARCHAR + CHECK` (`native_enum=False`, lowercase `values_callable`) — no Postgres ENUM type to migrate.

## Frontend

- `services/socketService.js` — shared Socket.IO client with `subscribeToJob`/`unsubscribeFromJob`/`cancelJob`. **Re-subscribes on every (re)connect** so a reconnect re-joins the room and triggers catch-up (no silently-missed metrics).
- `Training.jsx` — subscribes to the started job, renders structured metrics, and shows a **Stop Training** button (disabled with "Cancellation requested…" after click). Charts are intentionally deferred to Week 6.
