### PR TITLE
fix: seed migration uses correct CSV filename and encode string labels before training

### DIFF
--- a/tensormap-backend/app/services/model_run.py
+++ b/tensormap-backend/app/services/model_run.py
@@ -229,6 +229,9 @@ def _prepare_training_data(features, target_field, training_split):
 
     X = features.drop(target_field, axis=1)
     y = features[target_field]
+    # Encode string labels to integers for categorical targets
+    if not pd.api.types.is_numeric_dtype(y):
+        y = pd.Categorical(y).codes
 
     split_index = int(len(X) * float(training_split) / 100)
     return X[:split_index], y[:split_index], X[split_index:], y[split_index:]

--- a/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
+++ b/tensormap-backend/migrations/versions/f4a8c2e91b37_seed_sample_project_pipeline.py
@@ -29,7 +29,7 @@ FILE_UUID = "00000000-0000-4000-a000-000000000002"
 # File paths (relative to tensormap-backend/, where alembic runs)
 DATA_DIR = "./data"
 MODEL_DIR = "./templates/json-model"
-SOURCE_CSV = os.path.join(DATA_DIR, "test_dataset.csv")
+SOURCE_CSV = os.path.join(DATA_DIR, "sample_data.csv")
 TARGET_CSV = os.path.join(DATA_DIR, "iris_sample.csv")
 MODEL_JSON_PATH = os.path.join(MODEL_DIR, "iris-classifier.json")
 


### PR DESCRIPTION
## What
Fixes #373 — Iris Sample Project training fails out of the box on a fresh install.

## Root Cause
Two bugs found through local debugging:

**Bug 1:** `f4a8c2e91b37_seed_sample_project_pipeline.py` references `test_dataset.csv` as the source CSV but the container ships `sample_data.csv`. The copy never executes so `iris_sample.csv` is never created on disk, causing `FileNotFoundError` at training time.

**Bug 2:** `_prepare_training_data` in `model_run.py` did not encode string target labels (e.g. `setosa`, `versicolor`, `virginica`) to integers before passing to `model.fit`, causing `ValueError: Invalid dtype: str`.

## Fix
1. Change `SOURCE_CSV` to `sample_data.csv` in the seed migration
2. Add `pd.Categorical(y).codes` encoding for non-numeric target columns

## Tested
Fresh `docker-compose up --build` → Iris Sample Project → Train → training completes successfully for all 10 epochs.