### PR TITLE
fix: reject disconnected canvas nodes instead of crashing with KeyError

### DIFF
--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -36,18 +36,21 @@ def model_generation(model_params: dict) -> dict:
 
     nodes_by_id = {node["id"]: node for node in model_params["nodes"]}
 
+    input_nodes = [node for node in model_params["nodes"] if node["type"] == "custominput"]
+    if not input_nodes:
+        raise ValueError("Model has no input layer. Add an Input node to the canvas before training.")
+
     # BFS from input nodes to build Keras layers in topological order
     keras_tensors = {}
     visited = set()
     queue = []
 
-    for node in model_params["nodes"]:
-        if node["type"] == "custominput":
-            dims = [int(node["data"]["params"].get(f"dim-{i + 1}", 0) or 0) for i in range(3)]
-            dims = [d for d in dims if d != 0]
-            keras_tensors[node["id"]] = tf.keras.Input(shape=dims, name=node["id"])
-            visited.add(node["id"])
-            queue.append(node["id"])
+    for node in input_nodes:
+        dims = [int(node["data"]["params"].get(f"dim-{i + 1}", 0) or 0) for i in range(3)]
+        dims = [d for d in dims if d != 0]
+        keras_tensors[node["id"]] = tf.keras.Input(shape=dims, name=node["id"])
+        visited.add(node["id"])
+        queue.append(node["id"])
 
     while queue:
         current_id = queue.pop(0)
@@ -71,8 +74,42 @@ def model_generation(model_params: dict) -> dict:
             node = nodes_by_id[target_id]
             keras_tensors[target_id] = _build_layer(node, input_tensor)
 
-    inputs = [keras_tensors[n["id"]] for n in model_params["nodes"] if n["type"] == "custominput"]
-    output_ids = [n["id"] for n in model_params["nodes"] if n["id"] not in source_to_targets]
+    # Every node must be reachable from an input layer. Anything left unvisited is
+    # either an orphan the user forgot to wire up or part of a cycle -- the BFS never
+    # built a tensor for it, so the output lookup below would fail with a bare
+    # KeyError. Fail early and name the offending nodes so the user can find them.
+    unreachable = sorted(node_id for node_id in nodes_by_id if node_id not in visited)
+    if unreachable:
+        raise ValueError(
+            f"Model contains layers that are not connected to any input layer: {', '.join(unreachable)}. "
+            "Connect them to the graph or remove them from the canvas."
+        )
+
+    inputs = [keras_tensors[node["id"]] for node in input_nodes]
+
+    # A node with no outgoing edges is a model output -- except for input nodes, which
+    # are dangling rather than terminal. Treating them as outputs silently produced a
+    # malformed model whose input was also its output.
+    output_ids = [
+        node["id"]
+        for node in model_params["nodes"]
+        if node["id"] not in source_to_targets and node["type"] != "custominput"
+    ]
+    if not output_ids:
+        raise ValueError(
+            "Model has no output layer. Connect at least one layer downstream of an input node before training."
+        )
+
+    # Input nodes are seeded into `visited` before the BFS runs, so the reachability
+    # check above cannot catch a dangling one. Report it here rather than letting
+    # Keras fail later with an opaque "`inputs` not connected to `outputs`".
+    dangling_inputs = sorted(node["id"] for node in input_nodes if node["id"] not in source_to_targets)
+    if dangling_inputs:
+        raise ValueError(
+            f"Input layers are not connected to any other layer: {', '.join(dangling_inputs)}. "
+            "Connect them to the graph or remove them from the canvas."
+        )
+
     outputs = [keras_tensors[oid] for oid in output_ids]
 
     model = tf.keras.Model(inputs=inputs, outputs=outputs)

--- a/tensormap-backend/tests/test_model_generation.py
+++ b/tensormap-backend/tests/test_model_generation.py
@@ -218,18 +218,14 @@ class TestModelGeneration:
         assert len(model.outputs) == 2
 
     def test_single_input_no_edges(self):
-        """A graph with only an input node and no edges may raise ValueError
-        (Keras 2) or produce a valid identity model (Keras 3)."""
+        """A graph with only an input node has no output layer and is rejected
+        with a clear message on every Keras version."""
         params = {
             "nodes": [_input_node("solo", [4])],
             "edges": [],
         }
-        try:
-            result = model_generation(params)
-            # Keras 3: succeeds — verify the result is still a valid dict
-            assert isinstance(result, dict)
-        except (ValueError, TypeError):
-            pass  # Keras 2: raises as expected
+        with pytest.raises(ValueError, match="no output layer"):
+            model_generation(params)
 
     def test_unknown_layer_type_raises_value_error(self):
         """An unsupported node type in the graph must propagate a ValueError."""
@@ -409,3 +405,158 @@ class TestDropoutInModelGeneration:
         }
         with pytest.raises(ValueError, match="Unknown node type"):
             model_generation(params)
+
+
+# ===================================================================
+# Tests for graph connectivity validation (issue #244)
+# ===================================================================
+
+
+class TestGraphConnectivityValidation:
+    """model_generation() must reject malformed graphs with a clear ValueError
+    instead of crashing with a bare KeyError or silently building a bad model."""
+
+    def test_orphan_node_raises_value_error_naming_the_node(self):
+        """
+        input → out      (dense "stray" left unconnected on the canvas)
+
+        The BFS never reaches "stray", so it previously fell through to the
+        output lookup and crashed with KeyError.
+        """
+        params = {
+            "nodes": [
+                _input_node("x", [10]),
+                _dense_node("out", 1, "sigmoid"),
+                _dense_node("stray", 8, "relu"),
+            ],
+            "edges": [_edge("x", "out")],
+        }
+        with pytest.raises(ValueError, match="not connected to any input layer") as exc_info:
+            model_generation(params)
+        assert "stray" in str(exc_info.value)
+
+    def test_orphan_node_does_not_raise_key_error(self):
+        """Regression guard: the failure mode must be ValueError, never KeyError."""
+        params = {
+            "nodes": [_input_node("x", [4]), _dense_node("out", 1), _flatten_node("orphan")],
+            "edges": [_edge("x", "out")],
+        }
+        with pytest.raises(ValueError):
+            model_generation(params)
+
+    def test_disconnected_input_and_dense_raises_value_error(self):
+        """The exact reproduction from the issue: an Input and a Dense node
+        placed on the canvas but never connected."""
+        params = {
+            "nodes": [_input_node("x", [10]), _dense_node("d", 32, "relu")],
+            "edges": [],
+        }
+        with pytest.raises(ValueError, match="not connected to any input layer") as exc_info:
+            model_generation(params)
+        assert "d" in str(exc_info.value)
+
+    def test_all_orphans_are_listed_in_the_error(self):
+        """Every unreachable node is named, so the user can fix them in one pass."""
+        params = {
+            "nodes": [
+                _input_node("x", [10]),
+                _dense_node("out", 1),
+                _dense_node("orphan_a", 4),
+                _dense_node("orphan_b", 4),
+            ],
+            "edges": [_edge("x", "out"), _edge("orphan_a", "orphan_b")],
+        }
+        with pytest.raises(ValueError) as exc_info:
+            model_generation(params)
+        message = str(exc_info.value)
+        assert "orphan_a" in message
+        assert "orphan_b" in message
+
+    def test_cycle_raises_value_error(self):
+        """Nodes in a cycle are never visited by the BFS and must be reported
+        rather than silently dropped from the model."""
+        params = {
+            "nodes": [
+                _input_node("x", [10]),
+                _dense_node("out", 1),
+                _dense_node("a", 4),
+                _dense_node("b", 4),
+            ],
+            "edges": [_edge("x", "out"), _edge("a", "b"), _edge("b", "a")],
+        }
+        with pytest.raises(ValueError, match="not connected to any input layer"):
+            model_generation(params)
+
+    def test_graph_with_no_input_node_raises_value_error(self):
+        """A graph without any custominput node has nothing to seed the BFS with."""
+        params = {
+            "nodes": [_dense_node("a", 8), _dense_node("b", 1)],
+            "edges": [_edge("a", "b")],
+        }
+        with pytest.raises(ValueError, match="no input layer"):
+            model_generation(params)
+
+    def test_empty_graph_raises_value_error(self):
+        with pytest.raises(ValueError, match="no input layer"):
+            model_generation({"nodes": [], "edges": []})
+
+    def test_dangling_input_node_is_not_treated_as_an_output(self):
+        """
+        in_used → out
+        in_dangling            (connected to nothing)
+
+        "in_dangling" has no outgoing edges, so it was previously collected as a
+        model output, producing a model whose input was also its output.
+        """
+        params = {
+            "nodes": [
+                _input_node("in_used", [10]),
+                _input_node("in_dangling", [5]),
+                _dense_node("out", 1, "sigmoid"),
+            ],
+            "edges": [_edge("in_used", "out")],
+        }
+        with pytest.raises(ValueError, match="Input layers are not connected") as exc_info:
+            model_generation(params)
+        assert "in_dangling" in str(exc_info.value)
+        assert "in_used" not in str(exc_info.value)
+
+    def test_input_only_graph_raises_no_output_layer(self):
+        """A lone input node is a dangling node, not a one-layer identity model."""
+        params = {
+            "nodes": [_input_node("solo", [4])],
+            "edges": [],
+        }
+        with pytest.raises(ValueError, match="no output layer"):
+            model_generation(params)
+
+    def test_valid_graph_still_builds_after_validation(self):
+        """The new guards must not reject well-formed graphs."""
+        params = {
+            "nodes": [
+                _input_node("x", [28, 28, 1]),
+                _flatten_node("f"),
+                _dense_node("h", 32, "relu"),
+                _dense_node("out", 10, "softmax"),
+            ],
+            "edges": [_edge("x", "f"), _edge("f", "h"), _edge("h", "out")],
+        }
+        result = model_generation(params)
+        model = tf.keras.models.model_from_json(json.dumps(result))
+        assert model.input_shape == (None, 28, 28, 1)
+        assert model.output_shape == (None, 10)
+
+    def test_multi_input_graph_still_builds_after_validation(self):
+        """Both inputs feed the output, so neither is flagged as unreachable."""
+        params = {
+            "nodes": [
+                _input_node("in1", [4]),
+                _input_node("in2", [6]),
+                _dense_node("out", 1, "sigmoid"),
+            ],
+            "edges": [_edge("in1", "out"), _edge("in2", "out")],
+        }
+        result = model_generation(params)
+        model = tf.keras.models.model_from_json(json.dumps(result))
+        assert len(model.inputs) == 2
+        assert len(model.outputs) == 1


### PR DESCRIPTION
## Description

`model_generation()` crashed with an unhandled `KeyError` whenever the ReactFlow graph contained a node that the BFS never reached, and silently built a malformed model when an input node had no outgoing edges.

Output detection used:

```python
output_ids = [n["id"] for n in model_params["nodes"] if n["id"] not in source_to_targets]
outputs = [keras_tensors[oid] for oid in output_ids]
```

An orphan node has no outgoing edges, so it is not in `source_to_targets` and is collected as an output — but the BFS never built a tensor for it, so the `keras_tensors[oid]` lookup raises a bare `KeyError` and the user gets a 500 with no indication of which node is at fault. The same rule also swept up `custominput` nodes with no outgoing edges, which *are* in `keras_tensors`, so instead of crashing they silently produced a model whose input was also its output.

This PR validates the graph before handing it to Keras:

- **No input node** → `Model has no input layer.`
- **Nodes unreachable from any input** → error naming each offending node ID. This also covers cycles, whose nodes never satisfy the "all sources visited" guard and were previously dropped from the model without warning.
- **Input nodes excluded from output detection**, plus an explicit error when that leaves the graph with no output layer.
- **Dangling input nodes** → error naming them. These are seeded into `visited` before the BFS runs, so the reachability check cannot catch them; without this Keras fails later with an opaque `` `inputs` not connected to `outputs` ``.

`ValueError` is the right signal here: both call sites in `services/deep_learning.py` already wrap `model_generation()` in `except ValueError` and return a 400 with the message, so these reach the UI as actionable feedback instead of a 500.

### Note on guard ordering

The four guards are deliberately ordered. The dangling-input check runs *after* the no-output check, not before it. A lone input node on an otherwise empty canvas satisfies both conditions, and running the dangling check first would make the no-output branch unreachable dead code. In the current order both errors are reachable and both are covered by a test.

Fixes #244
Fixes #199

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update

## How Has This Been Tested?

Added `TestGraphConnectivityValidation` to `tests/test_model_generation.py` — 11 new cases covering: the exact reproduction from the issue (unconnected Input + Dense), an orphan alongside a valid path, a regression guard that the failure is `ValueError` and never `KeyError`, multiple orphans all named in one message, cycles, a graph with no input node, an empty graph, a dangling input node not being treated as an output, an input-only graph, and two guards that well-formed single- and multi-input graphs still build.

Also tightened the existing `test_single_input_no_edges`, which previously accepted either an exception or success to paper over a Keras 2/3 behaviour difference. That case is now deterministic and asserts the specific error.

- [x] Existing tests pass
- [x] New tests added
- [ ] Manual testing

**Backend suite:** ~469 passed, 5 skipped. `tests/test_model_generation.py` goes from 27 to 38 tests, all passing. Ruff `check` and `format --check` clean across the backend.

Two caveats, both confirmed pre-existing by stashing this branch's changes and re-running against an unmodified checkout:

1. `test_cp2_integration.py::test_training_jobs_list_endpoint` fails. It asserts a `started_at DESC` ordering over three rows inserted in the same instant, so the tie-break is nondeterministic. Fails identically on unmodified `main`, and is unrelated to model generation.
2. Running the whole suite in a single process hits `Fatal Python error: Aborted` during a lazy TensorFlow import on Windows (TF 2.16 / Python 3.12). This aborts at the identical line on an unmodified checkout, so it is an environment issue rather than a code one. Results above were collected by running each test file in its own process.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review
- [x] I have added/updated documentation as needed
- [x] My changes generate no new warnings
- [x] Tests pass locally
