### PR TITLE
feat: Model Export Service (SavedModel, TFLite, ONNX)(Week 7 Deliverables)

### DIFF
--- a/SECURITY_FIXES.md
+++ b/SECURITY_FIXES.md
@@ -1,0 +1,141 @@
+# Security and Quality Fixes for Export Service
+
+This document summarizes the critical fixes applied to the model export service based on the automated code review feedback.
+
+## Fixed Issues
+
+### 1. [BLOCKING/SECURITY] Path Traversal Vulnerability (Fixed ✅)
+
+**Issue:** Model names were validated only for non-emptiness but used directly in file paths, allowing attackers to write files outside the intended directory.
+
+**Fix:**
+- Added `_sanitize_filename()` function in `model_export.py` that:
+  - Removes path separators (`/`, `\`)
+  - Removes parent directory references (`..`)
+  - Only allows safe characters: alphanumeric, underscore, hyphen, dot
+  - Prevents hidden files (starts with dot)
+  - Limits length to 100 characters
+- Applied sanitization in all export functions: `export_savedmodel()`, `export_tflite()`, `export_onnx()`, and `get_export_formats()`
+- Added test `test_path_traversal_prevention()` to verify the fix
+
+**Impact:** Prevents arbitrary file write attacks through crafted model names.
+
+---
+
+### 2. [MAJOR/BUG] Blocking I/O in Async Endpoints (Fixed ✅)
+
+**Issue:** Export endpoints called synchronous TensorFlow/tf2onnx functions directly from async handlers, blocking the event loop and freezing all other requests.
+
+**Fix:**
+- Wrapped all blocking export calls with `run_in_threadpool()` in `export.py`:
+  - `await run_in_threadpool(export_savedmodel, job_id, model_name)`
+  - `await run_in_threadpool(export_tflite, job_id, model_name)`
+  - `await run_in_threadpool(export_onnx, job_id, model_name, model.graph_ir)`
+
+**Impact:** Prevents freezing of the entire application during model exports; maintains responsiveness for all users.
+
+---
+
+### 3. [MAJOR/QUALITY] Unnecessary Model Loading (Fixed ✅)
+
+**Issue:** `get_export_formats()` loaded the full TensorFlow model just to call `validate_onnx_compatible()`, which never actually used the model parameter.
+
+**Fix:**
+- Modified `get_export_formats()` to pass `None` as the model parameter to `validate_onnx_compatible()`
+- Removed the expensive `tf.keras.models.load_model()` call
+- `validate_onnx_compatible()` only inspects `graph_ir`, not the model
+
+**Impact:** Significantly faster format listing (called on every ExportPanel mount and after each download).
+
+---
+
+### 4. [MINOR/BUG] Background Task Session Issue (Fixed ✅)
+
+**Issue:** Background task `update_download_timestamp()` used the request-scoped `db` session, which would be closed before the task ran.
+
+**Fix:**
+- Changed background task to use `get_session()` context manager
+- Creates a new session specifically for the background task
+- Properly queries, updates, and commits within the new session context
+
+**Impact:** Ensures `last_export_download_at` is reliably updated.
+
+---
+
+### 5. [MINOR/BUG] Frontend Filename Fallback (Fixed ✅)
+
+**Issue:** Fallback filename for SavedModel was `{modelName}.savedmodel` instead of `{modelName}.savedmodel.zip`, and cross-origin requests couldn't read the `Content-Disposition` header.
+
+**Fixes:**
+- Updated frontend fallback logic in `ExportPanel.tsx` to use `.savedmodel.zip` for SavedModel format
+- Added `expose_headers=["Content-Disposition"]` to CORS middleware in `main.py`
+
+**Impact:** Users always get the correct filename with proper extension, even in cross-origin setups.
+
+---
+
+### 6. [MINOR/QUALITY] Error Handling in Cascade Cleanup (Fixed ✅)
+
+**Issue:** `delete_model_exports()` would abort on first failure, leaving remaining export directories undeleted despite being described as "best-effort."
+
+**Fix:**
+- Wrapped individual `delete_job_exports()` calls in try-except
+- Log failures but continue processing remaining jobs
+- Return count of successfully deleted directories
+
+**Impact:** True best-effort cleanup; one failed deletion doesn't prevent cleanup of others.
+
+---
+
+### 7. [NIT/STYLE] Duplicated Export Path (Fixed ✅)
+
+**Issue:** `metrics_callback.py` hardcoded `Path("./exports/{job_id}")` instead of importing `EXPORTS_BASE`.
+
+**Fix:**
+- Imported `EXPORTS_BASE` from `model_export.py`
+- Used `EXPORTS_BASE / self.job_id` consistently
+
+**Impact:** Maintains single source of truth for export directory location.
+
+---
+
+## Testing
+
+All fixes are validated by existing and new tests:
+
+```bash
+cd tensormap-backend
+pytest tests/test_model_export.py -v
+```
+
+**Results:** 12 passed, 2 skipped (tf2onnx availability)
+
+Key new test:
+- `test_path_traversal_prevention()` - Verifies malicious model names are sanitized
+
+---
+
+## Code Quality
+
+All changes pass linting:
+
+```bash
+ruff check app/services/model_export.py app/routers/export.py app/callbacks/metrics_callback.py
+```
+
+**Result:** All checks passed! ✅
+
+---
+
+## Summary
+
+All blocking, major, and minor issues from the automated review have been addressed:
+- ✅ Security vulnerability patched (path traversal)
+- ✅ Performance issue fixed (blocking I/O)
+- ✅ Unnecessary operations removed (model loading)
+- ✅ Background task reliability improved
+- ✅ Cross-browser compatibility enhanced
+- ✅ Error handling made resilient
+- ✅ Code consistency improved
+
+The export service is now production-ready with proper security, performance, and reliability characteristics.

--- a/tensormap-backend/app/callbacks/metrics_callback.py
+++ b/tensormap-backend/app/callbacks/metrics_callback.py
@@ -110,7 +110,20 @@ class MetricsCallback(tf.keras.callbacks.Callback):
         and still fires ``on_train_end``; guarding on the current status keeps us
         from overwriting CANCELLED/FAILED with COMPLETED. Emits a terminal status
         event so subscribers know the run is over.
+
+        Also saves the trained model to exports/{job_id}/model.keras for later export.
         """
+        from app.services.model_export import EXPORTS_BASE
+
+        # Save model to exports/{job_id}/model.keras
+        export_dir = EXPORTS_BASE / self.job_id
+        export_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            self.model.save(export_dir / "model.keras")
+            logger.info(f"Saved model.keras for job {self.job_id}")
+        except Exception as e:
+            logger.error(f"Failed to save model.keras for job {self.job_id}: {e}")
+
         final_status = None
         with self.session_factory() as session:
             job = session.get(TrainingJob, self.job_id)

--- a/tensormap-backend/app/database.py
+++ b/tensormap-backend/app/database.py
@@ -1,6 +1,7 @@
 """Database engine and session dependency for FastAPI."""
 
 from collections.abc import Generator
+from contextlib import contextmanager
 
 from sqlmodel import Session, create_engine
 
@@ -27,5 +28,12 @@ engine = _build_engine()
 
 def get_db() -> Generator[Session, None, None]:
     """Yield a SQLModel session and close it when the request finishes."""
+    with Session(engine) as session:
+        yield session
+
+
+@contextmanager
+def get_session() -> Generator[Session, None, None]:
+    """Context manager for getting a database session outside of FastAPI requests."""
     with Session(engine) as session:
         yield session

--- a/tensormap-backend/app/main.py
+++ b/tensormap-backend/app/main.py
@@ -22,7 +22,7 @@ from app.exceptions import (
     validation_exception_handler,
 )
 from app.middleware import RequestIDMiddleware, RequestLoggingMiddleware
-from app.routers import data_process, data_upload, deep_learning, health, layers, project, training
+from app.routers import data_process, data_upload, deep_learning, export, health, layers, project, training
 from app.shared.logging_config import get_logger
 from app.socketio_instance import sio
 
@@ -32,10 +32,14 @@ logger = get_logger(__name__)
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """Run Alembic migrations on startup, then yield control to the app."""
+    import asyncio
+
     from alembic import command
     from alembic.config import Config
     from alembic.runtime.migration import MigrationContext
     from alembic.script import ScriptDirectory
+
+    cleanup_task = None
 
     if os.environ.get("TESTING"):
         logger.info("TESTING mode — skipping Alembic migrations")
@@ -74,7 +78,33 @@ async def lifespan(app: FastAPI):
             orphan_recovery()
         except Exception as e:
             logger.error(f"Orphan recovery error: {e}")
+
+        # Start background cleanup task for old export files
+        async def _export_cleanup_loop():
+            from app.database import get_session
+            from app.services.model_export import cleanup_exports
+
+            while True:
+                await asyncio.sleep(6 * 3600)  # every 6 hours
+                try:
+                    retention_days = int(os.getenv("EXPORT_RETENTION_DAYS", "7"))
+                    with get_session() as session:
+                        count = cleanup_exports(retention_days, session)
+                    logger.info(f"Export cleanup: deleted {count} directories")
+                except Exception as e:
+                    logger.error(f"Export cleanup error: {e}")
+
+        cleanup_task = asyncio.create_task(_export_cleanup_loop())
+
     yield
+
+    # Cleanup on shutdown
+    if cleanup_task:
+        import contextlib
+
+        cleanup_task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await cleanup_task
 
 
 app = FastAPI(title="TensorMap API", lifespan=lifespan)
@@ -86,6 +116,7 @@ app.add_middleware(
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],
+    expose_headers=["Content-Disposition"],
 )
 app.add_middleware(RequestLoggingMiddleware)
 app.add_middleware(RequestIDMiddleware)
@@ -105,6 +136,7 @@ app.include_router(deep_learning.router, prefix=settings.api_base)
 app.include_router(project.router, prefix=settings.api_base)
 app.include_router(layers.router, prefix=settings.api_base)
 app.include_router(training.router, prefix=settings.api_base)
+app.include_router(export.router, prefix=settings.api_base)
 
 # Wrap FastAPI with SocketIO so socket.io requests are handled,
 # and everything else passes through to FastAPI.

--- a/tensormap-backend/app/routers/export.py
+++ b/tensormap-backend/app/routers/export.py
@@ -1,0 +1,154 @@
+"""Export router for trained model downloads (SavedModel, TFLite, ONNX)."""
+
+from datetime import UTC, datetime
+from typing import Literal
+
+from fastapi import APIRouter, BackgroundTasks, Depends, HTTPException
+from fastapi.concurrency import run_in_threadpool
+from fastapi.responses import FileResponse
+from sqlmodel import Session
+
+from app.database import get_db, get_session
+from app.models.ml import ModelBasic
+from app.models.training_job import TrainingJob
+from app.services.model_export import (
+    ONNXUnsupportedError,
+    export_onnx,
+    export_savedmodel,
+    export_tflite,
+    get_export_formats,
+)
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+router = APIRouter(prefix="/model/export", tags=["export"])
+
+
+@router.get("/{job_id}/formats")
+async def list_export_formats(
+    job_id: str,
+    db: Session = Depends(get_db),
+) -> dict:
+    """Returns available export formats with metadata.
+
+    Response:
+    {
+        "formats": {
+            "savedmodel": {
+                "available": bool,
+                "size_bytes": int | null,
+                "expires_at": str | null
+            },
+            "tflite": {...},
+            "onnx": {
+                ...,
+                "onnx_supported": bool,
+                "onnx_issues": list[str] | null
+            }
+        }
+    }
+    """
+    # Check if job exists
+    job = db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+
+    # Get model to retrieve name and graph_ir
+    model = db.get(ModelBasic, job.model_id)
+    if not model:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    formats = get_export_formats(job_id, model.model_name, model.graph_ir)
+
+    return {"formats": formats}
+
+
+@router.get("/{job_id}")
+async def download_export(
+    job_id: str,
+    format: Literal["savedmodel", "tflite", "onnx"],
+    background_tasks: BackgroundTasks,
+    db: Session = Depends(get_db),
+) -> FileResponse:
+    """Download exported model in specified format.
+
+    Query params:
+        format: savedmodel | tflite | onnx
+
+    Returns:
+        FileResponse with appropriate content-type and filename
+
+    Updates last_export_download_at on training_job after download.
+    Runs export generation in threadpool to avoid blocking the event loop.
+    """
+    # Check if job exists
+    job = db.get(TrainingJob, job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="Training job not found")
+
+    # Get model to retrieve name
+    model = db.get(ModelBasic, job.model_id)
+    if not model:
+        raise HTTPException(status_code=404, detail="Model not found")
+
+    model_name = model.model_name
+
+    # Generate export based on format (run in threadpool to avoid blocking)
+    try:
+        if format == "savedmodel":
+            file_path = await run_in_threadpool(export_savedmodel, job_id, model_name)
+            filename = f"{model_name}.savedmodel.zip"
+            media_type = "application/zip"
+
+        elif format == "tflite":
+            file_path = await run_in_threadpool(export_tflite, job_id, model_name)
+            filename = f"{model_name}.tflite"
+            media_type = "application/octet-stream"
+
+        elif format == "onnx":
+            file_path = await run_in_threadpool(export_onnx, job_id, model_name, model.graph_ir)
+            filename = f"{model_name}.onnx"
+            media_type = "application/octet-stream"
+
+        else:
+            raise HTTPException(status_code=400, detail=f"Unsupported format: {format}")
+
+    except FileNotFoundError as e:
+        logger.error(f"Export file not found for job {job_id}: {e}")
+        raise HTTPException(
+            status_code=404,
+            detail="Model file not found. Training may not be completed yet.",
+        ) from e
+
+    except ONNXUnsupportedError as e:
+        logger.warning(f"ONNX export unsupported for job {job_id}: {e.issues}")
+        raise HTTPException(
+            status_code=400,
+            detail={
+                "error": "onnx_unsupported",
+                "issues": e.issues,
+                "suggestion": "Use SavedModel or TFLite format instead",
+            },
+        ) from e
+
+    except Exception as e:
+        logger.error(f"Export failed for job {job_id}: {e}")
+        raise HTTPException(status_code=500, detail=f"Export failed: {str(e)}") from e
+
+    # Update last_export_download_at in background using a new session
+    def update_download_timestamp():
+        with get_session() as session:
+            job_to_update = session.get(TrainingJob, job_id)
+            if job_to_update:
+                job_to_update.last_export_download_at = datetime.now(UTC)
+                session.add(job_to_update)
+                session.commit()
+
+    background_tasks.add_task(update_download_timestamp)
+
+    return FileResponse(
+        path=file_path,
+        filename=filename,
+        media_type=media_type,
+    )

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -679,6 +679,18 @@ def delete_model_service(db: Session, model_id: int) -> tuple:
         return _resp(404, False, "Model not found")
 
     model_name = model.model_name
+
+    # Delete all exports for this model's training jobs
+    try:
+        from app.services.model_export import delete_model_exports
+
+        deleted_count = delete_model_exports(model_id, db)
+        if deleted_count > 0:
+            logger.info(f"Deleted {deleted_count} export directories for model {model_id}")
+    except Exception as e:
+        logger.warning(f"Failed to delete exports for model {model_id}: {e}")
+        # Continue with model deletion even if export cleanup fails
+
     try:
         db.delete(model)
         db.commit()

--- a/tensormap-backend/app/services/model_export.py
+++ b/tensormap-backend/app/services/model_export.py
@@ -1,0 +1,393 @@
+"""Model export service for SavedModel, TFLite, and ONNX formats.
+
+Exports are generated lazily on first request and cached in exports/{job_id}/.
+Background cleanup task removes exports older than retention_days.
+"""
+
+import re
+import shutil
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from sqlmodel import Session, select
+
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.shared.logging_config import get_logger
+
+logger = get_logger(__name__)
+
+EXPORTS_BASE = Path("./exports")
+
+
+def _sanitize_filename(name: str) -> str:
+    """Sanitize model name to prevent path traversal attacks.
+
+    Removes any path separators and ensures the name is safe for filesystem use.
+    Only allows alphanumeric, underscore, hyphen, and dot characters.
+    """
+    # Remove any path separators
+    name = name.replace("/", "_").replace("\\", "_")
+    # Remove parent directory references
+    name = name.replace("..", "_")
+    # Only allow safe characters: alphanumeric, underscore, hyphen, dot
+    name = re.sub(r"[^\w\-.]", "_", name)
+    # Ensure it doesn't start with a dot (hidden file)
+    if name.startswith("."):
+        name = "_" + name[1:]
+    # Limit length
+    if len(name) > 100:
+        name = name[:100]
+    return name
+
+
+class ONNXUnsupportedError(Exception):
+    """Raised when ONNX export is not supported for the model architecture."""
+
+    def __init__(self, issues: list[str]):
+        self.issues = issues
+        super().__init__(f"ONNX export not supported: {'; '.join(issues)}")
+
+
+def export_savedmodel(job_id: str, model_name: str) -> Path:
+    """Exports model to SavedModel format, zips it, returns zip path.
+
+    Generates on-demand; returns existing zip if already generated.
+    """
+    # Sanitize model_name to prevent path traversal
+    safe_name = _sanitize_filename(model_name)
+    export_dir = EXPORTS_BASE / job_id
+    zip_path = export_dir / f"{safe_name}.savedmodel.zip"
+
+    if zip_path.exists():
+        logger.info(f"SavedModel export already exists for job {job_id}")
+        return zip_path  # Already generated
+
+    model_path = export_dir / "model.keras"
+    if not model_path.exists():
+        raise FileNotFoundError(f"model.keras not found for job {job_id}")
+
+    # Lazy import to avoid loading TensorFlow in non-training processes
+    import tensorflow as tf
+
+    logger.info(f"Loading model from {model_path}")
+    model = tf.keras.models.load_model(model_path)
+
+    savedmodel_dir = export_dir / "savedmodel"
+    logger.info(f"Saving SavedModel to {savedmodel_dir}")
+    tf.keras.models.save_model(model, str(savedmodel_dir), save_format="tf")
+
+    # Zip the savedmodel directory
+    logger.info(f"Creating zip archive at {zip_path}")
+    shutil.make_archive(str(zip_path.with_suffix("")), "zip", str(export_dir), "savedmodel")
+
+    return zip_path
+
+
+def export_tflite(job_id: str, model_name: str) -> Path:
+    """Exports model to TFLite format. Returns .tflite path."""
+    # Sanitize model_name to prevent path traversal
+    safe_name = _sanitize_filename(model_name)
+    export_dir = EXPORTS_BASE / job_id
+    tflite_path = export_dir / f"{safe_name}.tflite"
+
+    if tflite_path.exists():
+        logger.info(f"TFLite export already exists for job {job_id}")
+        return tflite_path
+
+    model_path = export_dir / "model.keras"
+    if not model_path.exists():
+        raise FileNotFoundError(f"model.keras not found for job {job_id}")
+
+    # Lazy import
+    import tensorflow as tf
+
+    logger.info(f"Loading model from {model_path}")
+    model = tf.keras.models.load_model(model_path)
+
+    logger.info("Converting to TFLite")
+    converter = tf.lite.TFLiteConverter.from_keras_model(model)
+    tflite_model = converter.convert()
+
+    tflite_path.write_bytes(tflite_model)
+    logger.info(f"TFLite model saved to {tflite_path}")
+
+    return tflite_path
+
+
+def validate_onnx_compatible(model, graph_ir: dict | None) -> list[str]:
+    """Pre-flight check for tf2onnx compatibility.
+
+    Returns list of issues (empty = compatible).
+
+    Checks:
+    - LSTM/GRU with return_sequences=True: require fixed sequence_length in Input spec
+    - Unsupported tf.keras ops (tf.while_loop etc.)
+
+    Returns: list[str] of human-readable issue descriptions
+    """
+    issues = []
+
+    if graph_ir is None:
+        # No graph IR available, skip validation
+        return issues
+
+    nodes = graph_ir.get("nodes", [])
+
+    # Check for LSTM/GRU with return_sequences=True and variable-length inputs
+    has_lstm_gru = False
+    has_variable_input = False
+
+    for node in nodes:
+        node_params = node.get("node_params", {})
+        layer_type = node_params.get("layer_type", "")
+
+        if layer_type in ("lstm", "gru"):
+            has_lstm_gru = True
+            return_sequences = node_params.get("return_sequences", False)
+            if return_sequences:
+                # Check if any Input node has None in shape
+                for inp_node in nodes:
+                    inp_params = inp_node.get("node_params", {})
+                    if inp_params.get("layer_type") == "input":
+                        shape = inp_params.get("shape", [])
+                        if isinstance(shape, (list, tuple)) and None in shape:
+                            has_variable_input = True
+                            break
+
+    if has_lstm_gru and has_variable_input:
+        issues.append(
+            "LSTM/GRU with return_sequences=True requires fixed input "
+            "sequence length. Set a fixed shape in your Input layer (e.g., [10, 128] instead of [None, 128])."
+        )
+
+    return issues
+
+
+def export_onnx(job_id: str, model_name: str, graph_ir: dict | None = None) -> Path:
+    """Exports model to ONNX format using tf2onnx.
+
+    Args:
+        job_id: Training job ID
+        model_name: Model name for output filename
+        graph_ir: Graph IR JSON for compatibility validation
+
+    Returns:
+        Path to generated .onnx file
+
+    Raises:
+        ONNXUnsupportedError: If model architecture is not ONNX-compatible
+        FileNotFoundError: If model.keras doesn't exist
+    """
+    # Sanitize model_name to prevent path traversal
+    safe_name = _sanitize_filename(model_name)
+    export_dir = EXPORTS_BASE / job_id
+    onnx_path = export_dir / f"{safe_name}.onnx"
+
+    if onnx_path.exists():
+        logger.info(f"ONNX export already exists for job {job_id}")
+        return onnx_path
+
+    model_path = export_dir / "model.keras"
+    if not model_path.exists():
+        raise FileNotFoundError(f"model.keras not found for job {job_id}")
+
+    # Lazy import
+    import tensorflow as tf
+
+    logger.info(f"Loading model from {model_path}")
+    model = tf.keras.models.load_model(model_path)
+
+    # Pre-flight check
+    issues = validate_onnx_compatible(model, graph_ir)
+    if issues:
+        logger.warning(f"ONNX export unsupported for job {job_id}: {issues}")
+        raise ONNXUnsupportedError(issues)
+
+    # Import tf2onnx
+    try:
+        import tf2onnx
+    except ImportError as e:
+        logger.error("tf2onnx not installed")
+        raise ONNXUnsupportedError(["tf2onnx library not installed"]) from e
+
+    logger.info("Converting to ONNX")
+    # Build input signature
+    input_shape = model.input_shape
+    if isinstance(input_shape, list):
+        # Multiple inputs
+        spec = tuple(tf.TensorSpec(shape, tf.float32, name=f"input_{i}") for i, shape in enumerate(input_shape))
+    else:
+        # Single input
+        spec = (tf.TensorSpec(input_shape, tf.float32, name="input"),)
+
+    onnx_model, _ = tf2onnx.convert.from_keras(model, input_signature=spec)
+
+    with open(onnx_path, "wb") as f:
+        f.write(onnx_model.SerializeToString())
+
+    logger.info(f"ONNX model saved to {onnx_path}")
+    return onnx_path
+
+
+def get_export_formats(job_id: str, model_name: str, graph_ir: dict | None = None) -> dict:
+    """Returns available export formats with existence status and metadata.
+
+    Returns:
+        dict with format info:
+        {
+            "savedmodel": {
+                "available": bool,
+                "size_bytes": int | None,
+                "expires_at": str | None (ISO format)
+            },
+            "tflite": {...},
+            "onnx": {
+                ...,
+                "onnx_supported": bool,
+                "onnx_issues": list[str] | None
+            }
+        }
+    """
+    # Sanitize model_name to prevent path traversal
+    safe_name = _sanitize_filename(model_name)
+    export_dir = EXPORTS_BASE / job_id
+    model_path = export_dir / "model.keras"
+
+    formats = {}
+
+    # Check if model.keras exists
+    if not model_path.exists():
+        # Training not completed yet
+        return {
+            "savedmodel": {"available": False, "size_bytes": None, "expires_at": None},
+            "tflite": {"available": False, "size_bytes": None, "expires_at": None},
+            "onnx": {
+                "available": False,
+                "size_bytes": None,
+                "expires_at": None,
+                "onnx_supported": False,
+                "onnx_issues": ["Training not completed"],
+            },
+        }
+
+    # SavedModel
+    savedmodel_zip = export_dir / f"{safe_name}.savedmodel.zip"
+    formats["savedmodel"] = {
+        "available": savedmodel_zip.exists(),
+        "size_bytes": savedmodel_zip.stat().st_size if savedmodel_zip.exists() else None,
+        "expires_at": _get_expiry_date(savedmodel_zip) if savedmodel_zip.exists() else None,
+    }
+
+    # TFLite
+    tflite_file = export_dir / f"{safe_name}.tflite"
+    formats["tflite"] = {
+        "available": tflite_file.exists(),
+        "size_bytes": tflite_file.stat().st_size if tflite_file.exists() else None,
+        "expires_at": _get_expiry_date(tflite_file) if tflite_file.exists() else None,
+    }
+
+    # ONNX - check compatibility without loading the model
+    # The validate_onnx_compatible function doesn't actually use the model parameter
+    onnx_issues = validate_onnx_compatible(None, graph_ir)
+    onnx_supported = len(onnx_issues) == 0
+
+    onnx_file = export_dir / f"{safe_name}.onnx"
+    formats["onnx"] = {
+        "available": onnx_file.exists(),
+        "size_bytes": onnx_file.stat().st_size if onnx_file.exists() else None,
+        "expires_at": _get_expiry_date(onnx_file) if onnx_file.exists() else None,
+        "onnx_supported": onnx_supported,
+        "onnx_issues": onnx_issues if not onnx_supported else None,
+    }
+
+    return formats
+
+
+def _get_expiry_date(file_path: Path, retention_days: int = 7) -> str:
+    """Calculate expiry date for an export file."""
+    mtime = datetime.fromtimestamp(file_path.stat().st_mtime, UTC)
+    expires_at = mtime + timedelta(days=retention_days)
+    return expires_at.isoformat()
+
+
+def cleanup_exports(retention_days: int = 7, session: Session = None) -> int:
+    """Deletes export directories for jobs completed > retention_days ago.
+
+    Returns count of directories deleted.
+    """
+    if not EXPORTS_BASE.exists():
+        return 0
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    deleted_count = 0
+
+    # If session provided, query completed jobs
+    if session:
+        stmt = select(TrainingJob).where(
+            TrainingJob.status.in_([TrainingStatus.COMPLETED, TrainingStatus.FAILED, TrainingStatus.CANCELLED]),
+            TrainingJob.completed_at < cutoff,
+        )
+        old_jobs = session.exec(stmt).all()
+
+        for job in old_jobs:
+            export_dir = EXPORTS_BASE / job.id
+            if export_dir.exists():
+                try:
+                    shutil.rmtree(export_dir)
+                    deleted_count += 1
+                    logger.info(f"Deleted export directory for job {job.id}")
+                except Exception as e:
+                    logger.error(f"Failed to delete export directory for job {job.id}: {e}")
+    else:
+        # Fallback: iterate all directories and check mtime
+        for export_dir in EXPORTS_BASE.iterdir():
+            if not export_dir.is_dir():
+                continue
+
+            # Check directory modification time
+            mtime = datetime.fromtimestamp(export_dir.stat().st_mtime, UTC)
+            if mtime < cutoff:
+                try:
+                    shutil.rmtree(export_dir)
+                    deleted_count += 1
+                    logger.info(f"Deleted export directory {export_dir.name}")
+                except Exception as e:
+                    logger.error(f"Failed to delete export directory {export_dir.name}: {e}")
+
+    return deleted_count
+
+
+def delete_job_exports(job_id: str) -> bool:
+    """Delete all exports for a specific job.
+
+    Returns True if directory was deleted, False if it didn't exist.
+    Raises exception on deletion failure.
+    """
+    export_dir = EXPORTS_BASE / job_id
+    if export_dir.exists():
+        shutil.rmtree(export_dir)
+        logger.info(f"Deleted export directory for job {job_id}")
+        return True
+    return False
+
+
+def delete_model_exports(model_id: int, session: Session) -> int:
+    """Delete all exports for all jobs of a given model (best-effort).
+
+    Returns count of directories successfully deleted.
+    Logs failures but continues with remaining jobs.
+    """
+    stmt = select(TrainingJob).where(TrainingJob.model_id == model_id)
+    jobs = session.exec(stmt).all()
+
+    deleted_count = 0
+    for job in jobs:
+        try:
+            if delete_job_exports(job.id):
+                deleted_count += 1
+        except Exception as e:
+            logger.error(f"Failed to delete export directory for job {job.id}: {e}")
+            # Continue with remaining jobs (best-effort cleanup)
+            continue
+
+    return deleted_count

--- a/tensormap-backend/pyproject.toml
+++ b/tensormap-backend/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "Jinja2>=3.1",
     "python-multipart>=0.0.9",
     "Werkzeug>=3.0",
+    "tf2onnx>=1.16",
 ]
 
 [project.optional-dependencies]

--- a/tensormap-backend/tests/test_model_export.py
+++ b/tensormap-backend/tests/test_model_export.py
@@ -1,0 +1,436 @@
+"""Tests for model export service (SavedModel, TFLite, ONNX)."""
+
+import importlib.util
+from datetime import UTC, datetime, timedelta
+from unittest.mock import Mock, patch
+from uuid import uuid4
+
+import pytest
+from sqlmodel import Session
+
+from app.models.ml import ModelBasic
+from app.models.training_job import TrainingJob, TrainingStatus
+from app.services.model_export import (
+    ONNXUnsupportedError,
+    cleanup_exports,
+    delete_job_exports,
+    delete_model_exports,
+    export_onnx,
+    export_savedmodel,
+    export_tflite,
+    get_export_formats,
+    validate_onnx_compatible,
+)
+
+
+def _check_tf2onnx_available():
+    """Check if tf2onnx can be imported without errors."""
+    try:
+        import tf2onnx  # noqa: F401
+
+        return True
+    except (ImportError, AttributeError):
+        return False
+
+
+@pytest.fixture
+def mock_keras_model():
+    """Create a mock Keras model."""
+    mock_model = Mock()
+    mock_model.input_shape = (None, 28, 28, 1)
+    mock_model.save = Mock()
+    return mock_model
+
+
+@pytest.fixture
+def setup_export_dir(tmp_path):
+    """Create a temporary export directory with model.keras."""
+    job_id = str(uuid4())
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+
+    # Create a dummy model.keras file
+    model_file = export_dir / "model.keras"
+    model_file.write_text("dummy model content")
+
+    return job_id, export_dir
+
+
+def test_savedmodel_export_creates_zip(tmp_path, mock_keras_model):
+    """SavedModel export creates a zip file."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    # Setup
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    # Patch EXPORTS_BASE and tensorflow
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_keras_model),
+        patch("tensorflow.keras.models.save_model"),
+    ):
+        # Create savedmodel directory for zipping
+        savedmodel_dir = export_dir / "savedmodel"
+        savedmodel_dir.mkdir()
+        (savedmodel_dir / "saved_model.pb").write_text("dummy pb")
+
+        zip_path = export_savedmodel(job_id, model_name)
+
+        assert zip_path.exists()
+        assert zip_path.suffix == ".zip"
+        assert model_name in zip_path.name
+
+
+def test_tflite_export_creates_file(tmp_path, mock_keras_model):
+    """TFLite export creates a .tflite file."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    # Mock TFLite converter
+    mock_converter = Mock()
+    mock_converter.convert.return_value = b"tflite model bytes"
+
+    # Import tensorflow to make the patch work
+    import tensorflow as tf
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch.object(tf.keras.models, "load_model", return_value=mock_keras_model),
+        patch.object(tf.lite.TFLiteConverter, "from_keras_model", return_value=mock_converter),
+    ):
+        tflite_path = export_tflite(job_id, model_name)
+
+        assert tflite_path.exists()
+        assert tflite_path.suffix == ".tflite"
+        assert tflite_path.read_bytes() == b"tflite model bytes"
+
+
+def test_savedmodel_cached_on_second_call(tmp_path, mock_keras_model):
+    """Second call to export_savedmodel returns existing file without regenerating."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    # Create existing zip
+    zip_path = export_dir / f"{model_name}.savedmodel.zip"
+    zip_path.write_text("existing zip")
+
+    with patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"):
+        result = export_savedmodel(job_id, model_name)
+
+        assert result == zip_path
+        assert result.read_text() == "existing zip"  # Not regenerated
+
+
+def test_export_fails_404_if_no_keras_file(tmp_path):
+    """Export fails if model.keras doesn't exist (training not completed)."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    # No model.keras file
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        pytest.raises(FileNotFoundError, match="model.keras not found"),
+    ):
+        export_savedmodel(job_id, model_name)
+
+
+def test_validate_onnx_compatible_passes_for_simple_model():
+    """validate_onnx_compatible returns empty list for simple Dense model."""
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": [28, 28, 1]}},
+            {"node_params": {"layer_type": "dense", "units": 10}},
+        ]
+    }
+
+    mock_model = Mock()
+    issues = validate_onnx_compatible(mock_model, graph_ir)
+
+    assert issues == []
+
+
+def test_validate_onnx_compatible_fails_for_rnn_var_length():
+    """validate_onnx_compatible detects LSTM with variable-length input."""
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": [None, 128]}},  # Variable length
+            {"node_params": {"layer_type": "lstm", "units": 64, "return_sequences": True}},
+        ]
+    }
+
+    mock_model = Mock()
+    issues = validate_onnx_compatible(mock_model, graph_ir)
+
+    assert len(issues) > 0
+    assert "LSTM/GRU" in issues[0]
+    assert "fixed input sequence length" in issues[0]
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("tf2onnx") or not _check_tf2onnx_available(),
+    reason="tf2onnx not available or dependencies incompatible",
+)
+def test_onnx_export_simple_dense(tmp_path, mock_keras_model):
+    """ONNX export succeeds for simple Dense model."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": [28, 28]}},
+            {"node_params": {"layer_type": "dense", "units": 10}},
+        ]
+    }
+
+    # Mock ONNX model
+    mock_onnx_model = Mock()
+    mock_onnx_model.SerializeToString.return_value = b"onnx model bytes"
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_keras_model),
+        patch("tensorflow.TensorSpec", return_value="tensor_spec"),
+        patch("tf2onnx.convert.from_keras", return_value=(mock_onnx_model, None)),
+    ):
+        onnx_path = export_onnx(job_id, model_name, graph_ir)
+
+        assert onnx_path.exists()
+        assert onnx_path.suffix == ".onnx"
+
+
+def test_onnx_export_raises_on_unsupported(tmp_path, mock_keras_model):
+    """ONNX export raises ONNXUnsupportedError for incompatible architecture."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": [None, 128]}},
+            {"node_params": {"layer_type": "lstm", "units": 64, "return_sequences": True}},
+        ]
+    }
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_keras_model),
+        pytest.raises(ONNXUnsupportedError) as exc_info,
+    ):
+        export_onnx(job_id, model_name, graph_ir)
+
+    assert len(exc_info.value.issues) > 0
+
+
+@pytest.mark.skipif(
+    not importlib.util.find_spec("tf2onnx") or not _check_tf2onnx_available(),
+    reason="tf2onnx not available or dependencies incompatible",
+)
+def test_onnx_export_succeeds_with_fixed_shape(tmp_path, mock_keras_model):
+    """ONNX export succeeds for LSTM with fixed input shape."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": [10, 128]}},  # Fixed length
+            {"node_params": {"layer_type": "lstm", "units": 64, "return_sequences": True}},
+        ]
+    }
+
+    # Mock ONNX model
+    mock_onnx_model = Mock()
+    mock_onnx_model.SerializeToString.return_value = b"onnx model bytes"
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_keras_model),
+        patch("tensorflow.TensorSpec", return_value="tensor_spec"),
+        patch("tf2onnx.convert.from_keras", return_value=(mock_onnx_model, None)),
+    ):
+        onnx_path = export_onnx(job_id, model_name, graph_ir)
+
+        assert onnx_path.exists()
+
+
+def test_get_export_formats_structure(tmp_path):
+    """get_export_formats returns correct structure."""
+    job_id = str(uuid4())
+    model_name = "test_model"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    graph_ir = {"nodes": [{"node_params": {"layer_type": "dense", "units": 10}}]}
+
+    mock_model = Mock()
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_model),
+    ):
+        formats = get_export_formats(job_id, model_name, graph_ir)
+
+        assert "savedmodel" in formats
+        assert "tflite" in formats
+        assert "onnx" in formats
+
+        # Check structure
+        assert "available" in formats["savedmodel"]
+        assert "size_bytes" in formats["savedmodel"]
+        assert "expires_at" in formats["savedmodel"]
+
+        # ONNX should have additional fields
+        assert "onnx_supported" in formats["onnx"]
+
+
+def test_cleanup_deletes_old_directories(tmp_path, db_session: Session):
+    """cleanup_exports deletes export directories older than retention_days."""
+    # Create old export directory
+    old_job_id = str(uuid4())
+    old_dir = tmp_path / "exports" / old_job_id
+    old_dir.mkdir(parents=True)
+    (old_dir / "model.keras").write_text("old")
+
+    # Create recent export directory
+    recent_job_id = str(uuid4())
+    recent_dir = tmp_path / "exports" / recent_job_id
+    recent_dir.mkdir(parents=True)
+    (recent_dir / "model.keras").write_text("recent")
+
+    # Parent model row so the training_job FK constraint is satisfied (Postgres/CI).
+    db_session.add(ModelBasic(id=1, model_name="export-cleanup-model"))
+    db_session.commit()
+
+    # Create training jobs
+    old_job = TrainingJob(
+        id=old_job_id,
+        model_id=1,
+        status=TrainingStatus.COMPLETED,
+        hyperparams={},
+        completed_at=datetime.now(UTC) - timedelta(days=10),
+    )
+    recent_job = TrainingJob(
+        id=recent_job_id,
+        model_id=1,
+        status=TrainingStatus.COMPLETED,
+        hyperparams={},
+        completed_at=datetime.now(UTC),
+    )
+
+    db_session.add(old_job)
+    db_session.add(recent_job)
+    db_session.commit()
+
+    with patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"):
+        count = cleanup_exports(retention_days=7, session=db_session)
+
+        assert count == 1
+        assert not old_dir.exists()
+        assert recent_dir.exists()
+
+
+def test_delete_job_exports(tmp_path):
+    """delete_job_exports removes export directory for a specific job."""
+    job_id = str(uuid4())
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    with patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"):
+        result = delete_job_exports(job_id)
+
+        assert result is True
+        assert not export_dir.exists()
+
+
+def test_delete_model_exports_cascades(tmp_path, db_session: Session):
+    """delete_model_exports removes all export directories for model's jobs."""
+    model_id = 1
+
+    # Parent model row so the training_job FK constraint is satisfied (Postgres/CI).
+    db_session.add(ModelBasic(id=model_id, model_name="export-cascade-model"))
+    db_session.commit()
+
+    # Create multiple jobs for the model
+    job1_id = str(uuid4())
+    job2_id = str(uuid4())
+
+    job1 = TrainingJob(id=job1_id, model_id=model_id, status=TrainingStatus.COMPLETED, hyperparams={})
+    job2 = TrainingJob(id=job2_id, model_id=model_id, status=TrainingStatus.COMPLETED, hyperparams={})
+
+    db_session.add(job1)
+    db_session.add(job2)
+    db_session.commit()
+
+    # Create export directories
+    job1_dir = tmp_path / "exports" / job1_id
+    job1_dir.mkdir(parents=True)
+    (job1_dir / "model.keras").write_text("job1")
+
+    job2_dir = tmp_path / "exports" / job2_id
+    job2_dir.mkdir(parents=True)
+    (job2_dir / "model.keras").write_text("job2")
+
+    with patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"):
+        count = delete_model_exports(model_id, db_session)
+
+        assert count == 2
+        assert not job1_dir.exists()
+        assert not job2_dir.exists()
+
+
+def test_path_traversal_prevention(tmp_path, mock_keras_model):
+    """Model names with path traversal attempts are sanitized."""
+    job_id = str(uuid4())
+    # Attempt path traversal with malicious model name
+    malicious_name = "../../../tmp/pwned"
+
+    export_dir = tmp_path / "exports" / job_id
+    export_dir.mkdir(parents=True)
+    (export_dir / "model.keras").write_text("dummy")
+
+    with (
+        patch("app.services.model_export.EXPORTS_BASE", tmp_path / "exports"),
+        patch("tensorflow.keras.models.load_model", return_value=mock_keras_model),
+        patch("tensorflow.keras.models.save_model"),
+    ):
+        # Create savedmodel directory for zipping
+        savedmodel_dir = export_dir / "savedmodel"
+        savedmodel_dir.mkdir()
+        (savedmodel_dir / "saved_model.pb").write_text("dummy pb")
+
+        zip_path = export_savedmodel(job_id, malicious_name)
+
+        # Verify the file is created inside the export_dir, not outside
+        assert zip_path.is_relative_to(export_dir)
+        assert ".." not in str(zip_path)
+        # Verify sanitized name doesn't contain path separators
+        assert "/" not in zip_path.name
+        assert "\\" not in zip_path.name
+        # Verify the actual path traversal was prevented
+        assert zip_path.parent == export_dir

--- a/tensormap-backend/uv.lock
+++ b/tensormap-backend/uv.lock
@@ -2,7 +2,8 @@ version = 1
 revision = 3
 requires-python = ">=3.12"
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
     "python_full_version == '3.13.*' and sys_platform == 'win32'",
@@ -792,6 +793,37 @@ wheels = [
 ]
 
 [[package]]
+name = "onnx"
+version = "1.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "ml-dtypes" },
+    { name = "numpy" },
+    { name = "protobuf" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5b/bf/b0a63ee9f3759dcd177b28c6f2cb22f2aecc6d9b3efecaabc298883caa5f/onnx-1.19.0.tar.gz", hash = "sha256:aa3f70b60f54a29015e41639298ace06adf1dd6b023b9b30f1bca91bb0db9473", size = 11949859, upload-time = "2025-08-27T02:34:27.107Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0d/94/f56f6ca5e2f921b28c0f0476705eab56486b279f04e1d568ed64c14e7764/onnx-1.19.0-cp312-cp312-macosx_12_0_universal2.whl", hash = "sha256:61d94e6498ca636756f8f4ee2135708434601b2892b7c09536befb19bc8ca007", size = 18322331, upload-time = "2025-08-27T02:33:20.373Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/00/8cc3f3c40b54b28f96923380f57c9176872e475face726f7d7a78bd74098/onnx-1.19.0-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:224473354462f005bae985c72028aaa5c85ab11de1b71d55b06fdadd64a667dd", size = 18027513, upload-time = "2025-08-27T02:33:23.44Z" },
+    { url = "https://files.pythonhosted.org/packages/61/90/17c4d2566fd0117a5e412688c9525f8950d467f477fbd574e6b32bc9cb8d/onnx-1.19.0-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ae475c85c89bc4d1f16571006fd21a3e7c0e258dd2c091f6e8aafb083d1ed9b", size = 18202278, upload-time = "2025-08-27T02:33:26.103Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/6e/a9383d9cf6db4ac761a129b081e9fa5d0cd89aad43cf1e3fc6285b915c7d/onnx-1.19.0-cp312-cp312-win32.whl", hash = "sha256:323f6a96383a9cdb3960396cffea0a922593d221f3929b17312781e9f9b7fb9f", size = 16333080, upload-time = "2025-08-27T02:33:28.559Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/2e/3ff480a8c1fa7939662bdc973e41914add2d4a1f2b8572a3c39c2e4982e5/onnx-1.19.0-cp312-cp312-win_amd64.whl", hash = "sha256:50220f3499a499b1a15e19451a678a58e22ad21b34edf2c844c6ef1d9febddc2", size = 16453927, upload-time = "2025-08-27T02:33:31.177Z" },
+    { url = "https://files.pythonhosted.org/packages/57/37/ad500945b1b5c154fe9d7b826b30816ebd629d10211ea82071b5bcc30aa4/onnx-1.19.0-cp312-cp312-win_arm64.whl", hash = "sha256:efb768299580b786e21abe504e1652ae6189f0beed02ab087cd841cb4bb37e43", size = 16426022, upload-time = "2025-08-27T02:33:33.515Z" },
+    { url = "https://files.pythonhosted.org/packages/be/29/d7b731f63d243f815d9256dce0dca3c151dcaa1ac59f73e6ee06c9afbe91/onnx-1.19.0-cp313-cp313-macosx_12_0_universal2.whl", hash = "sha256:9aed51a4b01acc9ea4e0fe522f34b2220d59e9b2a47f105ac8787c2e13ec5111", size = 18322412, upload-time = "2025-08-27T02:33:36.723Z" },
+    { url = "https://files.pythonhosted.org/packages/58/f5/d3106becb42cb374f0e17ff4c9933a97f1ee1d6a798c9452067f7d3ff61b/onnx-1.19.0-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce2cdc3eb518bb832668c4ea9aeeda01fbaa59d3e8e5dfaf7aa00f3d37119404", size = 18026565, upload-time = "2025-08-27T02:33:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/83/fa/b086d17bab3900754c7ffbabfb244f8e5e5da54a34dda2a27022aa2b373b/onnx-1.19.0-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:8b546bd7958734b6abcd40cfede3d025e9c274fd96334053a288ab11106bd0aa", size = 18202077, upload-time = "2025-08-27T02:33:42.115Z" },
+    { url = "https://files.pythonhosted.org/packages/35/f2/5e2dfb9d4cf873f091c3f3c6d151f071da4295f9893fbf880f107efe3447/onnx-1.19.0-cp313-cp313-win32.whl", hash = "sha256:03086bffa1cf5837430cf92f892ca0cd28c72758d8905578c2bf8ffaf86c6743", size = 16333198, upload-time = "2025-08-27T02:33:45.172Z" },
+    { url = "https://files.pythonhosted.org/packages/79/67/b3751a35c2522f62f313156959575619b8fa66aa883db3adda9d897d8eb2/onnx-1.19.0-cp313-cp313-win_amd64.whl", hash = "sha256:1715b51eb0ab65272e34ef51cb34696160204b003566cd8aced2ad20a8f95cb8", size = 16453836, upload-time = "2025-08-27T02:33:47.779Z" },
+    { url = "https://files.pythonhosted.org/packages/14/b9/1df85effc960fbbb90bb7bc36eb3907c676b104bc2f88bce022bcfdaef63/onnx-1.19.0-cp313-cp313-win_arm64.whl", hash = "sha256:6bf5acdb97a3ddd6e70747d50b371846c313952016d0c41133cbd8f61b71a8d5", size = 16425877, upload-time = "2025-08-27T02:33:50.357Z" },
+    { url = "https://files.pythonhosted.org/packages/23/2b/089174a1427be9149f37450f8959a558ba20f79fca506ba461d59379d3a1/onnx-1.19.0-cp313-cp313t-macosx_12_0_universal2.whl", hash = "sha256:46cf29adea63e68be0403c68de45ba1b6acc9bb9592c5ddc8c13675a7c71f2cb", size = 18348546, upload-time = "2025-08-27T02:33:56.132Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/d6/3458f0e3a9dc7677675d45d7d6528cb84ad321c8670cc10c69b32c3e03da/onnx-1.19.0-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:246f0de1345498d990a443d55a5b5af5101a3e25a05a2c3a5fe8b7bd7a7d0707", size = 18033067, upload-time = "2025-08-27T02:33:58.661Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/16/6e4130e1b4b29465ee1fb07d04e8d6f382227615c28df8f607ba50909e2a/onnx-1.19.0-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ae0d163ffbc250007d984b8dd692a4e2e4506151236b50ca6e3560b612ccf9ff", size = 18205741, upload-time = "2025-08-27T02:34:01.538Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d8/f64d010fd024b2a2b11ce0c4ee179e4f8f6d4ccc95f8184961c894c22af1/onnx-1.19.0-cp313-cp313t-win_amd64.whl", hash = "sha256:7c151604c7cca6ae26161c55923a7b9b559df3344938f93ea0074d2d49e7fe78", size = 16453839, upload-time = "2025-08-27T02:34:06.515Z" },
+    { url = "https://files.pythonhosted.org/packages/67/ec/8761048eabef4dad55af4c002c672d139b9bd47c3616abaed642a1710063/onnx-1.19.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:236bc0e60d7c0f4159300da639953dd2564df1c195bce01caba172a712e75af4", size = 18027605, upload-time = "2025-08-27T02:34:08.962Z" },
+]
+
+[[package]]
 name = "opt-einsum"
 version = "3.4.0"
 source = { registry = "https://pypi.org/simple" }
@@ -900,7 +932,8 @@ name = "pandas"
 version = "2.3.3"
 source = { registry = "https://pypi.org/simple" }
 resolution-markers = [
-    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine != 's390x' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and platform_machine == 's390x' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
@@ -1632,6 +1665,7 @@ dependencies = [
     { name = "sqlalchemy" },
     { name = "sqlmodel" },
     { name = "tensorflow" },
+    { name = "tf2onnx" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "werkzeug" },
 ]
@@ -1672,6 +1706,7 @@ requires-dist = [
     { name = "sqlalchemy", specifier = ">=2.0.37,<3" },
     { name = "sqlmodel", specifier = ">=0.0.22,<0.0.23" },
     { name = "tensorflow", specifier = ">=2.16,<2.17" },
+    { name = "tf2onnx", specifier = ">=1.16" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.34" },
     { name = "werkzeug", specifier = ">=3.0" },
 ]
@@ -1684,6 +1719,22 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/46/79/cf31d7a93a8fdc6aa0fbb665be84426a8c5a557d9240b6239e9e11e35fc5/termcolor-3.3.0.tar.gz", hash = "sha256:348871ca648ec6a9a983a13ab626c0acce02f515b9e1983332b17af7979521c5", size = 14434, upload-time = "2025-12-29T12:55:21.882Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/33/d1/8bb87d21e9aeb323cc03034f5eaf2c8f69841e40e4853c2627edf8111ed3/termcolor-3.3.0-py3-none-any.whl", hash = "sha256:cf642efadaf0a8ebbbf4bc7a31cec2f9b5f21a9f726f4ccbb08192c9c26f43a5", size = 7734, upload-time = "2025-12-29T12:55:20.718Z" },
+]
+
+[[package]]
+name = "tf2onnx"
+version = "1.17.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "flatbuffers" },
+    { name = "numpy" },
+    { name = "onnx" },
+    { name = "protobuf" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8e/62/09bc2e8a91c717a2b37b6631ad08535f1f04d951010abbc5b6e446c988eb/tf2onnx-1.17.0.tar.gz", hash = "sha256:998dc1841d5e2405226d985f28287570569034b7609924a52fb297b42462c1c1", size = 591633, upload-time = "2026-03-04T19:37:23.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/98/83/05d2b28b2246118105c48a7a8c02e3419f2ea0fff0bb49a8bd7876e7373c/tf2onnx-1.17.0-py3-none-any.whl", hash = "sha256:64506e0ff12ddb21918b5659541577a4e9eec06d6bb1f2c7c4ebba5b09f30dba", size = 839132, upload-time = "2026-03-04T19:37:21.236Z" },
 ]
 
 [[package]]

--- a/tensormap-frontend/src/components/export/ExportPanel.tsx
+++ b/tensormap-frontend/src/components/export/ExportPanel.tsx
@@ -1,0 +1,306 @@
+/**
+ * ExportPanel component for downloading trained models in different formats.
+ *
+ * Features:
+ * - Lists available export formats (SavedModel, TFLite, ONNX)
+ * - Shows file sizes and expiry dates
+ * - Handles ONNX compatibility issues gracefully
+ * - Downloads exports on button click
+ * - Shows loading and error states
+ */
+
+import { useState, useEffect } from "react";
+import { Download, Package, AlertCircle, CheckCircle, Clock } from "lucide-react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import axios from "../../shared/Axios";
+import * as urls from "../../constants/Urls";
+import logger from "../../shared/logger";
+import type { ExportFormat, ExportFormatsResponse, ExportError } from "../../types/export";
+
+interface ExportPanelProps {
+  jobId: string;
+  modelName: string;
+}
+
+interface FormatDisplay {
+  format: ExportFormat;
+  label: string;
+  description: string;
+  icon: typeof Package;
+}
+
+const FORMAT_INFO: FormatDisplay[] = [
+  {
+    format: "savedmodel",
+    label: "SavedModel",
+    description: "TensorFlow SavedModel format (directory structure, zipped)",
+    icon: Package,
+  },
+  {
+    format: "tflite",
+    label: "TFLite",
+    description: "TensorFlow Lite format for mobile/edge deployment",
+    icon: Package,
+  },
+  {
+    format: "onnx",
+    label: "ONNX",
+    description: "Open Neural Network Exchange format for cross-framework compatibility",
+    icon: Package,
+  },
+];
+
+export default function ExportPanel({ jobId, modelName }: ExportPanelProps) {
+  const [formats, setFormats] = useState<ExportFormatsResponse["formats"] | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [downloading, setDownloading] = useState<Record<ExportFormat, boolean>>({
+    savedmodel: false,
+    tflite: false,
+    onnx: false,
+  });
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetchFormats();
+  }, [jobId]);
+
+  const fetchFormats = async () => {
+    try {
+      setLoading(true);
+      setError(null);
+      const response = await axios.get<ExportFormatsResponse>(
+        `${urls.BACKEND_MODEL_EXPORT}/${jobId}/formats`,
+      );
+      setFormats(response.data.formats);
+    } catch (err: any) {
+      logger.error("Failed to fetch export formats:", err);
+      setError(err.response?.data?.message || err.message || "Failed to load export formats");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleDownload = async (format: ExportFormat) => {
+    try {
+      setDownloading((prev) => ({ ...prev, [format]: true }));
+      setError(null);
+
+      const response = await axios.get(`${urls.BACKEND_MODEL_EXPORT}/${jobId}`, {
+        params: { format },
+        responseType: "blob",
+      });
+
+      // Extract filename from Content-Disposition header or generate one
+      const contentDisposition = response.headers["content-disposition"];
+      let filename: string;
+      
+      if (contentDisposition) {
+        const filenameMatch = contentDisposition.match(/filename="?(.+)"?/);
+        if (filenameMatch) {
+          filename = filenameMatch[1];
+        } else {
+          // Fallback with correct extension
+          filename = format === "savedmodel" 
+            ? `${modelName}.savedmodel.zip` 
+            : `${modelName}.${format}`;
+        }
+      } else {
+        // Fallback with correct extension
+        filename = format === "savedmodel" 
+          ? `${modelName}.savedmodel.zip` 
+          : `${modelName}.${format}`;
+      }
+
+      // Create download link
+      const url = window.URL.createObjectURL(new Blob([response.data]));
+      const link = document.createElement("a");
+      link.href = url;
+      link.setAttribute("download", filename);
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      window.URL.revokeObjectURL(url);
+
+      // Refresh formats to update "available" status
+      await fetchFormats();
+    } catch (err: any) {
+      logger.error(`Failed to download ${format} export:`, err);
+
+      // Check if it's an ONNX compatibility error
+      if (err.response?.data && typeof err.response.data === "object") {
+        try {
+          // If the response is a blob, try to parse it as JSON
+          const text = await new Response(err.response.data).text();
+          const errorData: ExportError = JSON.parse(text);
+          if (errorData.error === "onnx_unsupported") {
+            setError(
+              `ONNX export not supported: ${errorData.issues.join("; ")}. ${errorData.suggestion}`,
+            );
+            return;
+          }
+        } catch {
+          // Not a JSON error, continue with default error handling
+        }
+      }
+
+      setError(err.response?.data?.detail || err.message || `Failed to download ${format} export`);
+    } finally {
+      setDownloading((prev) => ({ ...prev, [format]: false }));
+    }
+  };
+
+  const formatBytes = (bytes: number | null): string => {
+    if (bytes === null) return "Unknown";
+    if (bytes === 0) return "0 B";
+    const k = 1024;
+    const sizes = ["B", "KB", "MB", "GB"];
+    const i = Math.floor(Math.log(bytes) / Math.log(k));
+    return `${parseFloat((bytes / Math.pow(k, i)).toFixed(2))} ${sizes[i]}`;
+  };
+
+  const formatExpiry = (expiresAt: string | null): string => {
+    if (!expiresAt) return "Unknown";
+    const date = new Date(expiresAt);
+    const now = new Date();
+    const diffMs = date.getTime() - now.getTime();
+    const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24));
+
+    if (diffDays < 0) return "Expired";
+    if (diffDays === 0) return "Expires today";
+    if (diffDays === 1) return "Expires tomorrow";
+    return `Expires in ${diffDays} days`;
+  };
+
+  if (loading) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />
+            Export Model
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-center py-8 text-muted-foreground">
+            Loading export formats...
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  if (!formats) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Package className="h-5 w-5" />
+            Export Model
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>
+              {error || "Failed to load export formats. Please try again."}
+            </AlertDescription>
+          </Alert>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Package className="h-5 w-5" />
+          Export Model
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {error && (
+          <Alert variant="destructive">
+            <AlertCircle className="h-4 w-4" />
+            <AlertDescription>{error}</AlertDescription>
+          </Alert>
+        )}
+
+        <div className="grid gap-4 md:grid-cols-3">
+          {FORMAT_INFO.map((info) => {
+            const formatData = formats[info.format];
+            const isOnnx = info.format === "onnx";
+            const onnxUnsupported = isOnnx && !formatData.onnx_supported;
+
+            return (
+              <div
+                key={info.format}
+                className="rounded-lg border p-4 space-y-3 hover:border-primary/50 transition-colors"
+              >
+                <div className="flex items-start justify-between">
+                  <div className="flex items-center gap-2">
+                    <info.icon className="h-5 w-5 text-muted-foreground" />
+                    <h3 className="font-semibold">{info.label}</h3>
+                  </div>
+                  {formatData.available && <CheckCircle className="h-4 w-4 text-green-600" />}
+                </div>
+
+                <p className="text-sm text-muted-foreground">{info.description}</p>
+
+                {onnxUnsupported && formatData.onnx_issues && (
+                  <Alert variant="default" className="py-2">
+                    <AlertCircle className="h-4 w-4" />
+                    <AlertDescription className="text-xs">
+                      {formatData.onnx_issues.join(" ")}
+                    </AlertDescription>
+                  </Alert>
+                )}
+
+                <div className="space-y-1 text-xs text-muted-foreground">
+                  {formatData.available && (
+                    <>
+                      <div className="flex items-center gap-1">
+                        <Package className="h-3 w-3" />
+                        <span>Size: {formatBytes(formatData.size_bytes)}</span>
+                      </div>
+                      <div className="flex items-center gap-1">
+                        <Clock className="h-3 w-3" />
+                        <span>{formatExpiry(formatData.expires_at)}</span>
+                      </div>
+                    </>
+                  )}
+                </div>
+
+                <Button
+                  onClick={() => handleDownload(info.format)}
+                  disabled={onnxUnsupported || downloading[info.format]}
+                  variant={formatData.available ? "default" : "outline"}
+                  className="w-full"
+                  size="sm"
+                >
+                  {downloading[info.format] ? (
+                    "Downloading..."
+                  ) : (
+                    <>
+                      <Download className="h-4 w-4 mr-2" />
+                      {formatData.available ? "Download" : "Generate & Download"}
+                    </>
+                  )}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+
+        <div className="text-xs text-muted-foreground border-t pt-4">
+          <p>
+            <strong>Note:</strong> Exports are generated on-demand and cached for 7 days. First
+            download may take a few seconds.
+          </p>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/tensormap-frontend/src/components/training/TrainingMetricsChart.tsx
+++ b/tensormap-frontend/src/components/training/TrainingMetricsChart.tsx
@@ -4,7 +4,7 @@
  * @module
  */
 
-import { useMemo } from "react";
+import { useMemo, useEffect } from "react";
 import { useTrainingMetrics } from "@/hooks/useTrainingMetrics";
 import TrainingHeader from "./TrainingHeader";
 import LossChart from "./LossChart";
@@ -12,9 +12,20 @@ import AccuracyChart from "./AccuracyChart";
 import MetricsSummaryBar from "./MetricsSummaryBar";
 import { TrainingMetricsChartProps } from "@/types/training";
 
-export default function TrainingMetricsChart({ jobId, totalEpochs }: TrainingMetricsChartProps) {
-  const { metrics, status, currentEpoch, cancel, cancelRequested, startedAt, error } =
+export default function TrainingMetricsChart({
+  jobId,
+  totalEpochs,
+  onComplete,
+}: TrainingMetricsChartProps) {
+  const { metrics, status, currentEpoch, cancel, cancelRequested, startedAt, error, isCompleted } =
     useTrainingMetrics(jobId, totalEpochs);
+
+  // Call onComplete when training finishes
+  useEffect(() => {
+    if (isCompleted && onComplete) {
+      onComplete(jobId);
+    }
+  }, [isCompleted, jobId, onComplete]);
 
   // Calculate elapsed time
   const elapsedTime = useMemo(() => {

--- a/tensormap-frontend/src/constants/Urls.js
+++ b/tensormap-frontend/src/constants/Urls.js
@@ -25,5 +25,6 @@ export const BACKEND_GET_MODEL_GRAPH = "/model";
 export const BACKEND_SAVE_MODEL = "/model/save";
 export const BACKEND_UPDATE_TRAINING_CONFIG = "/model/training-config";
 export const BACKEND_DELETE_MODEL = "/model";
+export const BACKEND_MODEL_EXPORT = "/model/export";
 export const BACKEND_PROJECT = "/project";
 export const BACKEND_GET_COLUMN_STATS = "/data/process/stats/";

--- a/tensormap-frontend/src/containers/Training/Training.jsx
+++ b/tensormap-frontend/src/containers/Training/Training.jsx
@@ -25,6 +25,7 @@ import logger from "../../shared/logger";
 import FeedbackDialog from "../../components/shared/FeedbackDialog";
 import Result from "../../components/ResultPanel/Result/Result";
 import TrainingMetricsChart from "@/components/training/TrainingMetricsChart";
+import ExportPanel from "@/components/export/ExportPanel";
 import {
   download_code,
   runModel,
@@ -64,6 +65,7 @@ export default function Training() {
 
   const [selectedModel, setSelectedModel] = useState(null);
   const [activeJobId, setActiveJobId] = useState(null);
+  const [completedJobInfo, setCompletedJobInfo] = useState(null); // { jobId, modelName }
   const [resultValues, setResultValues] = useState([]);
   const [isLoading, setIsLoading] = useState(false);
   const [isHistoryLoading, setIsHistoryLoading] = useState(true);
@@ -460,6 +462,7 @@ export default function Training() {
     setResultValues([]);
     setIsLoading(true);
     setActiveJobId(null);
+    setCompletedJobInfo(null); // Clear previous completed job
 
     timeoutRef.current = setTimeout(() => {
       setIsLoading(false);
@@ -493,6 +496,7 @@ export default function Training() {
     setResultValues([]);
     setIsLoading(false);
     setActiveJobId(null);
+    setCompletedJobInfo(null); // Also clear completed job info
   };
 
   const handleDeleteClick = (model, e) => {
@@ -626,7 +630,9 @@ export default function Training() {
             </Button>
             <Button
               onClick={handleClear}
-              disabled={resultValues.length === 0 && !activeJobId && !isLoading}
+              disabled={
+                resultValues.length === 0 && !activeJobId && !completedJobInfo && !isLoading
+              }
               variant="secondary"
             >
               Clear
@@ -872,7 +878,17 @@ export default function Training() {
         <TrainingMetricsChart
           jobId={activeJobId}
           totalEpochs={Number(trainingConfig.epochs) || 0}
+          onComplete={(jobId) => {
+            // When training completes, show export panel
+            setCompletedJobInfo({ jobId, modelName: selectedModel });
+            setActiveJobId(null); // Hide the live chart
+          }}
         />
+      )}
+
+      {/* NEW: Export Panel (shown when training completes) */}
+      {completedJobInfo && (
+        <ExportPanel jobId={completedJobInfo.jobId} modelName={completedJobInfo.modelName} />
       )}
 
       {/* Legacy text output for errors */}

--- a/tensormap-frontend/src/hooks/useTrainingMetrics.ts
+++ b/tensormap-frontend/src/hooks/useTrainingMetrics.ts
@@ -32,6 +32,7 @@ interface UseTrainingMetricsReturn {
   cancelRequested: boolean;
   startedAt: string | null;
   error: string | null;
+  isCompleted: boolean;
 }
 
 export function useTrainingMetrics(
@@ -182,5 +183,6 @@ export function useTrainingMetrics(
     cancelRequested,
     startedAt,
     error,
+    isCompleted: status === "completed",
   };
 }

--- a/tensormap-frontend/src/types/export.ts
+++ b/tensormap-frontend/src/types/export.ts
@@ -1,0 +1,27 @@
+/**
+ * Types for model export functionality.
+ */
+
+export type ExportFormat = "savedmodel" | "tflite" | "onnx";
+
+export interface FormatInfo {
+  available: boolean;
+  size_bytes: number | null;
+  expires_at: string | null;
+  onnx_supported?: boolean;
+  onnx_issues?: string[] | null;
+}
+
+export interface ExportFormatsResponse {
+  formats: {
+    savedmodel: FormatInfo;
+    tflite: FormatInfo;
+    onnx: FormatInfo;
+  };
+}
+
+export interface ExportError {
+  error: string;
+  issues: string[];
+  suggestion: string;
+}

--- a/tensormap-frontend/src/types/training.ts
+++ b/tensormap-frontend/src/types/training.ts
@@ -24,6 +24,7 @@ export interface TrainingState {
 export interface TrainingMetricsChartProps {
   jobId: string;
   totalEpochs: number;
+  onComplete?: (jobId: string) => void;
 }
 
 export interface TrainingHeaderProps {


### PR DESCRIPTION
## Summary

This PR adds a model export service so users can download their trained models in production-ready formats directly from the Training page. After a training job completes, the trained model is persisted and can be exported as **SavedModel** (zip), **TFLite**, or **ONNX** — with a pre-flight compatibility check for ONNX and clear guidance when an architecture isn't convertible.

## What's New

### Backend

**Export service** (`app/services/model_export.py`)
- `export_savedmodel(job_id, model_name)` — loads `model.keras`, saves as TensorFlow SavedModel, zips it. Cached: returns the existing zip on subsequent calls.
- `export_tflite(job_id, model_name)` — converts via `TFLiteConverter`, writes `.tflite`. Cached the same way.
- `export_onnx(job_id, model_name, graph_ir)` — converts via `tf2onnx` with a proper input signature (handles single- and multi-input models).
- `validate_onnx_compatible(model, graph_ir)` — pre-flight check that flags LSTM/GRU with `return_sequences=True` on variable-length inputs, which tf2onnx can't convert. Users get an actionable message ("set a fixed shape in your Input layer") instead of a cryptic converter error.
- `get_export_formats(job_id, model_name, graph_ir)` — reports availability, size, and expiry for each format, plus ONNX support status.
- `cleanup_exports(retention_days, session)` — deletes export directories older than the retention window (default 7 days, configurable via `EXPORT_RETENTION_DAYS`).
- `delete_job_exports(job_id)` / `delete_model_exports(model_id, session)` — targeted cleanup used when a model is deleted.
- TensorFlow and tf2onnx are lazily imported so non-training processes don't pay the import cost.

**Export router** (`app/routers/export.py`) — two endpoints under `/api/v1/model/export`:
- `GET /model/export/{job_id}/formats` — available formats with metadata (size, expiry, ONNX compatibility issues).
- `GET /model/export/{job_id}?format=savedmodel|tflite|onnx` — streams the file with the right content type and filename; generates the export lazily on first request. Returns 404 if the job/model/keras file is missing, 400 with structured `onnx_unsupported` details (issues + suggested fallback) when ONNX conversion isn't possible. Updates `last_export_download_at` on the job as a background task.

**Integration points**
- `MetricsCallback.on_train_end` now saves the trained model to `exports/{job_id}/model.keras`, making completed jobs exportable (save failures are logged, never fail the run).
- App lifespan starts a background task that runs `cleanup_exports` every 6 hours and cancels it cleanly on shutdown.
- `delete_model_service` cascades export-directory deletion for all of a model's training jobs (best-effort; model deletion proceeds even if disk cleanup fails).
- New `get_session()` context manager in `app/database.py` for sessions outside FastAPI request scope.
- New dependency: `tf2onnx>=1.16`.

### Frontend

- **`ExportPanel`** (`src/components/export/ExportPanel.tsx`) — shown on the Training page when a job completes. Fetches available formats, renders a download button per format with size and expiry info, disables ONNX with the reported issues when the architecture isn't supported, and refreshes format metadata after each download.
- **Types** (`src/types/export.ts`) — `ExportFormat`, `FormatInfo`, `ExportFormatsResponse`, `ExportError`.
- `useTrainingMetrics` exposes `isCompleted`; `Training.jsx` uses it (via a new `onComplete` callback) to mount the panel once training finishes.
- New URL constant `BACKEND_MODEL_EXPORT`.

## Testing

`tests/test_model_export.py` — 13 tests covering:
- SavedModel export creates a zip and is cached on the second call
- TFLite export creates the file
- ONNX pre-flight validation passes for simple models and fails for RNNs with variable-length inputs
- ONNX export raises `ONNXUnsupportedError` with actionable issues for unsupported architectures
- 404 when no `model.keras` exists for the job
- `get_export_formats` response structure
- Retention cleanup deletes only directories older than `retention_days`
- Per-job and per-model (cascade) export deletion

The two ONNX conversion tests skip automatically when tf2onnx or its dependencies are unavailable in the environment.

The cleanup/cascade tests create the parent `model_basic` row before inserting `training_job` rows, so they pass against PostgreSQL in CI (which enforces the foreign key) as well as local SQLite.

```
11 passed, 2 skipped
```

Ruff lint and format checks pass across the backend.

## Notes

- Exports are generated lazily on first download and cached under `exports/{job_id}/`, so repeated downloads are instant and no disk is spent on formats nobody requests.
- Retention default is 7 days, configurable with the `EXPORT_RETENTION_DAYS` environment variable.
- ONNX limitations are surfaced to the user with a suggested fallback (SavedModel/TFLite) rather than failing opaquely.
