### PR TITLE
fix: _estimate_param_count now handles scalar input shape (first Dense weights omitted)

### DIFF
--- a/tensormap-backend/app/services/deep_learning.py
+++ b/tensormap-backend/app/services/deep_learning.py
@@ -700,6 +700,8 @@ def _estimate_param_count(graph_ir: dict) -> int:
             if isinstance(shape, list) and len(shape) > 0:
                 # For input, store the last dimension
                 prev_shape = shape[-1] if shape[-1] is not None else 128  # default guess
+            elif isinstance(shape, int):
+                prev_shape = shape
 
         elif layer_type == "dense":
             units = node_params.get("units", 0)

--- a/tensormap-backend/tests/test_model_architecture.py
+++ b/tensormap-backend/tests/test_model_architecture.py
@@ -172,3 +172,29 @@ def test_estimate_param_count_embedding(db_session: Session):
     # Dense: 64 * 1 + 1 = 65
     # Total: 1,329,473
     assert data["param_count"] == 1329473
+
+
+def test_estimate_param_count_scalar_shape(db_session: Session):
+    """The IR schema stores input shape as a scalar int (e.g. 10), not a list.
+    The first Dense layer's weights must still be counted."""
+    graph_ir = {
+        "nodes": [
+            {"node_params": {"layer_type": "input", "shape": 10}},
+            {"node_params": {"layer_type": "dense", "units": 64}},
+            {"node_params": {"layer_type": "dense", "units": 32}},
+            {"node_params": {"layer_type": "dense", "units": 3}},
+        ]
+    }
+    model = ModelBasic(id=1, model_name="scalar_shape_model", graph_ir=graph_ir)
+    db_session.add(model)
+    db_session.commit()
+
+    response = client.get("/api/v1/model/architecture/1?include_stats=true")
+    assert response.status_code == 200
+
+    data = response.json()["data"]
+    # Input(10) -> Dense(64): 10*64 + 64 = 704
+    # Dense(64) -> Dense(32): 64*32 + 32 = 2080
+    # Dense(32) -> Dense(3): 32*3 + 3 = 99
+    # Total: 704 + 2080 + 99 = 2883
+    assert data["param_count"] == 2883


### PR DESCRIPTION
## Summary

Fixes #402 — `GET /api/v1/model/architecture/{id}?include_stats=true` reported an incorrect parameter count for models whose input shape is stored as a scalar integer (the actual IR schema format).

## Changes

### Backend

- **`deep_learning.py`** — `_estimate_param_count` now handles a scalar `int` input shape (the format the IR schema actually produces) in addition to the list format, so the first Dense layer's weights are counted correctly.

### Tests

- **`test_model_architecture.py`** — added a regression test using the real IR-format scalar shape (`Input(10) -> Dense(64) -> Dense(32) -> Dense(3)`) asserting `2883` params.

## Verification

- `test_model_architecture.py` → 8 passed
- `ruff check` clean

## Related

- Closes #402