### PR TITLE
fix: CreateProjectDialog shows no error feedback on API failure

### DIFF
--- a/tensormap-frontend/src/containers/ProjectsPage/CreateProjectDialog.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/CreateProjectDialog.jsx
@@ -27,12 +27,14 @@ export default function CreateProjectDialog({ open, onOpenChange, onCreated }) {
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
   const [loading, setLoading] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
 
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (!name.trim()) return;
 
     setLoading(true);
+    setErrorMessage("");
     try {
       const resp = await createProject({
         name: name.trim(),
@@ -43,16 +45,34 @@ export default function CreateProjectDialog({ open, onOpenChange, onCreated }) {
         setName("");
         setDescription("");
         onOpenChange(false);
+      } else {
+        setErrorMessage(resp.data.message || "Failed to create project");
       }
     } catch (err) {
       logger.error("Failed to create project:", err);
+      const msg =
+        err.response?.data?.message ||
+        (Array.isArray(err.response?.data?.detail)
+          ? err.response.data.detail.map((d) => d.msg).join("; ")
+          : typeof err.response?.data?.detail === "string"
+            ? err.response.data.detail
+            : undefined) ||
+        err.message ||
+        "Failed to create project";
+      setErrorMessage(msg);
     } finally {
       setLoading(false);
     }
   };
 
   return (
-    <Dialog open={open} onOpenChange={onOpenChange}>
+    <Dialog
+      open={open}
+      onOpenChange={(open) => {
+        if (!open) setErrorMessage("");
+        onOpenChange(open);
+      }}
+    >
       <DialogContent>
         <DialogHeader>
           <DialogTitle>New Project</DialogTitle>
@@ -85,8 +105,20 @@ export default function CreateProjectDialog({ open, onOpenChange, onCreated }) {
               />
             </div>
           </div>
+          {errorMessage && (
+            <div className="mb-4 text-sm text-destructive" role="alert">
+              {errorMessage}
+            </div>
+          )}
           <DialogFooter>
-            <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            <Button
+              type="button"
+              variant="outline"
+              onClick={() => {
+                setErrorMessage("");
+                onOpenChange(false);
+              }}
+            >
               Cancel
             </Button>
             <Button type="submit" disabled={loading || !name.trim()}>

--- a/tensormap-frontend/src/containers/ProjectsPage/tests/CreateProjectDialog.test.jsx
+++ b/tensormap-frontend/src/containers/ProjectsPage/tests/CreateProjectDialog.test.jsx
@@ -1,0 +1,148 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, it, expect, vi } from "vitest";
+import CreateProjectDialog from "../CreateProjectDialog";
+
+vi.mock("../../../services/ProjectServices", () => ({
+  createProject: vi.fn(),
+}));
+
+vi.mock("../../../shared/logger", () => ({
+  default: { error: vi.fn() },
+}));
+
+import { createProject } from "../../../services/ProjectServices";
+
+const defaultProps = {
+  open: true,
+  onOpenChange: vi.fn(),
+  onCreated: vi.fn(),
+};
+
+describe("CreateProjectDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows error when API returns success: false", async () => {
+    createProject.mockResolvedValue({
+      data: { success: false, message: "Name already taken" },
+    });
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Name already taken");
+  });
+
+  it("shows error from err.message on network failure", async () => {
+    createProject.mockRejectedValue(new Error("Network Error"));
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Network Error");
+  });
+
+  it("shows error from FastAPI detail array on validation failure", async () => {
+    const axiosErr = new Error("Request failed");
+    axiosErr.response = {
+      data: {
+        detail: [
+          {
+            loc: ["body", "name"],
+            msg: "String should have at most 100 characters",
+            type: "string_too_long",
+          },
+        ],
+      },
+    };
+    createProject.mockRejectedValue(axiosErr);
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("String should have at most 100 characters");
+  });
+
+  it("shows generic fallback when error has no readable message", async () => {
+    createProject.mockRejectedValue(new Error());
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("Failed to create project");
+  });
+
+  it("clears error when dialog is closed", async () => {
+    createProject.mockResolvedValue({
+      data: { success: false, message: "Name already taken" },
+    });
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    expect(await screen.findByRole("alert")).toHaveTextContent("Name already taken");
+
+    await userEvent.click(screen.getByText("Cancel"));
+
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not show alert when no error", () => {
+    render(<CreateProjectDialog {...defaultProps} />);
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("calls onCreated on success and closes the dialog", async () => {
+    const projectData = { id: "1", name: "My Project" };
+    createProject.mockResolvedValue({
+      data: { success: true, data: projectData },
+    });
+
+    const onOpenChange = vi.fn();
+    const onCreated = vi.fn();
+    render(<CreateProjectDialog open={true} onOpenChange={onOpenChange} onCreated={onCreated} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    await waitFor(() => {
+      expect(onCreated).toHaveBeenCalledWith(projectData);
+      expect(onOpenChange).toHaveBeenCalledWith(false);
+    });
+  });
+
+  it("disables submit button while loading", async () => {
+    createProject.mockReturnValue(new Promise(() => {}));
+
+    render(<CreateProjectDialog {...defaultProps} />);
+
+    const nameInput = screen.getByLabelText("Project Name");
+    await userEvent.type(nameInput, "My Project");
+    await userEvent.click(screen.getByText("Create Project"));
+
+    expect(screen.getByText("Creating...")).toBeInTheDocument();
+    expect(screen.getByText("Creating...")).toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Description

When the project creation API returns an error (backend 500, validation 422, network failure), `CreateProjectDialog` silently stops the loading spinner with no visible feedback — no error message, no toast, nothing. Users click "Create" repeatedly, unaware of what went wrong.

## Root Cause

`handleSubmit` has no `else` branch on `if (resp.data.success)` (line 41) and the `catch` block (line 47-49) only calls `logger.error`. No `errorMessage` state exists in the component.

## Changes

1. **`errorMessage` state** — Added `const [errorMessage, setErrorMessage] = useState("")` to track the error string.

2. **`else` branch** — On `resp.data.success === false`, sets error from `resp.data.message`. Defensive: backend uses non-2xx for errors today, but future changes could produce 2xx + `success: false`.

3. **`catch` block error extraction** — Extracts from three error shapes in priority order:
   - `err.response?.data?.message` (our API convention)
   - FastAPI `detail` (array → `.msg` join, or plain string)
   - `err.message` (network errors, JS errors)
   - Fallback: `"Failed to create project"`

4. **Error display** — `<div className="mb-4 text-sm text-destructive">` rendered before `DialogFooter`, shown conditionally when `errorMessage` is non-empty.

5. **Error reset** — `setErrorMessage("")` at the top of `handleSubmit` clears stale errors before each attempt.

## Verification

- Lint: clean (0 errors, 0 warnings)
- Tests: 15 files, 80 tests passed (no regressions)
