### PR TITLE
fix: harden model save validation against malformed graphs (KeyError, missing IR validation)

### DIFF
--- a/tensormap-backend/app/generators/tensorflow_generator.py
+++ b/tensormap-backend/app/generators/tensorflow_generator.py
@@ -113,6 +113,13 @@ class TensorFlowGenerator:
                 visited.add(target_id)
                 queue.append(target_id)
 
+                # An edge may reference a target node that does not exist in the
+                # graph. Reject it with a clear error instead of a bare KeyError.
+                if target_id not in nodes_by_id:
+                    raise TensorFlowGeneratorError(
+                        f"Edge {current_id} -> {target_id} references a node that does not exist in the graph"
+                    )
+
                 node = nodes_by_id[target_id]
 
                 # Gather input tensors

--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -75,6 +75,21 @@ def _extract_graph(payload: dict) -> dict | None:
     return payload
 
 
+def _blocking_ir_errors(graph_ir) -> list[str]:
+    """Return IR-graph validation messages that should block model saving.
+
+    Structural errors (cycles, edges to unknown nodes, invalid merge arity,
+    missing input) are surfaced early with clear messages instead of being
+    deferred to opaque Keras failures. Multi-input models are a supported
+    feature (both generators handle them), so the "multiple input nodes"
+    check is intentionally excluded.
+    """
+    from app.ir.schema import validate_ir_graph
+
+    errors = validate_ir_graph(graph_ir)
+    return [e.message for e in errors if "multiple input nodes" not in e.message]
+
+
 def _validate_graph_size(graph: dict | None) -> str | None:
     """Return an error message if the serialised graph exceeds the size limit, else None."""
     if graph is None:
@@ -138,6 +153,12 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
         graph_ir = reactflow_to_ir(incoming["model"])
         graph_ir_data = graph_ir.model_dump()
         logger.debug("Successfully converted ReactFlow to IRGraph for model validation")
+
+        # Surface structural graph errors early with clear messages instead of
+        # opaque Keras failures later on.
+        blocking = _blocking_ir_errors(graph_ir)
+        if blocking:
+            return _resp(400, False, "; ".join(blocking))
     except Exception as e:
         logger.warning("Failed to convert ReactFlow to IRGraph (falling back to legacy generator): %s", str(e))
 
@@ -160,7 +181,7 @@ def model_validate_service(db: Session, incoming: dict, project_id: uuid_pkg.UUI
     if model_generated is None:
         try:
             model_generated = model_generation(model_params=incoming["model"])
-        except ValueError as e:
+        except (ValueError, KeyError, TypeError) as e:
             return _resp(400, False, str(e))
 
     try:
@@ -263,6 +284,12 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
         graph_ir = reactflow_to_ir(incoming)
         graph_ir_data = graph_ir.model_dump()
         logger.debug("Successfully converted ReactFlow to IRGraph for model save")
+
+        # Surface structural graph errors early with clear messages instead of
+        # opaque Keras failures later on.
+        blocking = _blocking_ir_errors(graph_ir)
+        if blocking:
+            return _resp(400, False, "; ".join(blocking))
     except Exception as e:
         logger.warning("Failed to convert ReactFlow to IRGraph (falling back to legacy generator): %s", str(e))
 
@@ -285,7 +312,7 @@ def model_save_service(db: Session, incoming: dict, model_name: str, project_id:
     if model_generated is None:
         try:
             model_generated = model_generation(model_params=incoming)
-        except ValueError as e:
+        except (ValueError, KeyError, TypeError) as e:
             return _resp(400, False, str(e))
 
     try:

--- a/tensormap-backend/app/services/model_generation.py
+++ b/tensormap-backend/app/services/model_generation.py
@@ -65,6 +65,15 @@ def model_generation(model_params: dict) -> dict:
             visited.add(target_id)
             queue.append(target_id)
 
+            # An edge may reference a target node that does not exist on the
+            # canvas. Reject it with a clear message instead of crashing with a
+            # bare KeyError on the lookup below.
+            if target_id not in nodes_by_id:
+                raise ValueError(
+                    f"Edge {current_id} -> {target_id} references a node that does not exist in the graph. "
+                    "Remove this edge from the canvas."
+                )
+
             source_tensors = [keras_tensors[src] for src in all_sources]
             if len(source_tensors) > 1:
                 input_tensor = tf.keras.layers.Concatenate(axis=-1)(source_tensors)

--- a/tensormap-backend/tests/test_model_generation.py
+++ b/tensormap-backend/tests/test_model_generation.py
@@ -560,3 +560,33 @@ class TestGraphConnectivityValidation:
         model = tf.keras.models.model_from_json(json.dumps(result))
         assert len(model.inputs) == 2
         assert len(model.outputs) == 1
+
+    def test_edge_to_nonexistent_node_raises_value_error_not_key_error(self):
+        """An edge targeting a node not in the graph must raise ValueError
+        (not KeyError) so the service can return a clean 400 response."""
+        params = {
+            "nodes": [
+                _input_node("x", [10]),
+                _dense_node("out", 1, "sigmoid"),
+            ],
+            "edges": [{"source": "x", "target": "ghost"}],
+        }
+        with pytest.raises(ValueError, match="does not exist"):
+            model_generation(params)
+
+    def test_ir_generator_edge_to_nonexistent_node_raises_descriptive_error(self):
+        """The IR generator must reject edges to unknown nodes with a clear
+        error rather than a bare KeyError."""
+        from app.generators.tensorflow_generator import TensorFlowGenerator, TensorFlowGeneratorError
+        from app.ir.translator import reactflow_to_ir
+
+        canvas = {
+            "nodes": [
+                {"id": "n1", "type": "input", "data": {"params": {"shape": 10}}},
+                {"id": "n2", "type": "dense", "data": {"params": {"units": 5}}},
+            ],
+            "edges": [{"source": "n1", "target": "ghost"}],
+        }
+        graph = reactflow_to_ir(canvas)
+        with pytest.raises(TensorFlowGeneratorError, match="does not exist"):
+            TensorFlowGenerator().build_model(graph)


### PR DESCRIPTION
## Summary

Fixes #400 — the model save/validate endpoints could return HTTP 500 or opaque Keras errors on malformed graphs instead of a clean HTTP 400.

## Changes

### Backend

- **`model_generation.py`** — reject edges that reference nodes missing from the graph with a clear `ValueError` instead of crashing with a bare `KeyError`.
- **`tensorflow_generator.py`** — same guard in the registry-driven generator, raising `TensorFlowGeneratorError`.
- **`deep_learning.py`** — `model_validate_service` and `model_save_service`:
  - Widen the legacy-fallback exception handling to also catch `KeyError` and `TypeError` so malformed input returns a clean 400.
  - Call `validate_ir_graph()` after ReactFlow → IR conversion and surface structural errors (cycles, edges to unknown nodes, invalid Concatenate arity, missing input) as 400 responses instead of opaque Keras failures. Multi-input models remain supported (the `multiple input nodes` IR check is excluded via `_blocking_ir_errors`).

### Tests

- **`test_model_generation.py`** — regression tests for edge-to-nonexistent-node in both the legacy generator and the IR generator, asserting a descriptive error (not `KeyError`).

## Verification

- `test_model_generation.py`, `test_api_integration.py`, `test_cp1.py`, `test_graph_json.py` → 112 passed
- `ruff check` clean

## Related

- Closes #400