### PR TITLE
fix: getCovMatrix silently returns undefined on success:false, crashing PreprocessData

### DIFF
--- a/tensormap-frontend/src/components/Process/PreprocessData.jsx
+++ b/tensormap-frontend/src/components/Process/PreprocessData.jsx
@@ -33,7 +33,7 @@ function PreprocessData({ fileId, updateFileList }) {
         setData(Object.keys(response.data_types));
       } catch (e) {
         logger.error(e);
-        setFetchError("Failed to load column data");
+        setFetchError(e.message);
         setData(null);
       }
     };

--- a/tensormap-frontend/src/services/FileServices.js
+++ b/tensormap-frontend/src/services/FileServices.js
@@ -67,6 +67,7 @@ export const getCovMatrix = async (file_id) =>
       if (resp.data.success === true) {
         return resp.data.data;
       }
+      throw new Error(resp.data.message || "Failed to fetch data metrics");
     })
     .catch((err) => {
       logger.error(err);


### PR DESCRIPTION
## Description

`getCovMatrix` in `FileServices.js:63-74` silently returns `undefined` when `resp.data.success !== true` because the `.then()` callback has no `return` statement on the fallthrough path. The caller `PreprocessData.jsx:32-33` then accesses `response.data_types` on `undefined`, causing a `TypeError`.

## Changes

1. **`FileServices.js:67-70`** — Added `throw new Error(resp.data.message || "Failed to fetch data metrics")` on `success: false`, matching the existing pattern in `getCorrelationMatrix` (line 89).

2. **`PreprocessData.jsx:36`** — Changed `setFetchError("Failed to load column data")` to `setFetchError(e.message)`, so users see the real backend error message instead of a generic string.

## Verification

- Lint: clean (0 errors, 0 warnings)
- Tests: 15 files, 80 tests passed (no regressions)
